### PR TITLE
timestamp: make saturating arithmetic panic for non-uniform units

### DIFF
--- a/COMPARE.md
+++ b/COMPARE.md
@@ -1093,7 +1093,7 @@ use jiff::{Timestamp, ToSpan};
 fn main() -> anyhow::Result<()> {
     let ts = Timestamp::MAX;
     assert!(ts.checked_add(1.day()).is_err());
-    assert_eq!(ts.saturating_add(1.day()), ts);
+    assert_eq!(ts.saturating_add(1.hour()), ts);
 
     Ok(())
 }


### PR DESCRIPTION
The saturating methods *should* return an error. But I goofed on the
API. So at this point, our two choices are: leave it as-is, which
produces completely incorrect results when there are non-zero units of
days or greater, or panic when it occurs. I think a panic is better.

In Jiff 0.2, these APIs will be made fallible. And hopefully by then
we'll have truly infallible APIs that accept an "absolute" duration.

Partially addresses #36
