### PR TITLE
fmt: improve strptime so that it can parse adjacent values more easily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+0.1.4 (2024-08-01)
+==================
+This release includes a small improvement for `strptime` that permits
+`%Y%m%d` to parse `20240730` correctly.
+
+* [#62](https://github.com/BurntSushi/jiff/issues/62):
+Tweak `strptime` so that things like `%Y` aren't unceremoniously greedy.
+
+
 0.1.3 (2024-07-30)
 ==================
 This release features support for `wasm32-unknown-unknown`. That is, when


### PR DESCRIPTION
Previously, `strptime` worked greedily. That is, specifiers like `%Y`
matched as many ASCII digits as possible, and then tried to parse all
of them into a year value.

But this meant that using `%Y%m%d` to parse something like `20240730`
couldn't work: `%Y` would consume all of `20240730` and then of course
fail since the value exceeds the year boundaries of Jiff.

Instead, we tweak how parsing works so that it only consumes the
maximum possible number of digits given its boundaries.

Fixes #62
