### PR TITLE
breaking: uppercase duration representations

### DIFF
--- a/COMPARE.md
+++ b/COMPARE.md
@@ -288,7 +288,7 @@ use jiff::{Span, ToSpan};
 fn main() -> anyhow::Result<()> {
     let span = 5.years().months(2).days(1).hours(20);
     let json = serde_json::to_string_pretty(&span)?;
-    assert_eq!(json, "\"P5y2m1dT20h\"");
+    assert_eq!(json, "\"P5Y2M1DT20H\"");
 
     let got: Span = serde_json::from_str(&json)?;
     assert_eq!(got, span);

--- a/src/civil/date.rs
+++ b/src/civil/date.rs
@@ -1711,11 +1711,11 @@ impl Date {
     ///
     /// // The default limits durations to using "days" as the biggest unit.
     /// let span = d2.since(d1)?;
-    /// assert_eq!(span.to_string(), "P8456d");
+    /// assert_eq!(span.to_string(), "P8456D");
     ///
     /// // But we can ask for units all the way up to years.
     /// let span = d2.since((Unit::Year, d1))?;
-    /// assert_eq!(span.to_string(), "P23y1m24d");
+    /// assert_eq!(span.to_string(), "P23Y1M24D");
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -1867,11 +1867,11 @@ impl Date {
     ///
     /// // The default limits durations to using "days" as the biggest unit.
     /// let span = d1.until(d2)?;
-    /// assert_eq!(span.to_string(), "P8456d");
+    /// assert_eq!(span.to_string(), "P8456D");
     ///
     /// // But we can ask for units all the way up to years.
     /// let span = d1.until((Unit::Year, d2))?;
-    /// assert_eq!(span.to_string(), "P23y1m24d");
+    /// assert_eq!(span.to_string(), "P23Y1M24D");
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```

--- a/src/civil/datetime.rs
+++ b/src/civil/datetime.rs
@@ -1820,11 +1820,11 @@ impl DateTime {
     ///
     /// // The default limits durations to using "days" as the biggest unit.
     /// let span = dt2.since(dt1)?;
-    /// assert_eq!(span.to_string(), "P8456dT12h5m29.9999965s");
+    /// assert_eq!(span.to_string(), "P8456DT12H5M29.9999965S");
     ///
     /// // But we can ask for units all the way up to years.
     /// let span = dt2.since((Unit::Year, dt1))?;
-    /// assert_eq!(span.to_string(), "P23y1m24dT12h5m29.9999965s");
+    /// assert_eq!(span.to_string(), "P23Y1M24DT12H5M29.9999965S");
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     ///
@@ -1976,11 +1976,11 @@ impl DateTime {
     ///
     /// // The default limits durations to using "days" as the biggest unit.
     /// let span = dt1.until(dt2)?;
-    /// assert_eq!(span.to_string(), "P8456dT12h5m29.9999965s");
+    /// assert_eq!(span.to_string(), "P8456DT12H5M29.9999965S");
     ///
     /// // But we can ask for units all the way up to years.
     /// let span = dt1.until((Unit::Year, dt2))?;
-    /// assert_eq!(span.to_string(), "P23y1m24dT12h5m29.9999965s");
+    /// assert_eq!(span.to_string(), "P23Y1M24DT12H5M29.9999965S");
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     ///

--- a/src/civil/time.rs
+++ b/src/civil/time.rs
@@ -1219,12 +1219,12 @@ impl Time {
     ///
     /// // The default limits spans to using "hours" as the biggest unit.
     /// let span = t2.since(t1)?;
-    /// assert_eq!(span.to_string(), "PT12h5m29.9999965s");
+    /// assert_eq!(span.to_string(), "PT12H5M29.9999965S");
     ///
     /// // But we can ask for smaller units, like capping the biggest unit
     /// // to minutes instead of hours.
     /// let span = t2.since((Unit::Minute, t1))?;
-    /// assert_eq!(span.to_string(), "PT725m29.9999965s");
+    /// assert_eq!(span.to_string(), "PT725M29.9999965S");
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -1292,12 +1292,12 @@ impl Time {
     ///
     /// // The default limits spans to using "hours" as the biggest unit.
     /// let span = t1.until(t2)?;
-    /// assert_eq!(span.to_string(), "PT12h5m29.9999965s");
+    /// assert_eq!(span.to_string(), "PT12H5M29.9999965S");
     ///
     /// // But we can ask for smaller units, like capping the biggest unit
     /// // to minutes instead of hours.
     /// let span = t1.until((Unit::Minute, t2))?;
-    /// assert_eq!(span.to_string(), "PT725m29.9999965s");
+    /// assert_eq!(span.to_string(), "PT725M29.9999965S");
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```

--- a/src/fmt/temporal/mod.rs
+++ b/src/fmt/temporal/mod.rs
@@ -86,18 +86,18 @@ use jiff::{Span, ToSpan};
 
 let spans = [
     ("P40D", 40.days()),
-    ("P1y1d", 1.year().days(1)),
-    ("P3dT4h59m", 3.days().hours(4).minutes(59)),
+    ("P1Y1D", 1.year().days(1)),
+    ("P3DT4H59M", 3.days().hours(4).minutes(59)),
     ("PT2H30M", 2.hours().minutes(30)),
-    ("P1m", 1.month()),
-    ("P1w", 1.week()),
-    ("P1w4d", 1.week().days(4)),
-    ("PT1m", 1.minute()),
-    ("PT0.0021s", 2.milliseconds().microseconds(100)),
-    ("PT0s", 0.seconds()),
-    ("P0d", 0.seconds()),
+    ("P1M", 1.month()),
+    ("P1W", 1.week()),
+    ("P1W4D", 1.week().days(4)),
+    ("PT1M", 1.minute()),
+    ("PT0.0021S", 2.milliseconds().microseconds(100)),
+    ("PT0S", 0.seconds()),
+    ("P0D", 0.seconds()),
     (
-        "P1y1m1dT1h1m1.1s",
+        "P1Y1M1DT1H1M1.1S",
         1.year().months(1).days(1).hours(1).minutes(1).seconds(1).milliseconds(100),
     ),
 ];
@@ -1045,7 +1045,7 @@ impl DateTimePrinter {
 /// // A parser can be created in a const context.
 /// static PARSER: SpanParser = SpanParser::new();
 ///
-/// let span = PARSER.parse_span(b"P3y7m25dT7h36m")?;
+/// let span = PARSER.parse_span(b"P3Y7M25DT7H36M")?;
 /// assert_eq!(span, 3.years().months(7).days(25).hours(7).minutes(36));
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1077,7 +1077,7 @@ impl SpanParser {
     ///
     /// static PARSER: SpanParser = SpanParser::new();
     ///
-    /// let span = PARSER.parse_span(b"PT48m")?;
+    /// let span = PARSER.parse_span(b"PT48M")?;
     /// assert_eq!(span, 48.minutes());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1091,7 +1091,7 @@ impl SpanParser {
     /// ```
     /// use jiff::{Span, ToSpan};
     ///
-    /// let span = "PT48m".parse::<Span>()?;
+    /// let span = "PT48M".parse::<Span>()?;
     /// assert_eq!(span, 48.minutes());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1133,7 +1133,7 @@ impl SpanParser {
 /// let mut buf = vec![];
 /// // Printing to a `Vec<u8>` can never fail.
 /// PRINTER.print_span(&span, &mut buf).unwrap();
-/// assert_eq!(buf, "PT48m".as_bytes());
+/// assert_eq!(buf, "PT48M".as_bytes());
 /// ```
 ///
 /// # Example: using adapters with `std::io::Write` and `std::fmt::Write`
@@ -1156,7 +1156,7 @@ impl SpanParser {
 /// let mut file = BufWriter::new(File::create(path)?);
 /// SpanPrinter::new().print_span(&span, StdIoWrite(&mut file)).unwrap();
 /// file.flush()?;
-/// assert_eq!(std::fs::read_to_string(path)?, "PT48m");
+/// assert_eq!(std::fs::read_to_string(path)?, "PT48M");
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
@@ -1192,7 +1192,7 @@ impl SpanPrinter {
     /// let mut buf = String::new();
     /// // Printing to a `String` can never fail.
     /// PRINTER.print_span(&span, &mut buf).unwrap();
-    /// assert_eq!(buf, "P3y5m");
+    /// assert_eq!(buf, "P3Y5M");
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```

--- a/src/fmt/temporal/parser.rs
+++ b/src/fmt/temporal/parser.rs
@@ -1319,57 +1319,58 @@ mod tests {
         let p =
             |input| SpanParser::new().parse_temporal_duration(input).unwrap();
 
-        insta::assert_debug_snapshot!(p(b"P5d"), @r###"
+        insta::assert_debug_snapshot!(p(b"P5D"), @r###"
         Parsed {
-            value: P5d,
+            value: P5D,
             input: "",
         }
         "###);
-        insta::assert_debug_snapshot!(p(b"-P5d"), @r###"
+        insta::assert_debug_snapshot!(p(b"-P5D"), @r###"
         Parsed {
-            value: -P5d,
+            value: -P5D,
             input: "",
         }
         "###);
-        insta::assert_debug_snapshot!(p(b"+P5d"), @r###"
+        insta::assert_debug_snapshot!(p(b"+P5D"), @r###"
         Parsed {
-            value: P5d,
+            value: P5D,
             input: "",
         }
         "###);
-        insta::assert_debug_snapshot!(p(b"P5DT1s"), @r###"
+        insta::assert_debug_snapshot!(p(b"P5DT1S"), @r###"
         Parsed {
-            value: P5dT1s,
+            value: P5DT1S,
             input: "",
         }
         "###);
         insta::assert_debug_snapshot!(p(b"PT1S"), @r###"
         Parsed {
-            value: PT1s,
+            value: PT1S,
             input: "",
         }
         "###);
         insta::assert_debug_snapshot!(p(b"PT0S"), @r###"
         Parsed {
-            value: PT0s,
+            value: PT0S,
             input: "",
         }
         "###);
         insta::assert_debug_snapshot!(p(b"P0Y"), @r###"
         Parsed {
-            value: PT0s,
+            value: PT0S,
             input: "",
         }
         "###);
         insta::assert_debug_snapshot!(p(b"P1Y1M1W1DT1H1M1S"), @r###"
         Parsed {
-            value: P1y1m1w1dT1h1m1s,
+            value: P1Y1M1W1DT1H1M1S,
             input: "",
         }
         "###);
+        // Next test checks leniency with lower case inputs.
         insta::assert_debug_snapshot!(p(b"P1y1m1w1dT1h1m1s"), @r###"
         Parsed {
-            value: P1y1m1w1dT1h1m1s,
+            value: P1Y1M1W1DT1H1M1S,
             input: "",
         }
         "###);
@@ -1380,59 +1381,59 @@ mod tests {
         let p =
             |input| SpanParser::new().parse_temporal_duration(input).unwrap();
 
-        insta::assert_debug_snapshot!(p(b"PT0.5h"), @r###"
+        insta::assert_debug_snapshot!(p(b"PT0.5H"), @r###"
         Parsed {
-            value: PT30m,
+            value: PT30M,
             input: "",
         }
         "###);
-        insta::assert_debug_snapshot!(p(b"PT0.123456789h"), @r###"
+        insta::assert_debug_snapshot!(p(b"PT0.123456789H"), @r###"
         Parsed {
-            value: PT7m24.4444404s,
+            value: PT7M24.4444404S,
             input: "",
         }
         "###);
-        insta::assert_debug_snapshot!(p(b"PT1.123456789h"), @r###"
+        insta::assert_debug_snapshot!(p(b"PT1.123456789H"), @r###"
         Parsed {
-            value: PT1h7m24.4444404s,
-            input: "",
-        }
-        "###);
-
-        insta::assert_debug_snapshot!(p(b"PT0.5m"), @r###"
-        Parsed {
-            value: PT30s,
-            input: "",
-        }
-        "###);
-        insta::assert_debug_snapshot!(p(b"PT0.123456789m"), @r###"
-        Parsed {
-            value: PT7.40740734s,
-            input: "",
-        }
-        "###);
-        insta::assert_debug_snapshot!(p(b"PT1.123456789m"), @r###"
-        Parsed {
-            value: PT1m7.40740734s,
+            value: PT1H7M24.4444404S,
             input: "",
         }
         "###);
 
-        insta::assert_debug_snapshot!(p(b"PT0.5s"), @r###"
+        insta::assert_debug_snapshot!(p(b"PT0.5M"), @r###"
         Parsed {
-            value: PT0.5s,
+            value: PT30S,
             input: "",
         }
         "###);
-        insta::assert_debug_snapshot!(p(b"PT0.123456789s"), @r###"
+        insta::assert_debug_snapshot!(p(b"PT0.123456789M"), @r###"
         Parsed {
-            value: PT0.123456789s,
+            value: PT7.40740734S,
             input: "",
         }
         "###);
-        insta::assert_debug_snapshot!(p(b"PT1.123456789s"), @r###"
+        insta::assert_debug_snapshot!(p(b"PT1.123456789M"), @r###"
         Parsed {
-            value: PT1.123456789s,
+            value: PT1M7.40740734S,
+            input: "",
+        }
+        "###);
+
+        insta::assert_debug_snapshot!(p(b"PT0.5S"), @r###"
+        Parsed {
+            value: PT0.5S,
+            input: "",
+        }
+        "###);
+        insta::assert_debug_snapshot!(p(b"PT0.123456789S"), @r###"
+        Parsed {
+            value: PT0.123456789S,
+            input: "",
+        }
+        "###);
+        insta::assert_debug_snapshot!(p(b"PT1.123456789S"), @r###"
+        Parsed {
+            value: PT1.123456789S,
             input: "",
         }
         "###);
@@ -1441,27 +1442,27 @@ mod tests {
         // maximum allowed seconds in a span. But they should still parse
         // correctly by spilling over into milliseconds, microseconds and
         // nanoseconds.
-        insta::assert_debug_snapshot!(p(b"PT1902545624836.854775807s"), @r###"
+        insta::assert_debug_snapshot!(p(b"PT1902545624836.854775807S"), @r###"
         Parsed {
-            value: PT1902545624836.854775807s,
+            value: PT1902545624836.854775807S,
             input: "",
         }
         "###);
-        insta::assert_debug_snapshot!(p(b"PT175307616h10518456960m640330789636.854775807s"), @r###"
+        insta::assert_debug_snapshot!(p(b"PT175307616H10518456960M640330789636.854775807S"), @r###"
         Parsed {
-            value: PT175307616h10518456960m640330789636.854775807s,
+            value: PT175307616H10518456960M640330789636.854775807S,
             input: "",
         }
         "###);
-        insta::assert_debug_snapshot!(p(b"-PT1902545624836.854775807s"), @r###"
+        insta::assert_debug_snapshot!(p(b"-PT1902545624836.854775807S"), @r###"
         Parsed {
-            value: -PT1902545624836.854775807s,
+            value: -PT1902545624836.854775807S,
             input: "",
         }
         "###);
-        insta::assert_debug_snapshot!(p(b"-PT175307616h10518456960m640330789636.854775807s"), @r###"
+        insta::assert_debug_snapshot!(p(b"-PT175307616H10518456960M640330789636.854775807S"), @r###"
         Parsed {
-            value: -PT175307616h10518456960m640330789636.854775807s,
+            value: -PT175307616H10518456960M640330789636.854775807S,
             input: "",
         }
         "###);

--- a/src/fmt/temporal/printer.rs
+++ b/src/fmt/temporal/printer.rs
@@ -225,22 +225,22 @@ impl SpanPrinter {
         let mut non_zero_greater_than_second = false;
         if span.get_years_ranged() != 0 {
             wtr.write_int(&FMT_INT, span.get_years_ranged().get().abs())?;
-            wtr.write_str("y")?;
+            wtr.write_str("Y")?;
             non_zero_greater_than_second = true;
         }
         if span.get_months_ranged() != 0 {
             wtr.write_int(&FMT_INT, span.get_months_ranged().get().abs())?;
-            wtr.write_str("m")?;
+            wtr.write_str("M")?;
             non_zero_greater_than_second = true;
         }
         if span.get_weeks_ranged() != 0 {
             wtr.write_int(&FMT_INT, span.get_weeks_ranged().get().abs())?;
-            wtr.write_str("w")?;
+            wtr.write_str("W")?;
             non_zero_greater_than_second = true;
         }
         if span.get_days_ranged() != 0 {
             wtr.write_int(&FMT_INT, span.get_days_ranged().get().abs())?;
-            wtr.write_str("d")?;
+            wtr.write_str("D")?;
             non_zero_greater_than_second = true;
         }
 
@@ -251,7 +251,7 @@ impl SpanPrinter {
                 printed_time_prefix = true;
             }
             wtr.write_int(&FMT_INT, span.get_hours_ranged().get().abs())?;
-            wtr.write_str("h")?;
+            wtr.write_str("H")?;
             non_zero_greater_than_second = true;
         }
         if span.get_minutes_ranged() != 0 {
@@ -260,7 +260,7 @@ impl SpanPrinter {
                 printed_time_prefix = true;
             }
             wtr.write_int(&FMT_INT, span.get_minutes_ranged().get().abs())?;
-            wtr.write_str("m")?;
+            wtr.write_str("M")?;
             non_zero_greater_than_second = true;
         }
 
@@ -283,7 +283,7 @@ impl SpanPrinter {
                 wtr.write_str("T")?;
             }
             wtr.write_int(&FMT_INT, seconds.get())?;
-            wtr.write_str("s")?;
+            wtr.write_str("S")?;
         } else if millis != 0 || micros != 0 || nanos != 0 {
             if !printed_time_prefix {
                 wtr.write_str("T")?;
@@ -312,7 +312,7 @@ impl SpanPrinter {
                 wtr.write_str(".")?;
                 wtr.write_int(&FMT_FRACTION, fraction_nano.get())?;
             }
-            wtr.write_str("s")?;
+            wtr.write_str("S")?;
         }
         Ok(())
     }
@@ -377,25 +377,25 @@ mod tests {
             buf
         };
 
-        insta::assert_snapshot!(p(Span::new()), @"PT0s");
-        insta::assert_snapshot!(p(1.second()), @"PT1s");
-        insta::assert_snapshot!(p(-1.second()), @"-PT1s");
+        insta::assert_snapshot!(p(Span::new()), @"PT0S");
+        insta::assert_snapshot!(p(1.second()), @"PT1S");
+        insta::assert_snapshot!(p(-1.second()), @"-PT1S");
         insta::assert_snapshot!(p(
             1.second().milliseconds(1).microseconds(1).nanoseconds(1),
-        ), @"PT1.001001001s");
+        ), @"PT1.001001001S");
         insta::assert_snapshot!(p(
             0.second().milliseconds(999).microseconds(999).nanoseconds(999),
-        ), @"PT0.999999999s");
+        ), @"PT0.999999999S");
         insta::assert_snapshot!(p(
             1.year().months(1).weeks(1).days(1)
             .hours(1).minutes(1).seconds(1)
             .milliseconds(1).microseconds(1).nanoseconds(1),
-        ), @"P1y1m1w1dT1h1m1.001001001s");
+        ), @"P1Y1M1W1DT1H1M1.001001001S");
         insta::assert_snapshot!(p(
             -1.year().months(1).weeks(1).days(1)
             .hours(1).minutes(1).seconds(1)
             .milliseconds(1).microseconds(1).nanoseconds(1),
-        ), @"-P1y1m1w1dT1h1m1.001001001s");
+        ), @"-P1Y1M1W1DT1H1M1.001001001S");
     }
 
     #[test]
@@ -409,52 +409,52 @@ mod tests {
         // These are all sub-second trickery tests.
         insta::assert_snapshot!(p(
             0.second().milliseconds(1000).microseconds(1000).nanoseconds(1000),
-        ), @"PT1.001001s");
+        ), @"PT1.001001S");
         insta::assert_snapshot!(p(
             1.second().milliseconds(1000).microseconds(1000).nanoseconds(1000),
-        ), @"PT2.001001s");
+        ), @"PT2.001001S");
         insta::assert_snapshot!(p(
             0.second()
             .milliseconds(t::SpanMilliseconds::MAX_REPR),
-        ), @"PT631107417600s");
+        ), @"PT631107417600S");
         insta::assert_snapshot!(p(
             0.second()
             .microseconds(t::SpanMicroseconds::MAX_REPR),
-        ), @"PT631107417600s");
+        ), @"PT631107417600S");
         insta::assert_snapshot!(p(
             0.second()
             .nanoseconds(t::SpanNanoseconds::MAX_REPR),
-        ), @"PT9223372036.854775807s");
+        ), @"PT9223372036.854775807S");
 
         insta::assert_snapshot!(p(
             0.second()
             .milliseconds(t::SpanMilliseconds::MAX_REPR)
             .microseconds(999_999),
-        ), @"PT631107417600.999999s");
+        ), @"PT631107417600.999999S");
         // This is 1 microsecond more than the maximum number of seconds
         // representable in a span.
         insta::assert_snapshot!(p(
             0.second()
             .milliseconds(t::SpanMilliseconds::MAX_REPR)
             .microseconds(1_000_000),
-        ), @"PT631107417601s");
+        ), @"PT631107417601S");
         insta::assert_snapshot!(p(
             0.second()
             .milliseconds(t::SpanMilliseconds::MAX_REPR)
             .microseconds(1_000_001),
-        ), @"PT631107417601.000001s");
+        ), @"PT631107417601.000001S");
         // This is 1 nanosecond more than the maximum number of seconds
         // representable in a span.
         insta::assert_snapshot!(p(
             0.second()
             .milliseconds(t::SpanMilliseconds::MAX_REPR)
             .nanoseconds(1_000_000_000),
-        ), @"PT631107417601s");
+        ), @"PT631107417601S");
         insta::assert_snapshot!(p(
             0.second()
             .milliseconds(t::SpanMilliseconds::MAX_REPR)
             .nanoseconds(1_000_000_001),
-        ), @"PT631107417601.000000001s");
+        ), @"PT631107417601.000000001S");
 
         // The max millis, micros and nanos, combined.
         insta::assert_snapshot!(p(
@@ -462,7 +462,7 @@ mod tests {
             .milliseconds(t::SpanMilliseconds::MAX_REPR)
             .microseconds(t::SpanMicroseconds::MAX_REPR)
             .nanoseconds(t::SpanNanoseconds::MAX_REPR),
-        ), @"PT1271438207236.854775807s");
+        ), @"PT1271438207236.854775807S");
         // The max seconds, millis, micros and nanos, combined.
         insta::assert_snapshot!(p(
             Span::new()
@@ -470,7 +470,7 @@ mod tests {
             .milliseconds(t::SpanMilliseconds::MAX_REPR)
             .microseconds(t::SpanMicroseconds::MAX_REPR)
             .nanoseconds(t::SpanNanoseconds::MAX_REPR),
-        ), @"PT1902545624836.854775807s");
+        ), @"PT1902545624836.854775807S");
     }
 
     #[test]
@@ -484,52 +484,52 @@ mod tests {
         // These are all sub-second trickery tests.
         insta::assert_snapshot!(p(
             -0.second().milliseconds(1000).microseconds(1000).nanoseconds(1000),
-        ), @"-PT1.001001s");
+        ), @"-PT1.001001S");
         insta::assert_snapshot!(p(
             -1.second().milliseconds(1000).microseconds(1000).nanoseconds(1000),
-        ), @"-PT2.001001s");
+        ), @"-PT2.001001S");
         insta::assert_snapshot!(p(
             0.second()
             .milliseconds(t::SpanMilliseconds::MIN_REPR),
-        ), @"-PT631107417600s");
+        ), @"-PT631107417600S");
         insta::assert_snapshot!(p(
             0.second()
             .microseconds(t::SpanMicroseconds::MIN_REPR),
-        ), @"-PT631107417600s");
+        ), @"-PT631107417600S");
         insta::assert_snapshot!(p(
             0.second()
             .nanoseconds(t::SpanNanoseconds::MIN_REPR),
-        ), @"-PT9223372036.854775807s");
+        ), @"-PT9223372036.854775807S");
 
         insta::assert_snapshot!(p(
             0.second()
             .milliseconds(t::SpanMilliseconds::MIN_REPR)
             .microseconds(999_999),
-        ), @"-PT631107417600.999999s");
+        ), @"-PT631107417600.999999S");
         // This is 1 microsecond more than the maximum number of seconds
         // representable in a span.
         insta::assert_snapshot!(p(
             0.second()
             .milliseconds(t::SpanMilliseconds::MIN_REPR)
             .microseconds(1_000_000),
-        ), @"-PT631107417601s");
+        ), @"-PT631107417601S");
         insta::assert_snapshot!(p(
             0.second()
             .milliseconds(t::SpanMilliseconds::MIN_REPR)
             .microseconds(1_000_001),
-        ), @"-PT631107417601.000001s");
+        ), @"-PT631107417601.000001S");
         // This is 1 nanosecond more than the maximum number of seconds
         // representable in a span.
         insta::assert_snapshot!(p(
             0.second()
             .milliseconds(t::SpanMilliseconds::MIN_REPR)
             .nanoseconds(1_000_000_000),
-        ), @"-PT631107417601s");
+        ), @"-PT631107417601S");
         insta::assert_snapshot!(p(
             0.second()
             .milliseconds(t::SpanMilliseconds::MIN_REPR)
             .nanoseconds(1_000_000_001),
-        ), @"-PT631107417601.000000001s");
+        ), @"-PT631107417601.000000001S");
 
         // The max millis, micros and nanos, combined.
         insta::assert_snapshot!(p(
@@ -537,7 +537,7 @@ mod tests {
             .milliseconds(t::SpanMilliseconds::MIN_REPR)
             .microseconds(t::SpanMicroseconds::MIN_REPR)
             .nanoseconds(t::SpanNanoseconds::MIN_REPR),
-        ), @"-PT1271438207236.854775807s");
+        ), @"-PT1271438207236.854775807S");
         // The max seconds, millis, micros and nanos, combined.
         insta::assert_snapshot!(p(
             Span::new()
@@ -545,6 +545,6 @@ mod tests {
             .milliseconds(t::SpanMilliseconds::MIN_REPR)
             .microseconds(t::SpanMicroseconds::MIN_REPR)
             .nanoseconds(t::SpanNanoseconds::MIN_REPR),
-        ), @"-PT1902545624836.854775807s");
+        ), @"-PT1902545624836.854775807S");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,7 +360,7 @@ use jiff::civil::date;
 let zdt1 = date(2020, 8, 26).at(6, 27, 0, 0).intz("America/New_York")?;
 let zdt2 = date(2023, 12, 31).at(18, 30, 0, 0).intz("America/New_York")?;
 let span = &zdt2 - &zdt1;
-assert_eq!(span.to_string(), "PT29341h3m");
+assert_eq!(span.to_string(), "PT29341H3M");
 
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
@@ -376,7 +376,7 @@ use jiff::{civil::date, Unit};
 let zdt1 = date(2020, 8, 26).at(6, 27, 0, 0).intz("America/New_York")?;
 let zdt2 = date(2023, 12, 31).at(18, 30, 0, 0).intz("America/New_York")?;
 let span = zdt1.until((Unit::Year, &zdt2))?;
-assert_eq!(span.to_string(), "P3y4m5dT12h3m");
+assert_eq!(span.to_string(), "P3Y4M5DT12H3M");
 
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
@@ -437,7 +437,7 @@ Jiff supports parsing ISO 8601 duration strings:
 ```
 use jiff::Span;
 
-let span: Span = "P5y1w10dT5h59m".parse()?;
+let span: Span = "P5Y1W10DT5H59M".parse()?;
 let expected = Span::new().years(5).weeks(1).days(10).hours(5).minutes(59);
 assert_eq!(span, expected);
 

--- a/src/span.rs
+++ b/src/span.rs
@@ -69,7 +69,7 @@ use crate::{
 /// use jiff::Span;
 ///
 /// let span = Span::new().days(5).hours(8).minutes(1);
-/// assert_eq!(span.to_string(), "P5dT8h1m");
+/// assert_eq!(span.to_string(), "P5DT8H1M");
 /// ```
 ///
 /// But Jiff provides a [`ToSpan`] trait that defines extension methods on
@@ -79,10 +79,10 @@ use crate::{
 /// use jiff::ToSpan;
 ///
 /// let span = 5.days().hours(8).minutes(1);
-/// assert_eq!(span.to_string(), "P5dT8h1m");
+/// assert_eq!(span.to_string(), "P5DT8H1M");
 /// // singular units on integers can be used too:
 /// let span = 1.day().hours(8).minutes(1);
-/// assert_eq!(span.to_string(), "P1dT8h1m");
+/// assert_eq!(span.to_string(), "P1DT8H1M");
 /// ```
 ///
 /// # Negative spans
@@ -93,25 +93,25 @@ use crate::{
 /// use jiff::{Span, ToSpan};
 ///
 /// let span = -Span::new().days(5);
-/// assert_eq!(span.to_string(), "-P5d");
+/// assert_eq!(span.to_string(), "-P5D");
 ///
 /// let span = Span::new().days(5).negate();
-/// assert_eq!(span.to_string(), "-P5d");
+/// assert_eq!(span.to_string(), "-P5D");
 ///
 /// let span = Span::new().days(-5);
-/// assert_eq!(span.to_string(), "-P5d");
+/// assert_eq!(span.to_string(), "-P5D");
 ///
 /// let span = -Span::new().days(-5).negate();
-/// assert_eq!(span.to_string(), "-P5d");
+/// assert_eq!(span.to_string(), "-P5D");
 ///
 /// let span = -5.days();
-/// assert_eq!(span.to_string(), "-P5d");
+/// assert_eq!(span.to_string(), "-P5D");
 ///
 /// let span = (-5).days();
-/// assert_eq!(span.to_string(), "-P5d");
+/// assert_eq!(span.to_string(), "-P5D");
 ///
 /// let span = -(5.days());
-/// assert_eq!(span.to_string(), "-P5d");
+/// assert_eq!(span.to_string(), "-P5D");
 /// ```
 ///
 /// The sign of a span applies to the entire span. When a span is negative,
@@ -175,7 +175,7 @@ use crate::{
 /// use jiff::Span;
 ///
 /// let span: Span = "P2M10DT2H30M".parse()?;
-/// assert_eq!(span.to_string(), "P2m10dT2h30m");
+/// assert_eq!(span.to_string(), "P2M10DT2H30M");
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
@@ -188,18 +188,19 @@ use crate::{
 ///
 /// let spans = [
 ///     ("P40D", 40.days()),
-///     ("P1y1d", 1.year().days(1)),
-///     ("P3dT4h59m", 3.days().hours(4).minutes(59)),
+///     ("P1Y1D", 1.year().days(1)),
+///     ("P3DT4H59M", 3.days().hours(4).minutes(59)),
 ///     ("PT2H30M", 2.hours().minutes(30)),
-///     ("P1m", 1.month()),
-///     ("P1w", 1.week()),
-///     ("P1w4d", 1.week().days(4)),
-///     ("PT1m", 1.minute()),
-///     ("PT0.0021s", 2.milliseconds().microseconds(100)),
-///     ("PT0s", 0.seconds()),
-///     ("P0d", 0.seconds()),
+///     ("P1M", 1.month()),
+///     ("P1W", 1.week()),
+///     ("P1W4D", 1.week().days(4)),
+///     ("PT1M", 1.minute()),
+///     ("PT0.0021S", 2.milliseconds().microseconds(100)),
+///     ("PT0S", 0.seconds()),
+///     ("PT0S", 0.seconds()),
+///     ("P0D", 0.seconds()),
 ///     (
-///         "P1y1m1dT1h1m1.1s",
+///         "P1Y1M1DT1H1M1.1S",
 ///         1.year().months(1).days(1).hours(1).minutes(1).seconds(1).milliseconds(100),
 ///     ),
 /// ];
@@ -249,7 +250,7 @@ use crate::{
 /// use jiff::{Span, ToSpan};
 ///
 /// let span1 = 2.hours().minutes(20);
-/// let span2: Span = "PT89400s".parse()?;
+/// let span2: Span = "PT89400S".parse()?;
 /// assert_eq!(span1.checked_add(span2)?, 27.hours().minutes(10));
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -898,9 +899,9 @@ impl Span {
     /// use jiff::ToSpan;
     ///
     /// let span = -100.seconds();
-    /// assert_eq!(span.to_string(), "-PT100s");
+    /// assert_eq!(span.to_string(), "-PT100S");
     /// let span = span.abs();
-    /// assert_eq!(span.to_string(), "PT100s");
+    /// assert_eq!(span.to_string(), "PT100S");
     /// ```
     #[inline]
     pub fn abs(self) -> Span {
@@ -922,9 +923,9 @@ impl Span {
     /// use jiff::ToSpan;
     ///
     /// let span = 100.days();
-    /// assert_eq!(span.to_string(), "P100d");
+    /// assert_eq!(span.to_string(), "P100D");
     /// let span = span.negate();
-    /// assert_eq!(span.to_string(), "-P100d");
+    /// assert_eq!(span.to_string(), "-P100D");
     /// ```
     ///
     /// # Example: available via the negation operator
@@ -935,9 +936,9 @@ impl Span {
     /// use jiff::ToSpan;
     ///
     /// let span = 100.days();
-    /// assert_eq!(span.to_string(), "P100d");
+    /// assert_eq!(span.to_string(), "P100D");
     /// let span = -span;
-    /// assert_eq!(span.to_string(), "-P100d");
+    /// assert_eq!(span.to_string(), "-P100D");
     /// ```
     #[inline]
     pub fn negate(self) -> Span {
@@ -1679,7 +1680,7 @@ impl Span {
     /// ```
     /// use jiff::{Span, ToSpan, Unit};
     ///
-    /// let span: Span = "PT23h50m3.123s".parse()?;
+    /// let span: Span = "PT23H50M3.123S".parse()?;
     /// assert_eq!(span.round((Unit::Minute, 30))?, 24.hours());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -2592,13 +2593,13 @@ impl quickcheck::Arbitrary for Span {
 /// ```
 /// use jiff::ToSpan;
 ///
-/// assert_eq!(5.days().to_string(), "P5d");
-/// assert_eq!(5.days().hours(10).to_string(), "P5dT10h");
+/// assert_eq!(5.days().to_string(), "P5D");
+/// assert_eq!(5.days().hours(10).to_string(), "P5DT10H");
 ///
 /// // Negation works and it doesn't matter where the sign goes. It can be
 /// // applied to the span itself or to the integer.
-/// assert_eq!((-5.days()).to_string(), "-P5d");
-/// assert_eq!((-5).days().to_string(), "-P5d");
+/// assert_eq!((-5.days()).to_string(), "-P5D");
+/// assert_eq!((-5).days().to_string(), "-P5D");
 /// ```
 ///
 /// # Example: alternative via span parsing
@@ -2609,7 +2610,7 @@ impl quickcheck::Arbitrary for Span {
 /// ```
 /// use jiff::Span;
 ///
-/// let span = "P5y2m15dT23h30m10s".parse::<Span>()?;
+/// let span = "P5Y2M15DT23H30M10S".parse::<Span>()?;
 /// assert_eq!(
 ///     span,
 ///     Span::new().years(5).months(2).days(15).hours(23).minutes(30).seconds(10),
@@ -2813,7 +2814,7 @@ impl_to_span!(i64);
 /// let zdt1: Zoned = "2024-07-06 17:40-04[America/New_York]".parse()?;
 /// let zdt2: Zoned = "2024-11-05 08:00-05[America/New_York]".parse()?;
 /// let span = zdt1.until((Unit::Year, &zdt2))?;
-/// assert_eq!(span.to_string(), "P3m29dT14h20m");
+/// assert_eq!(span.to_string(), "P3M29DT14H20M");
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -1531,11 +1531,11 @@ impl Timestamp {
     ///
     /// // The default limits durations to using "seconds" as the biggest unit.
     /// let span = ts2.since(ts1)?;
-    /// assert_eq!(span.to_string(), "PT730641929.9999965s");
+    /// assert_eq!(span.to_string(), "PT730641929.9999965S");
     ///
     /// // But we can ask for units all the way up to hours.
     /// let span = ts2.since((Unit::Hour, ts1))?;
-    /// assert_eq!(span.to_string(), "PT202956h5m29.9999965s");
+    /// assert_eq!(span.to_string(), "PT202956H5M29.9999965S");
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -1660,11 +1660,11 @@ impl Timestamp {
     ///
     /// // The default limits durations to using "seconds" as the biggest unit.
     /// let span = ts1.until(ts2)?;
-    /// assert_eq!(span.to_string(), "PT730641929.9999965s");
+    /// assert_eq!(span.to_string(), "PT730641929.9999965S");
     ///
     /// // But we can ask for units all the way up to hours.
     /// let span = ts1.until((Unit::Hour, ts2))?;
-    /// assert_eq!(span.to_string(), "PT202956h5m29.9999965s");
+    /// assert_eq!(span.to_string(), "PT202956H5M29.9999965S");
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```

--- a/src/tz/snapshots/jiff__tz__zic__tests__parse_zic_man1.snap
+++ b/src/tz/snapshots/jiff__tz__zic__tests__parse_zic_man1.snap
@@ -22,11 +22,11 @@ ZicP {
                     weekday: Sunday,
                 },
                 at: RuleAtP {
-                    span: PT2h,
+                    span: PT2H,
                     suffix: None,
                 },
                 save: RuleSaveP {
-                    span: PT0s,
+                    span: PT0S,
                     suffix: None,
                 },
                 letters: RuleLettersP {
@@ -50,11 +50,11 @@ ZicP {
                     weekday: Sunday,
                 },
                 at: RuleAtP {
-                    span: PT2h,
+                    span: PT2H,
                     suffix: None,
                 },
                 save: RuleSaveP {
-                    span: PT1h,
+                    span: PT1H,
                     suffix: None,
                 },
                 letters: RuleLettersP {
@@ -70,7 +70,7 @@ ZicP {
                     name: "America/Menominee",
                 },
                 stdoff: ZoneStdoffP {
-                    span: -PT5h,
+                    span: -PT5H,
                 },
                 rules: None,
                 format: Static {
@@ -86,7 +86,7 @@ ZicP {
                             day: 29,
                         },
                         duration: RuleAtP {
-                            span: PT2h,
+                            span: PT2H,
                             suffix: None,
                         },
                     },
@@ -95,7 +95,7 @@ ZicP {
             continuations: [
                 ZoneContinuationP {
                     stdoff: ZoneStdoffP {
-                        span: -PT6h,
+                        span: -PT6H,
                     },
                     rules: Named(
                         RuleNameP {

--- a/src/tz/snapshots/jiff__tz__zic__tests__parse_zic_man2.snap
+++ b/src/tz/snapshots/jiff__tz__zic__tests__parse_zic_man2.snap
@@ -23,13 +23,13 @@ ZicP {
                     day: 1,
                 },
                 at: RuleAtP {
-                    span: PT1h,
+                    span: PT1H,
                     suffix: Some(
                         Universal,
                     ),
                 },
                 save: RuleSaveP {
-                    span: PT1h,
+                    span: PT1H,
                     suffix: None,
                 },
                 letters: RuleLettersP {
@@ -51,13 +51,13 @@ ZicP {
                     weekday: Sunday,
                 },
                 at: RuleAtP {
-                    span: PT1h,
+                    span: PT1H,
                     suffix: Some(
                         Universal,
                     ),
                 },
                 save: RuleSaveP {
-                    span: PT0s,
+                    span: PT0S,
                     suffix: None,
                 },
                 letters: RuleLettersP {
@@ -79,13 +79,13 @@ ZicP {
                     day: 1,
                 },
                 at: RuleAtP {
-                    span: PT1h,
+                    span: PT1H,
                     suffix: Some(
                         Universal,
                     ),
                 },
                 save: RuleSaveP {
-                    span: PT0s,
+                    span: PT0S,
                     suffix: None,
                 },
                 letters: RuleLettersP {
@@ -109,13 +109,13 @@ ZicP {
                     weekday: Sunday,
                 },
                 at: RuleAtP {
-                    span: PT1h,
+                    span: PT1H,
                     suffix: Some(
                         Universal,
                     ),
                 },
                 save: RuleSaveP {
-                    span: PT0s,
+                    span: PT0S,
                     suffix: None,
                 },
                 letters: RuleLettersP {
@@ -137,13 +137,13 @@ ZicP {
                     weekday: Sunday,
                 },
                 at: RuleAtP {
-                    span: PT1h,
+                    span: PT1H,
                     suffix: Some(
                         Universal,
                     ),
                 },
                 save: RuleSaveP {
-                    span: PT1h,
+                    span: PT1H,
                     suffix: None,
                 },
                 letters: RuleLettersP {
@@ -165,13 +165,13 @@ ZicP {
                     weekday: Sunday,
                 },
                 at: RuleAtP {
-                    span: PT1h,
+                    span: PT1H,
                     suffix: Some(
                         Universal,
                     ),
                 },
                 save: RuleSaveP {
-                    span: PT0s,
+                    span: PT0S,
                     suffix: None,
                 },
                 letters: RuleLettersP {
@@ -198,11 +198,11 @@ ZicP {
                     day: 1,
                 },
                 at: RuleAtP {
-                    span: PT1h,
+                    span: PT1H,
                     suffix: None,
                 },
                 save: RuleSaveP {
-                    span: PT1h,
+                    span: PT1H,
                     suffix: None,
                 },
                 letters: RuleLettersP {
@@ -227,11 +227,11 @@ ZicP {
                     day: 1,
                 },
                 at: RuleAtP {
-                    span: PT2h,
+                    span: PT2H,
                     suffix: None,
                 },
                 save: RuleSaveP {
-                    span: PT0s,
+                    span: PT0S,
                     suffix: None,
                 },
                 letters: RuleLettersP {
@@ -247,7 +247,7 @@ ZicP {
                     name: "Europe/Zurich",
                 },
                 stdoff: ZoneStdoffP {
-                    span: PT34m8s,
+                    span: PT34M8S,
                 },
                 rules: None,
                 format: Static {
@@ -268,7 +268,7 @@ ZicP {
             continuations: [
                 ZoneContinuationP {
                     stdoff: ZoneStdoffP {
-                        span: PT29m45.5s,
+                        span: PT29M45.5S,
                     },
                     rules: None,
                     format: Static {
@@ -285,7 +285,7 @@ ZicP {
                 },
                 ZoneContinuationP {
                     stdoff: ZoneStdoffP {
-                        span: PT1h,
+                        span: PT1H,
                     },
                     rules: Named(
                         RuleNameP {
@@ -304,7 +304,7 @@ ZicP {
                 },
                 ZoneContinuationP {
                     stdoff: ZoneStdoffP {
-                        span: PT1h,
+                        span: PT1H,
                     },
                     rules: Named(
                         RuleNameP {

--- a/src/tz/zic.rs
+++ b/src/tz/zic.rs
@@ -1712,13 +1712,13 @@ mod tests {
                 weekday: Sunday,
             },
             at: RuleAtP {
-                span: PT2h,
+                span: PT2H,
                 suffix: Some(
                     Wall,
                 ),
             },
             save: RuleSaveP {
-                span: PT1h,
+                span: PT1H,
                 suffix: Some(
                     Dst,
                 ),
@@ -1754,7 +1754,7 @@ mod tests {
                 name: "America/Menominee",
             },
             stdoff: ZoneStdoffP {
-                span: -PT5h,
+                span: -PT5H,
             },
             rules: None,
             format: Static {
@@ -1781,7 +1781,7 @@ mod tests {
                 name: "America/Menominee",
             },
             stdoff: ZoneStdoffP {
-                span: -PT5h,
+                span: -PT5H,
             },
             rules: None,
             format: Static {
@@ -1797,7 +1797,7 @@ mod tests {
                         day: 29,
                     },
                     duration: RuleAtP {
-                        span: PT2h,
+                        span: PT2H,
                         suffix: None,
                     },
                 },
@@ -1825,7 +1825,7 @@ mod tests {
         insta::assert_debug_snapshot!(zone, @r###"
         ZoneContinuationP {
             stdoff: ZoneStdoffP {
-                span: -PT5h,
+                span: -PT5H,
             },
             rules: None,
             format: Static {
@@ -1842,7 +1842,7 @@ mod tests {
         insta::assert_debug_snapshot!(zone, @r###"
         ZoneContinuationP {
             stdoff: ZoneStdoffP {
-                span: -PT5h,
+                span: -PT5H,
             },
             rules: None,
             format: Static {
@@ -1858,7 +1858,7 @@ mod tests {
                         day: 29,
                     },
                     duration: RuleAtP {
-                        span: PT2h,
+                        span: PT2H,
                         suffix: None,
                     },
                 },

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -2520,11 +2520,11 @@ impl Zoned {
     ///
     /// // The default limits durations to using "hours" as the biggest unit.
     /// let span = zdt2.since(&zdt1)?;
-    /// assert_eq!(span.to_string(), "PT202956h5m29.9999965s");
+    /// assert_eq!(span.to_string(), "PT202956H5M29.9999965S");
     ///
     /// // But we can ask for units all the way up to years.
     /// let span = zdt2.since((Unit::Year, &zdt1))?;
-    /// assert_eq!(span.to_string(), "P23y1m24dT12h5m29.9999965s");
+    /// assert_eq!(span.to_string(), "P23Y1M24DT12H5M29.9999965S");
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     ///
@@ -2693,11 +2693,11 @@ impl Zoned {
     ///
     /// // The default limits durations to using "hours" as the biggest unit.
     /// let span = zdt1.until(&zdt2)?;
-    /// assert_eq!(span.to_string(), "PT202956h5m29.9999965s");
+    /// assert_eq!(span.to_string(), "PT202956H5M29.9999965S");
     ///
     /// // But we can ask for units all the way up to years.
     /// let span = zdt1.until((Unit::Year, &zdt2))?;
-    /// assert_eq!(span.to_string(), "P23y1m24dT12h5m29.9999965s");
+    /// assert_eq!(span.to_string(), "P23Y1M24DT12H5M29.9999965S");
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     ///

--- a/tests/tc39_262/civil/date/add.rs
+++ b/tests/tc39_262/civil/date/add.rs
@@ -35,7 +35,7 @@ fn balance_smaller_units_basic() -> Result {
 fn balance_smaller_units() -> Result {
     let d = date(2000, 5, 2);
 
-    let span: Span = "P1dT24h1440m86400s".parse()?;
+    let span: Span = "P1DT24H1440M86400S".parse()?;
     assert_eq!(d + span, date(2000, 5, 6));
 
     let span = 1

--- a/tests/tc39_262/civil/datetime/until.rs
+++ b/tests/tc39_262/civil/datetime/until.rs
@@ -88,15 +88,15 @@ fn balance() -> Result {
     let c: DateTime = "2021-03-05T09:32:45+00:00[UTC]".parse()?;
 
     let span = a.until((Unit::Month, b))?;
-    assert_eq!(span.to_string(), "P40m27dT19h25m31s");
+    assert_eq!(span.to_string(), "P40M27DT19H25M31S");
     assert_eq!(a + span, b);
 
     let span = b.until((Unit::Month, a))?;
-    assert_eq!(span.to_string(), "-P40m30dT19h25m31s");
+    assert_eq!(span.to_string(), "-P40M30DT19H25M31S");
     assert_eq!(b + span, a);
 
     let span = c.until((Unit::Month, a))?;
-    assert_eq!(span.to_string(), "-P41mT1h25m31s");
+    assert_eq!(span.to_string(), "-P41MT1H25M31S");
     assert_eq!(c + span, a);
 
     Ok(())
@@ -474,8 +474,8 @@ fn weeks_months_mutually_exclusive() -> Result {
     let dt1 = date(1976, 11, 18).at(15, 23, 30, 123_456_789);
     let dt2 = dt1 + 42.days().hours(3);
 
-    assert_eq!(dt1.until((Unit::Week, dt2))?.to_string(), "P6wT3h");
-    assert_eq!(dt1.until((Unit::Month, dt2))?.to_string(), "P1m12dT3h");
+    assert_eq!(dt1.until((Unit::Week, dt2))?.to_string(), "P6WT3H");
+    assert_eq!(dt1.until((Unit::Month, dt2))?.to_string(), "P1M12DT3H");
     Ok(())
 }
 

--- a/tests/tc39_262/civil/time/until.rs
+++ b/tests/tc39_262/civil/time/until.rs
@@ -27,22 +27,22 @@ fn balance_negative_time_units() -> Result {
     let t2 = time(1, 1, 1, 001_001_001);
 
     let t1 = time(0, 0, 0, 000_000_002);
-    assert_eq!(t1.until(t2)?.to_string(), "PT1h1m1.001000999s");
+    assert_eq!(t1.until(t2)?.to_string(), "PT1H1M1.001000999S");
 
     let t1 = time(0, 0, 0, 000_002_000);
-    assert_eq!(t1.until(t2)?.to_string(), "PT1h1m1.000999001s");
+    assert_eq!(t1.until(t2)?.to_string(), "PT1H1M1.000999001S");
 
     let t1 = time(0, 0, 0, 002_000_000);
-    assert_eq!(t1.until(t2)?.to_string(), "PT1h1m0.999001001s");
+    assert_eq!(t1.until(t2)?.to_string(), "PT1H1M0.999001001S");
 
     let t1 = time(0, 0, 2, 0);
-    assert_eq!(t1.until(t2)?.to_string(), "PT1h59.001001001s");
+    assert_eq!(t1.until(t2)?.to_string(), "PT1H59.001001001S");
 
     let t1 = time(0, 2, 0, 0);
-    assert_eq!(t1.until(t2)?.to_string(), "PT59m1.001001001s");
+    assert_eq!(t1.until(t2)?.to_string(), "PT59M1.001001001S");
 
     let t1 = time(2, 0, 0, 0);
-    assert_eq!(t1.until(t2)?.to_string(), "-PT58m58.998998999s");
+    assert_eq!(t1.until(t2)?.to_string(), "-PT58M58.998998999S");
 
     Ok(())
 }
@@ -54,10 +54,10 @@ fn basic() -> Result {
     let two = time(16, 23, 30, 123_456_789);
     let three = time(17, 0, 30, 123_456_789);
 
-    assert_eq!(one.until(two)?.to_string(), "PT1h");
-    assert_eq!(two.until(one)?.to_string(), "-PT1h");
-    assert_eq!(one.until(three)?.to_string(), "PT1h37m");
-    assert_eq!(three.until(one)?.to_string(), "-PT1h37m");
+    assert_eq!(one.until(two)?.to_string(), "PT1H");
+    assert_eq!(two.until(one)?.to_string(), "-PT1H");
+    assert_eq!(one.until(three)?.to_string(), "PT1H37M");
+    assert_eq!(three.until(one)?.to_string(), "-PT1H37M");
 
     Ok(())
 }
@@ -109,10 +109,10 @@ fn largestunit() -> Result {
     let t1 = time(4, 48, 55, 0);
     let t2 = time(11, 59, 58, 0);
 
-    assert_eq!(t1.until(t2)?.to_string(), "PT7h11m3s");
-    assert_eq!(t1.until((Unit::Hour, t2))?.to_string(), "PT7h11m3s");
-    assert_eq!(t1.until((Unit::Minute, t2))?.to_string(), "PT431m3s");
-    assert_eq!(t1.until((Unit::Second, t2))?.to_string(), "PT25863s");
+    assert_eq!(t1.until(t2)?.to_string(), "PT7H11M3S");
+    assert_eq!(t1.until((Unit::Hour, t2))?.to_string(), "PT7H11M3S");
+    assert_eq!(t1.until((Unit::Minute, t2))?.to_string(), "PT431M3S");
+    assert_eq!(t1.until((Unit::Second, t2))?.to_string(), "PT25863S");
 
     Ok(())
 }
@@ -132,7 +132,7 @@ fn result_sub_second() -> Result {
     // via fractional seconds.)
     assert_eq!(
         t1.until((Unit::Millisecond, t2))?.to_string(),
-        "PT24762.25025025s",
+        "PT24762.25025025S",
     );
 
     assert_eq!(
@@ -141,7 +141,7 @@ fn result_sub_second() -> Result {
     );
     assert_eq!(
         t1.until((Unit::Microsecond, t2))?.to_string(),
-        "PT24762.25025025s",
+        "PT24762.25025025S",
     );
 
     assert_eq!(
@@ -150,7 +150,7 @@ fn result_sub_second() -> Result {
     );
     assert_eq!(
         t1.until((Unit::Nanosecond, t2))?.to_string(),
-        "PT24762.25025025s",
+        "PT24762.25025025S",
     );
 
     Ok(())

--- a/tests/tc39_262/span/round.rs
+++ b/tests/tc39_262/span/round.rs
@@ -201,14 +201,14 @@ fn duration_out_of_range_added_to_relative() -> Result {
     let relative = SpanRound::new().relative(d);
     insta::assert_snapshot!(
         sp.round(relative.smallest(Unit::Year)).unwrap_err(),
-        @"failed to add P2000000dT170000000h to 2000-01-01T00:00:00: failed to add overflowing span, P7083333d, from adding PT170000000h to 00:00:00, to 7475-10-25: parameter 'days' with value 7083333 is not in the required range of -4371587..=2932896",
+        @"failed to add P2000000DT170000000H to 2000-01-01T00:00:00: failed to add overflowing span, P7083333D, from adding PT170000000H to 00:00:00, to 7475-10-25: parameter 'days' with value 7083333 is not in the required range of -4371587..=2932896",
     );
 
     let sp = -2_000_000.days().hours(170_000_000);
     let relative = SpanRound::new().relative(d);
     insta::assert_snapshot!(
         sp.round(relative.smallest(Unit::Year)).unwrap_err(),
-        @"failed to add -P2000000dT170000000h to 2000-01-01T00:00:00: failed to add overflowing span, -P7083334d, from adding -PT170000000h to 00:00:00, to -003476-03-09: parameter 'days' with value -7083334 is not in the required range of -4371587..=2932896",
+        @"failed to add -P2000000DT170000000H to 2000-01-01T00:00:00: failed to add overflowing span, -P7083334D, from adding -PT170000000H to 00:00:00, to -003476-03-09: parameter 'days' with value -7083334 is not in the required range of -4371587..=2932896",
     );
 
     Ok(())
@@ -579,13 +579,13 @@ fn largestunit_smallestunit_mismatch() -> Result {
 /// Source: https://github.com/tc39/test262/blob/29c6f7028a683b8259140e7d6352ae0ca6448a85/test/built-ins/Temporal/Duration/prototype/round/largestunit-undefined.js
 #[test]
 fn largestunit_undefined() -> Result {
-    let sp = "PT1h120m1.123456789s".parse::<Span>()?;
+    let sp = "PT1H120M1.123456789S".parse::<Span>()?;
     let result = sp.round(Unit::Nanosecond)?;
-    assert_eq!(result, "PT3h1.123456789s".parse()?);
+    assert_eq!(result, "PT3H1.123456789S".parse()?);
 
-    let sp = "PT120m1.123456789s".parse::<Span>()?;
+    let sp = "PT120M1.123456789S".parse::<Span>()?;
     let result = sp.round(Unit::Nanosecond)?;
-    assert_eq!(result, "PT120m1.123456789s".parse()?);
+    assert_eq!(result, "PT120M1.123456789S".parse()?);
 
     Ok(())
 }
@@ -602,7 +602,7 @@ fn out_of_range_when_adjusting_rounded_days() -> Result {
     insta::assert_snapshot!(
         sp.round(options).unwrap_err(),
         // Kind of a brutal error message...
-        @"failed to add P1dT631107331200.999999999s to 1970-01-01T00:00:00+00:00[UTC]: failed to add span PT631107331200.999999999s to timestamp 1970-01-02T00:00:00Z (which was created from 1970-01-02T00:00:00): adding PT631107331200.999999999s to 1970-01-02T00:00:00Z overflowed: parameter 'span' with value 631107331200999999999 is not in the required range of -377705023201000000000..=253402207200999999999",
+        @"failed to add P1DT631107331200.999999999S to 1970-01-01T00:00:00+00:00[UTC]: failed to add span PT631107331200.999999999S to timestamp 1970-01-02T00:00:00Z (which was created from 1970-01-02T00:00:00): adding PT631107331200.999999999S to 1970-01-02T00:00:00Z overflowed: parameter 'span' with value 631107331200999999999 is not in the required range of -377705023201000000000..=253402207200999999999",
     );
 
     Ok(())


### PR DESCRIPTION
All the ISO8601 resources I could find use uppercased representations for Durations/Periods.

3.4.1 notes:
> NOTE 1: In date and time representations lower case characters may be used when upper case characters are not available.

3.4.3 notes:
> In representations of duration (4.4.3.2), the following designators are used as part of the expression: [Y] [M] [W] [D] [H] [M] [S]

This change introduces a breaking change: durations are now emitted fully uppercased.

It looks like other projects are lenient in what they accept - and strict in emitting uppercase.
Spring Boot:
https://github.com/spring-projects/spring-boot/blob/4d466c3cc097/spring-boot-project/spring-boot/src/test/java/org/springframework/boot/convert/DurationStyleTests.java

Temporal:
https://github.com/tc39/test262/blob/880f8a5ba6/test/built-ins/Temporal/Duration


**I understand this is quite a highly pedantic change** :D