### PR TITLE
fmt/strtime: add %V and %:V for formatting and parsing IANA time zone identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 0.1.5 (TBD)
 ==================
-This releases fixes a bug with fixed precision fractional formatting.
+This release includes some improvements and bug fixes for Jiff's `strtime`
+APIs.
+
+Enhancements:
+
+* [#75](https://github.com/BurntSushi/jiff/issues/75):
+Add support for `%V` for formatting _and_ parsing IANA time zone identifiers.
 
 Bug fixes:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -481,17 +481,17 @@ a "odd" custom format into a zoned datetime:
 use jiff::Zoned;
 
 let zdt = Zoned::strptime(
-    "%A, %B %d, %Y at %I:%M%p %z",
-    "Monday, July 15, 2024 at 5:30pm -0400",
+    "%A, %B %d, %Y at %I:%M%p %V",
+    "Monday, July 15, 2024 at 5:30pm US/Eastern",
 )?;
-assert_eq!(zdt.to_string(), "2024-07-15T17:30:00-04:00[-04:00]");
+assert_eq!(zdt.to_string(), "2024-07-15T17:30:00-04:00[US/Eastern]");
 
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
-And this shows how to use [`Zoned::strftime`] to format a zoned datetime. Note
-the use of `%Z` instead of `%z`, which will print a time zone abbreviation
-(when one is available) instead of an offset (`%Z` can't be used for parsing):
+And this shows how to use [`Zoned::strftime`] to format a zoned datetime.
+Note the use of `%Z`, which will print a time zone abbreviation (when one is
+available) instead of an offset (`%Z` can't be used for parsing):
 
 ```
 use jiff::civil::date;
@@ -500,6 +500,22 @@ let zdt = date(2024, 7, 15).at(17, 30, 59, 0).intz("Australia/Tasmania")?;
 // %-I instead of %I means no padding.
 let string = zdt.strftime("%A, %B %d, %Y at %-I:%M%P %Z").to_string();
 assert_eq!(string, "Monday, July 15, 2024 at 5:30pm AEST");
+
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+However, time zone abbreviations aren't parsable because they are ambiguous.
+For example, `CST` can stand for `Central Standard Time`, `Cuba Standard Time`
+or `China Standard Time`. Instead, it is recommended to use `%V` to format an
+IANA time zone identifier (which can be parsed, as shown above):
+
+```
+use jiff::civil::date;
+
+let zdt = date(2024, 7, 15).at(17, 30, 59, 0).intz("Australia/Tasmania")?;
+// %-I instead of %I means no padding.
+let string = zdt.strftime("%A, %B %d, %Y at %-I:%M%P %V").to_string();
+assert_eq!(string, "Monday, July 15, 2024 at 5:30pm Australia/Tasmania");
 
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -3092,17 +3092,16 @@ impl Zoned {
     ///
     /// # Warning
     ///
-    /// The `strtime` module APIs do not support parsing or formatting with
-    /// IANA time zone identifiers. This means that if you format a zoned
+    /// The `strtime` module APIs do not require an IANA time zone identifier
+    /// to parse a `Zoned`. If one is not used, then if you format a zoned
     /// datetime in a time zone like `America/New_York` and then parse it back
     /// again, the zoned datetime you get back will be a "fixed offset" zoned
     /// datetime. This in turn means it will not perform daylight saving time
     /// safe arithmetic.
     ///
-    /// The `strtime` modules APIs are useful for ad hoc formatting and
-    /// parsing, but they shouldn't be used as an interchange format. For
-    /// an interchange format, the default `std::fmt::Display` and
-    /// `std::str::FromStr` trait implementations on `Zoned` are appropriate.
+    /// However, the `%V` directive may be used to both format and parse an
+    /// IANA time zone identifier. It is strongly recommended to use this
+    /// directive whenever one is formatting or parsing `Zoned` values.
     ///
     /// # Errors
     ///
@@ -3120,16 +3119,8 @@ impl Zoned {
     /// ```
     /// use jiff::Zoned;
     ///
-    /// let zdt = Zoned::strptime("%F %H:%M %:z", "2024-07-14 21:14 -04:00")?;
-    /// assert_eq!(zdt.to_string(), "2024-07-14T21:14:00-04:00[-04:00]");
-    ///
-    /// // It might be prudent to convert the zoned datetime you get back
-    /// // into a "real" time zone:
-    /// let zdt = zdt.intz("Australia/Tasmania")?;
-    /// assert_eq!(
-    ///     zdt.to_string(),
-    ///     "2024-07-15T11:14:00+10:00[Australia/Tasmania]",
-    /// );
+    /// let zdt = Zoned::strptime("%F %H:%M %:V", "2024-07-14 21:14 US/Eastern")?;
+    /// assert_eq!(zdt.to_string(), "2024-07-14T21:14:00-04:00[US/Eastern]");
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```


### PR DESCRIPTION
This matches the V specifier used by [Java's formatting/parsing
infrastructure][java format].

The motivation for this is to bring the strtime APIs to parity with
`jiff::fmt::temporal`. Namely, without an IANA time zone identifier, one
cannot correctly roundtrip a `Zoned` value.

Jiff does support `%Z` when formatting for printing time zone
abbreviations like `EDT` or `EST`, but since these are ambiguous, they
aren't supported while parsing. (Perhaps we should support parsing and
validating them though, especially in conjunction with a IANA time zone
identifier.)

When using `%V`, if there is no IANA time zone identifier, then the
offset without colons is used instead. To get an offset with colons, use
`%:V`.

[java format]: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/format/DateTimeFormatter.html#ISO_ZONED_DATE_TIME
