### PR TITLE
doc: fix typo in example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ fn main() -> Result<(), jiff::Error> {
     let zoned = time.intz("America/New_York")?.checked_add(1.month().hours(2))?;
     assert_eq!(zoned.to_string(), "2024-08-10T23:14:00-04:00[America/New_York]");
     // Or, if you want an RFC3339 formatted string:
-    assert_eq!(zoned.timestamp().to_string(), "2024-08-11T03:14:00Z");
+    assert_eq!(zoned.timestamp().to_string(), "2024-08-11T23:14:00Z");
     Ok(())
 }
 ```


### PR DESCRIPTION
Just caught this by coincidence and figured it's a good opportunity to try this Github web based README editing feature :)