### PR TITLE
fmt/strtime: support parsing and formatting fractional seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Enhancements:
 Improve documentation for `Span` getter methods.
 * [PR #53](https://github.com/BurntSushi/jiff/pull/53):
 Add support for skipping weekday checking when parsing datetimes.
+* [PR #55](https://github.com/BurntSushi/jiff/pull/55):
+Add support for fractional seconds in `jiff::fmt::strtime`.
 
 Bug fixes:
 

--- a/src/fmt/offset.rs
+++ b/src/fmt/offset.rs
@@ -243,7 +243,7 @@ impl core::fmt::Display for Numeric {
         }
         if let Some(nanos) = self.nanoseconds {
             static FMT: DecimalFormatter =
-                DecimalFormatter::new().fractional(9);
+                DecimalFormatter::new().fractional(0, 9);
             write!(f, ".{}", FMT.format(i64::from(nanos)).as_str())?;
         }
         Ok(())

--- a/src/fmt/temporal/printer.rs
+++ b/src/fmt/temporal/printer.rs
@@ -103,7 +103,7 @@ impl DateTimePrinter {
     ) -> Result<(), Error> {
         static FMT_TWO: DecimalFormatter = DecimalFormatter::new().padding(2);
         static FMT_FRACTION: DecimalFormatter =
-            DecimalFormatter::new().fractional(9);
+            DecimalFormatter::new().fractional(0, 9);
 
         wtr.write_int(&FMT_TWO, time.hour())?;
         wtr.write_str(":")?;
@@ -215,7 +215,7 @@ impl SpanPrinter {
     ) -> Result<(), Error> {
         static FMT_INT: DecimalFormatter = DecimalFormatter::new();
         static FMT_FRACTION: DecimalFormatter =
-            DecimalFormatter::new().fractional(9);
+            DecimalFormatter::new().fractional(0, 9);
 
         if span.is_negative() {
             wtr.write_str("-")?;


### PR DESCRIPTION
This isn't supported in the analogous C APIs, but it turns out it was
supported in the `chrono` crate and was actually being used.

This adds two new directives, `%f` and `%.f`. The former always writes
out at least one digit (and parsing requires at least one digit) and
corresponds to the number of fractional nanoseconds. The latter includes
the leading `.` and is satisfied by the empty string. That is, if a `.`
isn't found when `%.f` is expected, then it is skipped entirely when
parsing. Similarly, when formatting, if there are no fractional seconds
(i.e., the subsecond component is `0`), then no fractional component is
written either.

It is expected that most use cases will reach for just `%.f`, since it
will just do the "right" thing without thinking much about it. For
example, `%H:%M:%S%.f` will parse both `23:30:01` and `23:30:01.789`.

Closes #54
