### PR TITLE
fmt: fix precision formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,19 @@
+0.1.5 (TBD)
+==================
+This releases fixes a bug with fixed precision fractional formatting.
+
+Bug fixes:
+
+* [#73](https://github.com/BurntSushi/jiff/issues/73):
+Make it so `%.Nf` only formats to `N` decimal places.
+
+
 0.1.4 (2024-08-01)
 ==================
 This release includes a small improvement for `strptime` that permits
 `%Y%m%d` to parse `20240730` correctly.
+
+Enhancements:
 
 * [#62](https://github.com/BurntSushi/jiff/issues/62):
 Tweak `strptime` so that things like `%Y` aren't unceremoniously greedy.

--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     util::escape,
 };
 
-use self::util::{Decimal, DecimalFormatter};
+use self::util::{Decimal, DecimalFormatter, Fractional, FractionalFormatter};
 
 mod offset;
 pub mod rfc2822;
@@ -229,10 +229,30 @@ trait WriteExt: Write {
         self.write_decimal(&Decimal::new(formatter, n.into()))
     }
 
+    /// Write the given fractional number using ASCII digits to this buffer.
+    /// The given formatter controls how the fractional number is formatted.
+    #[inline]
+    fn write_fraction(
+        &mut self,
+        formatter: &FractionalFormatter,
+        n: impl Into<i64>,
+    ) -> Result<(), Error> {
+        self.write_fractional(&Fractional::new(formatter, n.into()))
+    }
+
     /// Write the given decimal number to this buffer.
     #[inline]
     fn write_decimal(&mut self, decimal: &Decimal) -> Result<(), Error> {
         self.write_str(decimal.as_str())
+    }
+
+    /// Write the given fractional number to this buffer.
+    #[inline]
+    fn write_fractional(
+        &mut self,
+        fractional: &Fractional,
+    ) -> Result<(), Error> {
+        self.write_str(fractional.as_str())
     }
 }
 

--- a/src/fmt/offset.rs
+++ b/src/fmt/offset.rs
@@ -106,7 +106,7 @@ from [Temporal's hybrid grammar].
 use crate::{
     error::{err, Error, ErrorContext},
     fmt::{
-        util::{parse_temporal_fraction, DecimalFormatter},
+        util::{parse_temporal_fraction, FractionalFormatter},
         Parsed,
     },
     tz::Offset,
@@ -242,8 +242,7 @@ impl core::fmt::Display for Numeric {
             write!(f, ":{:02}", seconds)?;
         }
         if let Some(nanos) = self.nanoseconds {
-            static FMT: DecimalFormatter =
-                DecimalFormatter::new().fractional(0, 9);
+            static FMT: FractionalFormatter = FractionalFormatter::new();
             write!(f, ".{}", FMT.format(i64::from(nanos)).as_str())?;
         }
         Ok(())

--- a/src/fmt/strtime/mod.rs
+++ b/src/fmt/strtime/mod.rs
@@ -196,13 +196,15 @@ default, `%d` will only try to consume at most 2 digits.
 
 The `%f` and `%.f` flags also support specifying the precision, up to
 nanoseconds. For example, `%3f` and `%.3f` will both always print a fractional
-second component to at least 3 decimal places. When no precision is specified,
+second component to exactly 3 decimal places. When no precision is specified,
 then `%f` will always emit at least one digit, even if it's zero. But `%.f`
 will emit the empty string when the fractional component is zero. Otherwise, it
 will include the leading `.`. For parsing, `%f` does not include the leading
 dot, but `%.f` does. Note that all of the options above are still parsed for
 `%f` and `%.f`, but they are all no-ops (except for the padding for `%f`, which
-is instead interpreted as a precision setting).
+is instead interpreted as a precision setting). When using a precision setting,
+truncation is used. If you need a different rounding mode, you should use
+higher level APIs like [`Timestamp::round`] or [`Zoned::round`].
 
 # Unsupported
 

--- a/src/fmt/temporal/printer.rs
+++ b/src/fmt/temporal/printer.rs
@@ -1,7 +1,10 @@
 use crate::{
     civil::{Date, DateTime, Time},
     error::Error,
-    fmt::{util::DecimalFormatter, Write, WriteExt},
+    fmt::{
+        util::{DecimalFormatter, FractionalFormatter},
+        Write, WriteExt,
+    },
     span::Span,
     tz::{Offset, TimeZone},
     util::{rangeint::RFrom, t},
@@ -102,8 +105,7 @@ impl DateTimePrinter {
         mut wtr: W,
     ) -> Result<(), Error> {
         static FMT_TWO: DecimalFormatter = DecimalFormatter::new().padding(2);
-        static FMT_FRACTION: DecimalFormatter =
-            DecimalFormatter::new().fractional(0, 9);
+        static FMT_FRACTION: FractionalFormatter = FractionalFormatter::new();
 
         wtr.write_int(&FMT_TWO, time.hour())?;
         wtr.write_str(":")?;
@@ -113,7 +115,7 @@ impl DateTimePrinter {
         let fractional_nanosecond = time.subsec_nanosecond();
         if fractional_nanosecond != 0 {
             wtr.write_str(".")?;
-            wtr.write_int(&FMT_FRACTION, fractional_nanosecond)?;
+            wtr.write_fraction(&FMT_FRACTION, fractional_nanosecond)?;
         }
         Ok(())
     }
@@ -214,8 +216,7 @@ impl SpanPrinter {
         mut wtr: W,
     ) -> Result<(), Error> {
         static FMT_INT: DecimalFormatter = DecimalFormatter::new();
-        static FMT_FRACTION: DecimalFormatter =
-            DecimalFormatter::new().fractional(0, 9);
+        static FMT_FRACTION: FractionalFormatter = FractionalFormatter::new();
 
         if span.is_negative() {
             wtr.write_str("-")?;
@@ -310,7 +311,7 @@ impl SpanPrinter {
             wtr.write_int(&FMT_INT, fraction_second.get())?;
             if fraction_nano != 0 {
                 wtr.write_str(".")?;
-                wtr.write_int(&FMT_FRACTION, fraction_nano.get())?;
+                wtr.write_fraction(&FMT_FRACTION, fraction_nano.get())?;
             }
             wtr.write_str("s")?;
         }


### PR DESCRIPTION
This PR fixes an issue with formatting fractional seconds with
fixed precision settings. For example, previously, when formatting
`1.123456789` with `%.3f`, it would emit `1.123456789`. But this should
be `1.123`.

We do a bit of refactoring to split integer and fractional formatting
apart. Previously, we were using one cursed formatter to handle both
cases. By splitting them apart, we simplify both.

Fixes #73
