### PR TITLE
fmt: add APIs for skipping weekday checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Enhancements:
 
 * [PR #52](https://github.com/BurntSushi/jiff/pull/52):
 Improve documentation for `Span` getter methods.
+* [PR #53](https://github.com/BurntSushi/jiff/pull/53):
+Add support for skipping weekday checking when parsing datetimes.
 
 Bug fixes:
 


### PR DESCRIPTION
In the course of doing some experiments with using Jiff in `gix-date`, I
discovered that it currently relies on the fact that parsing RFC 2822
datetimes (and similar) does *not* do error checking if the date and
weekday are inconsistent. Prior to this PR, Jiff required that the
weekday and date were consistent. This PR adds APIs for skipping this
check.

For RFC 2822, this adds a new `relaxed_weekday` configuration on the
`DateTimeParser` builder.

For the strtime APIs, we achieve this by adding more granular accessors
and mutators on `BrokenDownTime`. So now folks can do this:

```
let tm = BrokenDownTime::parse("%a, %F", "Wed, 2024-07-27")?;
tm.set_weekday(None);
assert_eq!(tm.to_date().unwrap(), jiff::civil::date(2024, 7, 27));
```

Where the above succeeds even though 2024-07-27 was a Saturday. It's a
little verbose, but my hope is that this is a rarely needed thing.

This PR also adds getters and setters for individual fields on a
`jiff::fmt::strtime::BrokenDownTime`. This affords a bit more flexibility
in terms of what can be parsed and formatted. For example, it
lets one parse _just_ a weekday:

```rust
use jiff::{civil::Weekday, fmt::strtime::BrokenDownTime};

let tm = BrokenDownTime::parse("%a", "Sat").unwrap();
assert_eq!(tm.weekday(), Some(Weekday::Saturday));
```