### PR TITLE
jiff: Days in month rangeint should always have range 28-31

### DIFF
--- a/src/util/common.rs
+++ b/src/util/common.rs
@@ -62,7 +62,7 @@ pub(crate) fn saturate_day_in_month(
 /// February.
 pub(crate) fn days_in_month(year: Year, month: Month) -> Day {
     if month == 2 && is_leap_year(year) {
-        Day::N::<29>()
+        Day::V::<29, 28, 31>()
     } else {
         days_in_month_common_year(month)
     }
@@ -93,19 +93,19 @@ pub(crate) const fn days_in_month_unranged(year: i16, month: i8) -> i8 {
 /// Returns the number of days in the given month for a non-leap year.
 pub(crate) fn days_in_month_common_year(month: Month) -> Day {
     const BY_MONTH: [Day; 13] = [
-        Day::N::<0>(),
-        Day::N::<31>(),
-        Day::N::<28>(),
-        Day::N::<31>(),
-        Day::N::<30>(),
-        Day::N::<31>(),
-        Day::N::<30>(),
-        Day::N::<31>(),
-        Day::N::<31>(),
-        Day::N::<30>(),
-        Day::N::<31>(),
-        Day::N::<30>(),
-        Day::N::<31>(),
+        Day::V::<0, 28, 31>(),
+        Day::V::<31, 28, 31>(),
+        Day::V::<28, 28, 31>(),
+        Day::V::<31, 28, 31>(),
+        Day::V::<30, 28, 31>(),
+        Day::V::<31, 28, 31>(),
+        Day::V::<30, 28, 31>(),
+        Day::V::<31, 28, 31>(),
+        Day::V::<31, 28, 31>(),
+        Day::V::<30, 28, 31>(),
+        Day::V::<31, 28, 31>(),
+        Day::V::<30, 28, 31>(),
+        Day::V::<31, 28, 31>(),
     ];
     BY_MONTH[usize::from(month.get() as u8)]
 }


### PR DESCRIPTION
I noticed that the `days_in_month` function returns constant rangeints where the range of the value is just the exact value, so for example `v: 31, min: 31, max: 31`. If the idea of the tracked min and max values (in debug builds) is to ensure that the code will work with all possible values of the function in question, then this means we don't actually check the computation for all possible responses to `days_in_month`.

By changing the return values to always have a range with min 28 and max 31 we can ensure that all calculations will work with every month and year, instead of the specific one they are tested with.

A sidenote is that if one returns just a common `Day` value from `days_in_month`, which has min of 1 and max of 31, this will end up throwing an error from the `nth_weekday_in_month` tests, as the algorithms there only stay in the correct range if the values returned by `days_in_month` are actually what they are commonly.

Not sure if I've figured out the situation correctly here – so feel free to just close this pull if it's a mistake.

And to be clear to anybody reading this – the changes here only affect debug builds and the internal safety checks in `jiff`. There are no external effects to these changes.