### PR TITLE
doc: minor correction: "printf"-style API

### DIFF
--- a/src/civil/date.rs
+++ b/src/civil/date.rs
@@ -2075,11 +2075,11 @@ impl Date {
     }
 }
 
-/// Parsing and formatting using a "printf" style of API.
+/// Parsing and formatting using a "printf"-style API.
 impl Date {
     /// Parses a civil date in `input` matching the given `format`.
     ///
-    /// The format string uses a "printf" style of API where conversion
+    /// The format string uses a "printf"-style API where conversion
     /// specifiers can be used as place holders to match components of
     /// a datetime. For details on the specifiers supported, see the
     /// [`fmt::strtime`] module documentation.
@@ -2116,7 +2116,7 @@ impl Date {
 
     /// Formats this civil date according to the given `format`.
     ///
-    /// The format string uses a "printf" style of API where conversion
+    /// The format string uses a "printf"-style API where conversion
     /// specifiers can be used as place holders to format components of
     /// a datetime. For details on the specifiers supported, see the
     /// [`fmt::strtime`] module documentation.

--- a/src/civil/datetime.rs
+++ b/src/civil/datetime.rs
@@ -2281,11 +2281,11 @@ impl DateTime {
     }
 }
 
-/// Parsing and formatting using a "printf" style of API.
+/// Parsing and formatting using a "printf"-style API.
 impl DateTime {
     /// Parses a civil datetime in `input` matching the given `format`.
     ///
-    /// The format string uses a "printf" style of API where conversion
+    /// The format string uses a "printf"-style API where conversion
     /// specifiers can be used as place holders to match components of
     /// a datetime. For details on the specifiers supported, see the
     /// [`fmt::strtime`] module documentation.
@@ -2321,7 +2321,7 @@ impl DateTime {
 
     /// Formats this civil datetime according to the given `format`.
     ///
-    /// The format string uses a "printf" style of API where conversion
+    /// The format string uses a "printf"-style API where conversion
     /// specifiers can be used as place holders to format components of
     /// a datetime. For details on the specifiers supported, see the
     /// [`fmt::strtime`] module documentation.

--- a/src/civil/time.rs
+++ b/src/civil/time.rs
@@ -1491,11 +1491,11 @@ impl Time {
     }
 }
 
-/// Parsing and formatting using a "printf" style of API.
+/// Parsing and formatting using a "printf"-style API.
 impl Time {
     /// Parses a civil time in `input` matching the given `format`.
     ///
-    /// The format string uses a "printf" style of API where conversion
+    /// The format string uses a "printf"-style API where conversion
     /// specifiers can be used as place holders to match components of
     /// a datetime. For details on the specifiers supported, see the
     /// [`fmt::strtime`] module documentation.
@@ -1532,7 +1532,7 @@ impl Time {
 
     /// Formats this civil time according to the given `format`.
     ///
-    /// The format string uses a "printf" style of API where conversion
+    /// The format string uses a "printf"-style API where conversion
     /// specifiers can be used as place holders to format components of
     /// a datetime. For details on the specifiers supported, see the
     /// [`fmt::strtime`] module documentation.

--- a/src/fmt/strtime/mod.rs
+++ b/src/fmt/strtime/mod.rs
@@ -1,5 +1,5 @@
 /*!
-Support for "printf" style parsing and formatting.
+Support for "printf"-style parsing and formatting.
 
 While the routines exposed in this module very closely resemble the
 corresponding [`strptime`] and [`strftime`] POSIX functions, it is not a goal

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -1908,12 +1908,12 @@ impl Timestamp {
     }
 }
 
-/// Parsing and formatting using a "printf" style of API.
+/// Parsing and formatting using a "printf"-style API.
 impl Timestamp {
     /// Parses a timestamp (expressed as broken down time) in `input` matching
     /// the given `format`.
     ///
-    /// The format string uses a "printf" style of API where conversion
+    /// The format string uses a "printf"-style API where conversion
     /// specifiers can be used as place holders to match components of
     /// a datetime. For details on the specifiers supported, see the
     /// [`fmt::strtime`] module documentation.
@@ -1951,7 +1951,7 @@ impl Timestamp {
 
     /// Formats this timestamp according to the given `format`.
     ///
-    /// The format string uses a "printf" style of API where conversion
+    /// The format string uses a "printf"-style API where conversion
     /// specifiers can be used as place holders to format components of
     /// a datetime. For details on the specifiers supported, see the
     /// [`fmt::strtime`] module documentation.

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -3081,11 +3081,11 @@ impl Zoned {
     }
 }
 
-/// Parsing and formatting using a "printf" style of API.
+/// Parsing and formatting using a "printf"-style API.
 impl Zoned {
     /// Parses a zoned datetime in `input` matching the given `format`.
     ///
-    /// The format string uses a "printf" style of API where conversion
+    /// The format string uses a "printf"-style API where conversion
     /// specifiers can be used as place holders to match components of
     /// a datetime. For details on the specifiers supported, see the
     /// [`fmt::strtime`] module documentation.
@@ -3143,7 +3143,7 @@ impl Zoned {
 
     /// Formats this zoned datetime according to the given `format`.
     ///
-    /// The format string uses a "printf" style of API where conversion
+    /// The format string uses a "printf"-style API where conversion
     /// specifiers can be used as place holders to format components of
     /// a datetime. For details on the specifiers supported, see the
     /// [`fmt::strtime`] module documentation.


### PR DESCRIPTION
I'm not a native speaker, so maybe I'm missing something. But the suggested phrasing would be easier for me to understand. I paused for a second at the "of" in *"The format string uses a "printf" style of API where conversion …"* when I read the docs. I also added a hyphen, but that can also be removed again.