### PR TITLE
fmt/temporal: fix parsing of spans like `PT843517081h`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 0.1.5 (TBD)
 ==================
-This release includes some improvements and bug fixes for Jiff's `strtime`
-APIs.
+This release includes some improvements and bug fixes, particularly for Jiff's
+`strtime` APIs.
 
 Enhancements:
 
@@ -10,6 +10,8 @@ Add support for `%V` for formatting _and_ parsing IANA time zone identifiers.
 
 Bug fixes:
 
+* [#59](https://github.com/BurntSushi/jiff/issues/59):
+Fixes a bug where some `Span`s could not be roundtripped through ISO 8601.
 * [#71](https://github.com/BurntSushi/jiff/issues/71):
 Tweak wording in documentation of "printf"-style API.
 * [#73](https://github.com/BurntSushi/jiff/issues/73):

--- a/src/fmt/temporal/mod.rs
+++ b/src/fmt/temporal/mod.rs
@@ -1207,6 +1207,10 @@ impl SpanPrinter {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::ToString;
+
+    use crate::Unit;
+
     use super::*;
 
     // This test ensures that strings like `2024-07-15+02` fail to parse.
@@ -1236,6 +1240,17 @@ mod tests {
         insta::assert_snapshot!(
             DateTimeParser::new().parse_date("-000000-01-01").unwrap_err(),
             @r###"failed to parse year in date "-000000-01-01": year zero must be written without a sign or a positive sign, but not a negative sign"###,
+        );
+    }
+
+    // Regression test for: https://github.com/BurntSushi/jiff/issues/59
+    #[test]
+    fn fractional_duration_roundtrip() {
+        let span1: Span = "Pt843517081,1H".parse().unwrap();
+        let span2: Span = span1.to_string().parse().unwrap();
+        assert_eq!(
+            span1.total(Unit::Hour).unwrap(),
+            span2.total(Unit::Hour).unwrap()
         );
     }
 }


### PR DESCRIPTION
Because Jiff spans (like Temporal durations) represent each unit
individually, and because ISO 8601 require the use of fractional seconds
to represent sub-second units, there is an inherent loss of fidelity
when spans are serialized to the ISO 8601 duration format.

For example, a Jiff span like `1 second 2000 milliseconds` is distinct from
`3 seconds` even though they represent the same amount of elapsed time.
These types of spans are unbalanced.

When a span like `1 second 2000 milliseconds` is ISO 8601 serialized,
it's turned into `PT3s` because there simply is no way to represent
greater-than-second durations in smaller-than-second units in the ISO
8601 duration format. So when `PT3s` is deserialized, Jiff of course has
no idea that `1 second 2000 milliseconds` was actually intended, and
thus treats it as `3 seconds`.

On top of this, Jiff imposes fairly strict limits on the individual
units of a `Span`. Other than nanoseconds, every individual unit can
express the full range of time supported by Jiff (`-9999-01-01` through
`9999-12-31`) and nothing more. So if one serializes a span to the ISO
8601 format with large millisecond, microsecond or nanosecond
components, those have to be folded into the larger hour, minute or
second units. This in turn can create a ISO 8601 duration whose hour,
minute and second units exceed Jiff's unit limits. So in order to
preserve the ability to at least roundtrip all Jiff spans (even if the
individual unit values are lost), Jiff will automatically rebalance
these "larger" units into smaller units at parse time.

This is a big complicated mess and it turns out I got one part of this
wrong: I was only re-balancing units at parse time when we parsed a
fractional component. But in fact, we should be re-balancing spans even
when there isn't a fractional component. Namely, the milliseconds,
microseconds and nanosecond components can add up to a whole number of
seconds, resulting in a whole number of seconds in the corresponding ISO
8601 duration.

This bug was found by @addisoncrump's fuzzer. Nice work.

Fixes #59
