### PR TITLE
doc: correct span format example regex

### DIFF
--- a/src/fmt/temporal/mod.rs
+++ b/src/fmt/temporal/mod.rs
@@ -61,7 +61,7 @@ To a first approximation, the span format supported roughly corresponds to this
 regular expression:
 
 ```text
-P(\d+y)?(\d+m)?(\d+w)?(\d+d)?(T(\d+h)?(\d+m)?(\d+d)?)?
+P(\d+y)?(\d+m)?(\d+w)?(\d+d)?(T(\d+h)?(\d+m)?(\d+s)?)?
 ```
 
 But there are some details not easily captured by a simple regular expression:


### PR DESCRIPTION
Just a small docs fix I noticed while browsing.

Use `s` for seconds at the end instead of `d` for days.