### PR TITLE
api: add new top-level SignedDuration type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,39 @@
+0.1.6 (TBD)
+===========
+This release includes a new top-level type, `SignedDuration`, that provides a
+near exact replica of `std::time::Duration`, but signed. It is meant to provide
+alternative APIs for working with durations at a lower level than what `Span`
+provides, and to facilitate better integration with the standard library.
+
+This marks an initial integration phase with `SignedDuration`. It is planned
+to integrate it more with the datetime types. Currently, there are integrations
+on `Timestamp` and `Span`, but more will be added in the future.
+
+This release also includes a few deprecations.
+
+Deprecations:
+
+* `Timestamp::as_duration`: to be replaced with `SignedDuration` in `jiff 0.2`.
+* `Timestamp::from_duration`: to be replaced with `SignedDuration` in
+`jiff 0.2`.
+* `Timestamp::from_signed_duration`: to be replaced with `SignedDuration` in
+`jiff 0.2`.
+* `Span::to_duration`: to be replaced with `SignedDuration` in `jiff 0.2`.
+
+Basically, all of the above APIs either accept or return a
+`std::time::Duration`. To avoid breaking chnages at this point, new methods
+for `SignedDuration` were added. For example, `Timestamp::as_jiff_duration`.
+In `jiff 0.2`, the above deprecated methods will be removed and replaced with
+equivalent methods that accept or return a `SignedDuration` instead. Callers
+can then convert between a `SignedDuration` and a `std::time::Duration` using
+appropriate `TryFrom` trait implementations.
+
+Enhancements:
+
+* [#XXX](https://github.com/BurntSushi/jiff/issues/XXX):
+Add new top-level `SignedDuration` type.
+
+
 0.1.5 (2024-08-09)
 ==================
 This release includes some improvements and bug fixes, particularly for Jiff's

--- a/src/civil/date.rs
+++ b/src/civil/date.rs
@@ -73,10 +73,10 @@ use crate::{
 /// then `d1 < d2`. For example:
 ///
 /// ```
-/// use jiff::civil::Date;
+/// use jiff::civil::date;
 ///
-/// let d1 = Date::constant(2024, 3, 11);
-/// let d2 = Date::constant(2025, 1, 31);
+/// let d1 = date(2024, 3, 11);
+/// let d2 = date(2025, 1, 31);
 /// assert!(d1 < d2);
 /// ```
 ///
@@ -96,11 +96,11 @@ use crate::{
 /// trait implementations. When the result overflows, a panic occurs.
 ///
 /// ```
-/// use jiff::{civil::Date, ToSpan};
+/// use jiff::{civil::date, ToSpan};
 ///
-/// let start = Date::constant(2024, 2, 25);
+/// let start = date(2024, 2, 25);
 /// let one_week_later = start + 1.weeks();
-/// assert_eq!(one_week_later, Date::constant(2024, 3, 3));
+/// assert_eq!(one_week_later, date(2024, 3, 3));
 /// ```
 ///
 /// One can compute the span of time between two dates using either
@@ -108,10 +108,10 @@ use crate::{
 /// `Date` values directly via a `Sub` trait implementation:
 ///
 /// ```
-/// use jiff::{civil::Date, ToSpan};
+/// use jiff::{civil::date, ToSpan};
 ///
-/// let date1 = Date::constant(2024, 3, 3);
-/// let date2 = Date::constant(2024, 2, 25);
+/// let date1 = date(2024, 3, 3);
+/// let date2 = date(2024, 2, 25);
 /// assert_eq!(date1 - date2, 7.days());
 /// ```
 ///
@@ -120,10 +120,10 @@ use crate::{
 /// (as exemplified above), but we can ask for bigger units:
 ///
 /// ```
-/// use jiff::{civil::Date, ToSpan, Unit};
+/// use jiff::{civil::date, ToSpan, Unit};
 ///
-/// let date1 = Date::constant(2024, 5, 3);
-/// let date2 = Date::constant(2024, 2, 25);
+/// let date1 = date(2024, 5, 3);
+/// let date2 = date(2024, 2, 25);
 /// assert_eq!(
 ///     date1.since((Unit::Year, date2))?,
 ///     2.months().days(7),
@@ -135,10 +135,10 @@ use crate::{
 /// Or even round the span returned:
 ///
 /// ```
-/// use jiff::{civil::{Date, DateDifference}, RoundMode, ToSpan, Unit};
+/// use jiff::{civil::{DateDifference, date}, RoundMode, ToSpan, Unit};
 ///
-/// let date1 = Date::constant(2024, 5, 15);
-/// let date2 = Date::constant(2024, 2, 25);
+/// let date1 = date(2024, 5, 15);
+/// let date2 = date(2024, 2, 25);
 /// assert_eq!(
 ///     date1.since(
 ///         DateDifference::new(date2)
@@ -315,27 +315,27 @@ impl Date {
     /// ISO 8601 week date to a Gregorian date.
     ///
     /// ```
-    /// use jiff::civil::{Date, ISOWeekDate, Weekday};
+    /// use jiff::civil::{Date, ISOWeekDate, Weekday, date};
     ///
     /// let weekdate = ISOWeekDate::new(1994, 52, Weekday::Sunday).unwrap();
-    /// let date = Date::from_iso_week_date(weekdate);
-    /// assert_eq!(date, Date::constant(1995, 1, 1));
+    /// let d = Date::from_iso_week_date(weekdate);
+    /// assert_eq!(d, date(1995, 1, 1));
     ///
     /// let weekdate = ISOWeekDate::new(1997, 1, Weekday::Tuesday).unwrap();
-    /// let date = Date::from_iso_week_date(weekdate);
-    /// assert_eq!(date, Date::constant(1996, 12, 31));
+    /// let d = Date::from_iso_week_date(weekdate);
+    /// assert_eq!(d, date(1996, 12, 31));
     ///
     /// let weekdate = ISOWeekDate::new(2020, 1, Weekday::Monday).unwrap();
-    /// let date = Date::from_iso_week_date(weekdate);
-    /// assert_eq!(date, Date::constant(2019, 12, 30));
+    /// let d = Date::from_iso_week_date(weekdate);
+    /// assert_eq!(d, date(2019, 12, 30));
     ///
     /// let weekdate = ISOWeekDate::new(2024, 10, Weekday::Saturday).unwrap();
-    /// let date = Date::from_iso_week_date(weekdate);
-    /// assert_eq!(date, Date::constant(2024, 3, 9));
+    /// let d = Date::from_iso_week_date(weekdate);
+    /// assert_eq!(d, date(2024, 3, 9));
     ///
     /// let weekdate = ISOWeekDate::new(9999, 52, Weekday::Friday).unwrap();
-    /// let date = Date::from_iso_week_date(weekdate);
-    /// assert_eq!(date, Date::constant(9999, 12, 31));
+    /// let d = Date::from_iso_week_date(weekdate);
+    /// assert_eq!(d, date(9999, 12, 31));
     /// ```
     #[inline]
     pub fn from_iso_week_date(weekdate: ISOWeekDate) -> Date {
@@ -415,15 +415,15 @@ impl Date {
     /// # Example
     ///
     /// ```
-    /// use jiff::civil::Date;
+    /// use jiff::civil::date;
     ///
-    /// let d1 = Date::constant(2024, 3, 9);
+    /// let d1 = date(2024, 3, 9);
     /// assert_eq!(d1.year(), 2024);
     ///
-    /// let d2 = Date::constant(-2024, 3, 9);
+    /// let d2 = date(-2024, 3, 9);
     /// assert_eq!(d2.year(), -2024);
     ///
-    /// let d3 = Date::constant(0, 3, 9);
+    /// let d3 = date(0, 3, 9);
     /// assert_eq!(d3.year(), 0);
     /// ```
     #[inline]
@@ -445,24 +445,24 @@ impl Date {
     /// # Example
     ///
     /// ```
-    /// use jiff::civil::{Date, Era};
+    /// use jiff::civil::{Era, date};
     ///
-    /// let d = Date::constant(2024, 10, 3);
+    /// let d = date(2024, 10, 3);
     /// assert_eq!(d.era_year(), (2024, Era::CE));
     ///
-    /// let d = Date::constant(1, 10, 3);
+    /// let d = date(1, 10, 3);
     /// assert_eq!(d.era_year(), (1, Era::CE));
     ///
-    /// let d = Date::constant(0, 10, 3);
+    /// let d = date(0, 10, 3);
     /// assert_eq!(d.era_year(), (1, Era::BCE));
     ///
-    /// let d = Date::constant(-1, 10, 3);
+    /// let d = date(-1, 10, 3);
     /// assert_eq!(d.era_year(), (2, Era::BCE));
     ///
-    /// let d = Date::constant(-10, 10, 3);
+    /// let d = date(-10, 10, 3);
     /// assert_eq!(d.era_year(), (11, Era::BCE));
     ///
-    /// let d = Date::constant(-9_999, 10, 3);
+    /// let d = date(-9_999, 10, 3);
     /// assert_eq!(d.era_year(), (10_000, Era::BCE));
     /// ```
     #[inline]
@@ -485,9 +485,9 @@ impl Date {
     /// # Example
     ///
     /// ```
-    /// use jiff::civil::Date;
+    /// use jiff::civil::date;
     ///
-    /// let d1 = Date::constant(2024, 3, 9);
+    /// let d1 = date(2024, 3, 9);
     /// assert_eq!(d1.month(), 3);
     /// ```
     #[inline]
@@ -500,9 +500,9 @@ impl Date {
     /// # Example
     ///
     /// ```
-    /// use jiff::civil::Date;
+    /// use jiff::civil::date;
     ///
-    /// let d1 = Date::constant(2024, 2, 29);
+    /// let d1 = date(2024, 2, 29);
     /// assert_eq!(d1.day(), 29);
     /// ```
     #[inline]
@@ -515,10 +515,10 @@ impl Date {
     /// # Example
     ///
     /// ```
-    /// use jiff::civil::{Date, Weekday};
+    /// use jiff::civil::{Weekday, date};
     ///
     /// // The Unix epoch was on a Thursday.
-    /// let d1 = Date::constant(1970, 1, 1);
+    /// let d1 = date(1970, 1, 1);
     /// assert_eq!(d1.weekday(), Weekday::Thursday);
     /// // One can also get the weekday as an offset in a variety of schemes.
     /// assert_eq!(d1.weekday().to_monday_zero_offset(), 3);
@@ -539,15 +539,15 @@ impl Date {
     /// # Example
     ///
     /// ```
-    /// use jiff::civil::Date;
+    /// use jiff::civil::date;
     ///
-    /// let d = Date::constant(2006, 8, 24);
+    /// let d = date(2006, 8, 24);
     /// assert_eq!(d.day_of_year(), 236);
     ///
-    /// let d = Date::constant(2023, 12, 31);
+    /// let d = date(2023, 12, 31);
     /// assert_eq!(d.day_of_year(), 365);
     ///
-    /// let d = Date::constant(2024, 12, 31);
+    /// let d = date(2024, 12, 31);
     /// assert_eq!(d.day_of_year(), 366);
     /// ```
     #[inline]
@@ -571,18 +571,18 @@ impl Date {
     /// # Example
     ///
     /// ```
-    /// use jiff::civil::Date;
+    /// use jiff::civil::date;
     ///
-    /// let d = Date::constant(2006, 8, 24);
+    /// let d = date(2006, 8, 24);
     /// assert_eq!(d.day_of_year_no_leap(), Some(236));
     ///
-    /// let d = Date::constant(2023, 12, 31);
+    /// let d = date(2023, 12, 31);
     /// assert_eq!(d.day_of_year_no_leap(), Some(365));
     ///
-    /// let d = Date::constant(2024, 12, 31);
+    /// let d = date(2024, 12, 31);
     /// assert_eq!(d.day_of_year_no_leap(), Some(365));
     ///
-    /// let d = Date::constant(2024, 2, 29);
+    /// let d = date(2024, 2, 29);
     /// assert_eq!(d.day_of_year_no_leap(), None);
     /// ```
     #[inline]
@@ -604,10 +604,10 @@ impl Date {
     /// # Example
     ///
     /// ```
-    /// use jiff::civil::Date;
+    /// use jiff::civil::date;
     ///
-    /// let d = Date::constant(2024, 2, 29);
-    /// assert_eq!(d.first_of_month(), Date::constant(2024, 2, 1));
+    /// let d = date(2024, 2, 29);
+    /// assert_eq!(d.first_of_month(), date(2024, 2, 1));
     /// ```
     #[inline]
     pub fn first_of_month(self) -> Date {
@@ -620,10 +620,10 @@ impl Date {
     /// # Example
     ///
     /// ```
-    /// use jiff::civil::Date;
+    /// use jiff::civil::date;
     ///
-    /// let d = Date::constant(2024, 2, 5);
-    /// assert_eq!(d.last_of_month(), Date::constant(2024, 2, 29));
+    /// let d = date(2024, 2, 5);
+    /// assert_eq!(d.last_of_month(), date(2024, 2, 29));
     /// ```
     #[inline]
     pub fn last_of_month(self) -> Date {
@@ -641,15 +641,15 @@ impl Date {
     /// # Example
     ///
     /// ```
-    /// use jiff::civil::Date;
+    /// use jiff::civil::date;
     ///
-    /// let d = Date::constant(2024, 2, 10);
+    /// let d = date(2024, 2, 10);
     /// assert_eq!(d.days_in_month(), 29);
     ///
-    /// let d = Date::constant(2023, 2, 10);
+    /// let d = date(2023, 2, 10);
     /// assert_eq!(d.days_in_month(), 28);
     ///
-    /// let d = Date::constant(2024, 8, 15);
+    /// let d = date(2024, 8, 15);
     /// assert_eq!(d.days_in_month(), 31);
     /// ```
     #[inline]
@@ -662,10 +662,10 @@ impl Date {
     /// # Example
     ///
     /// ```
-    /// use jiff::civil::Date;
+    /// use jiff::civil::date;
     ///
-    /// let d = Date::constant(2024, 2, 29);
-    /// assert_eq!(d.first_of_year(), Date::constant(2024, 1, 1));
+    /// let d = date(2024, 2, 29);
+    /// assert_eq!(d.first_of_year(), date(2024, 1, 1));
     /// ```
     #[inline]
     pub fn first_of_year(self) -> Date {
@@ -678,10 +678,10 @@ impl Date {
     /// # Example
     ///
     /// ```
-    /// use jiff::civil::Date;
+    /// use jiff::civil::date;
     ///
-    /// let d = Date::constant(2024, 2, 5);
-    /// assert_eq!(d.last_of_year(), Date::constant(2024, 12, 31));
+    /// let d = date(2024, 2, 5);
+    /// assert_eq!(d.last_of_year(), date(2024, 12, 31));
     /// ```
     #[inline]
     pub fn last_of_year(self) -> Date {
@@ -697,12 +697,12 @@ impl Date {
     /// # Example
     ///
     /// ```
-    /// use jiff::civil::Date;
+    /// use jiff::civil::date;
     ///
-    /// let d = Date::constant(2024, 7, 10);
+    /// let d = date(2024, 7, 10);
     /// assert_eq!(d.days_in_year(), 366);
     ///
-    /// let d = Date::constant(2023, 7, 10);
+    /// let d = date(2023, 7, 10);
     /// assert_eq!(d.days_in_year(), 365);
     /// ```
     #[inline]
@@ -720,10 +720,10 @@ impl Date {
     /// # Example
     ///
     /// ```
-    /// use jiff::civil::Date;
+    /// use jiff::civil::date;
     ///
-    /// assert!(Date::constant(2024, 1, 1).in_leap_year());
-    /// assert!(!Date::constant(2023, 12, 31).in_leap_year());
+    /// assert!(date(2024, 1, 1).in_leap_year());
+    /// assert!(!date(2023, 12, 31).in_leap_year());
     /// ```
     #[inline]
     pub fn in_leap_year(self) -> bool {
@@ -739,10 +739,10 @@ impl Date {
     /// # Example
     ///
     /// ```
-    /// use jiff::civil::Date;
+    /// use jiff::civil::{Date, date};
     ///
-    /// let d = Date::constant(2024, 2, 28);
-    /// assert_eq!(d.tomorrow()?, Date::constant(2024, 2, 29));
+    /// let d = date(2024, 2, 28);
+    /// assert_eq!(d.tomorrow()?, date(2024, 2, 29));
     ///
     /// // The max doesn't have a tomorrow.
     /// assert!(Date::MAX.tomorrow().is_err());
@@ -765,10 +765,10 @@ impl Date {
     /// # Example
     ///
     /// ```
-    /// use jiff::civil::Date;
+    /// use jiff::civil::{Date, date};
     ///
-    /// let d = Date::constant(2024, 3, 1);
-    /// assert_eq!(d.yesterday()?, Date::constant(2024, 2, 29));
+    /// let d = date(2024, 3, 1);
+    /// assert_eq!(d.yesterday()?, date(2024, 2, 29));
     ///
     /// // The min doesn't have a yesterday.
     /// assert!(Date::MIN.yesterday().is_err());
@@ -801,11 +801,11 @@ impl Date {
     /// beginning of the month:
     ///
     /// ```
-    /// use jiff::civil::{Date, Weekday};
+    /// use jiff::civil::{Weekday, date};
     ///
-    /// let month = Date::constant(2017, 3, 1);
+    /// let month = date(2017, 3, 1);
     /// let second_friday = month.nth_weekday_of_month(2, Weekday::Friday)?;
-    /// assert_eq!(second_friday, Date::constant(2017, 3, 10));
+    /// assert_eq!(second_friday, date(2017, 3, 10));
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -814,16 +814,16 @@ impl Date {
     /// weekday in a month:
     ///
     /// ```
-    /// use jiff::civil::{Date, Weekday};
+    /// use jiff::civil::{Weekday, date};
     ///
-    /// let month = Date::constant(2024, 3, 1);
+    /// let month = date(2024, 3, 1);
     /// let last_thursday = month.nth_weekday_of_month(-1, Weekday::Thursday)?;
-    /// assert_eq!(last_thursday, Date::constant(2024, 3, 28));
+    /// assert_eq!(last_thursday, date(2024, 3, 28));
     /// let second_last_thursday = month.nth_weekday_of_month(
     ///     -2,
     ///     Weekday::Thursday,
     /// )?;
-    /// assert_eq!(second_last_thursday, Date::constant(2024, 3, 21));
+    /// assert_eq!(second_last_thursday, date(2024, 3, 21));
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -832,11 +832,11 @@ impl Date {
     /// for this month. For example, March 2024 only has 4 Mondays:
     ///
     /// ```
-    /// use jiff::civil::{Date, Weekday};
+    /// use jiff::civil::{Weekday, date};
     ///
-    /// let month = Date::constant(2024, 3, 25);
+    /// let month = date(2024, 3, 25);
     /// let fourth_monday = month.nth_weekday_of_month(4, Weekday::Monday)?;
-    /// assert_eq!(fourth_monday, Date::constant(2024, 3, 25));
+    /// assert_eq!(fourth_monday, date(2024, 3, 25));
     /// // There is no 5th Monday.
     /// assert!(month.nth_weekday_of_month(5, Weekday::Monday).is_err());
     /// // Same goes for counting backwards.
@@ -906,24 +906,24 @@ impl Date {
     /// time:
     ///
     /// ```
-    /// use jiff::civil::{Date, Weekday};
+    /// use jiff::civil::{Weekday, date};
     ///
     /// // Use a Sunday in March as our start date.
-    /// let d = Date::constant(2024, 3, 10);
+    /// let d = date(2024, 3, 10);
     /// assert_eq!(d.weekday(), Weekday::Sunday);
     ///
     /// // The first next Monday is tomorrow!
     /// let next_monday = d.nth_weekday(1, Weekday::Monday)?;
-    /// assert_eq!(next_monday, Date::constant(2024, 3, 11));
+    /// assert_eq!(next_monday, date(2024, 3, 11));
     ///
     /// // But the next Sunday is a week away, because this doesn't
     /// // include the current weekday.
     /// let next_sunday = d.nth_weekday(1, Weekday::Sunday)?;
-    /// assert_eq!(next_sunday, Date::constant(2024, 3, 17));
+    /// assert_eq!(next_sunday, date(2024, 3, 17));
     ///
     /// // "not this Thursday, but next Thursday"
     /// let next_next_thursday = d.nth_weekday(2, Weekday::Thursday)?;
-    /// assert_eq!(next_next_thursday, Date::constant(2024, 3, 21));
+    /// assert_eq!(next_next_thursday, date(2024, 3, 21));
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -932,23 +932,23 @@ impl Date {
     /// time:
     ///
     /// ```
-    /// use jiff::civil::{Date, Weekday};
+    /// use jiff::civil::{Weekday, date};
     ///
     /// // Use a Sunday in March as our start date.
-    /// let d = Date::constant(2024, 3, 10);
+    /// let d = date(2024, 3, 10);
     /// assert_eq!(d.weekday(), Weekday::Sunday);
     ///
     /// // "last Saturday" was yesterday!
     /// let last_saturday = d.nth_weekday(-1, Weekday::Saturday)?;
-    /// assert_eq!(last_saturday, Date::constant(2024, 3, 9));
+    /// assert_eq!(last_saturday, date(2024, 3, 9));
     ///
     /// // "last Sunday" was a week ago.
     /// let last_sunday = d.nth_weekday(-1, Weekday::Sunday)?;
-    /// assert_eq!(last_sunday, Date::constant(2024, 3, 3));
+    /// assert_eq!(last_sunday, date(2024, 3, 3));
     ///
     /// // "not last Thursday, but the one before"
     /// let prev_prev_thursday = d.nth_weekday(-2, Weekday::Thursday)?;
-    /// assert_eq!(prev_prev_thursday, Date::constant(2024, 2, 29));
+    /// assert_eq!(prev_prev_thursday, date(2024, 2, 29));
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -975,12 +975,12 @@ impl Date {
     /// that date using both `nth_weekday` and [`Date::nth_weekday_of_month`]:
     ///
     /// ```
-    /// use jiff::civil::{Date, Weekday};
+    /// use jiff::civil::{Weekday, date};
     ///
-    /// let march = Date::constant(2024, 3, 1);
+    /// let march = date(2024, 3, 1);
     /// let last_sunday = march.nth_weekday_of_month(-1, Weekday::Sunday)?;
     /// let dst_starts_on = last_sunday.nth_weekday(-1, Weekday::Friday)?;
-    /// assert_eq!(dst_starts_on, Date::constant(2024, 3, 29));
+    /// assert_eq!(dst_starts_on, date(2024, 3, 29));
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -993,15 +993,15 @@ impl Date {
     /// both.
     ///
     /// ```
-    /// use jiff::civil::{Date, Weekday};
+    /// use jiff::civil::{Weekday, date};
     ///
-    /// let d = Date::constant(2024, 3, 15);
+    /// let d = date(2024, 3, 15);
     /// // For weeks starting with Sunday.
     /// let start_of_week = d.tomorrow()?.nth_weekday(-1, Weekday::Sunday)?;
-    /// assert_eq!(start_of_week, Date::constant(2024, 3, 10));
+    /// assert_eq!(start_of_week, date(2024, 3, 10));
     /// // For weeks starting with Monday.
     /// let start_of_week = d.tomorrow()?.nth_weekday(-1, Weekday::Monday)?;
-    /// assert_eq!(start_of_week, Date::constant(2024, 3, 11));
+    /// assert_eq!(start_of_week, date(2024, 3, 11));
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -1011,16 +1011,16 @@ impl Date {
     /// works as expected even at the boundaries of a week:
     ///
     /// ```
-    /// use jiff::civil::{Date, Weekday};
+    /// use jiff::civil::{Weekday, date};
     ///
     /// // The start of the week.
-    /// let d = Date::constant(2024, 3, 10);
+    /// let d = date(2024, 3, 10);
     /// let start_of_week = d.tomorrow()?.nth_weekday(-1, Weekday::Sunday)?;
-    /// assert_eq!(start_of_week, Date::constant(2024, 3, 10));
+    /// assert_eq!(start_of_week, date(2024, 3, 10));
     /// // The end of the week.
-    /// let d = Date::constant(2024, 3, 16);
+    /// let d = date(2024, 3, 16);
     /// let start_of_week = d.tomorrow()?.nth_weekday(-1, Weekday::Sunday)?;
-    /// assert_eq!(start_of_week, Date::constant(2024, 3, 10));
+    /// assert_eq!(start_of_week, date(2024, 3, 10));
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -1072,24 +1072,24 @@ impl Date {
     /// ISO 8601 week date to a Gregorian date.
     ///
     /// ```
-    /// use jiff::civil::{Date, Weekday};
+    /// use jiff::civil::{Date, Weekday, date};
     ///
-    /// let weekdate = Date::constant(1995, 1, 1).to_iso_week_date();
+    /// let weekdate = date(1995, 1, 1).to_iso_week_date();
     /// assert_eq!(weekdate.year(), 1994);
     /// assert_eq!(weekdate.week(), 52);
     /// assert_eq!(weekdate.weekday(), Weekday::Sunday);
     ///
-    /// let weekdate = Date::constant(1996, 12, 31).to_iso_week_date();
+    /// let weekdate = date(1996, 12, 31).to_iso_week_date();
     /// assert_eq!(weekdate.year(), 1997);
     /// assert_eq!(weekdate.week(), 1);
     /// assert_eq!(weekdate.weekday(), Weekday::Tuesday);
     ///
-    /// let weekdate = Date::constant(2019, 12, 30).to_iso_week_date();
+    /// let weekdate = date(2019, 12, 30).to_iso_week_date();
     /// assert_eq!(weekdate.year(), 2020);
     /// assert_eq!(weekdate.week(), 1);
     /// assert_eq!(weekdate.weekday(), Weekday::Monday);
     ///
-    /// let weekdate = Date::constant(2024, 3, 9).to_iso_week_date();
+    /// let weekdate = date(2024, 3, 9).to_iso_week_date();
     /// assert_eq!(weekdate.year(), 2024);
     /// assert_eq!(weekdate.week(), 10);
     /// assert_eq!(weekdate.weekday(), Weekday::Saturday);
@@ -1260,10 +1260,10 @@ impl Date {
     /// # Example
     ///
     /// ```
-    /// use jiff::civil::{Date, DateTime, Time};
+    /// use jiff::civil::{DateTime, date, time};
     ///
-    /// let date = Date::constant(2010, 3, 14);
-    /// let time = Time::constant(2, 30, 0, 0);
+    /// let date = date(2010, 3, 14);
+    /// let time = time(2, 30, 0, 0);
     /// assert_eq!(DateTime::from_parts(date, time), date.to_datetime(time));
     /// ```
     #[inline]
@@ -1335,19 +1335,19 @@ impl Date {
     /// creation of spans.
     ///
     /// ```
-    /// use jiff::{civil::Date, ToSpan};
+    /// use jiff::{civil::date, ToSpan};
     ///
-    /// let d = Date::constant(2024, 3, 31);
-    /// assert_eq!(d.checked_add(1.months())?, Date::constant(2024, 4, 30));
+    /// let d = date(2024, 3, 31);
+    /// assert_eq!(d.checked_add(1.months())?, date(2024, 4, 30));
     /// // Adding two months gives us May 31, not May 30.
-    /// let d = Date::constant(2024, 3, 31);
-    /// assert_eq!(d.checked_add(2.months())?, Date::constant(2024, 5, 31));
+    /// let d = date(2024, 3, 31);
+    /// assert_eq!(d.checked_add(2.months())?, date(2024, 5, 31));
     /// // Any time in the span that does not exceed a day is ignored.
-    /// let d = Date::constant(2024, 3, 31);
-    /// assert_eq!(d.checked_add(23.hours())?, Date::constant(2024, 3, 31));
+    /// let d = date(2024, 3, 31);
+    /// assert_eq!(d.checked_add(23.hours())?, date(2024, 3, 31));
     /// // But if the time exceeds a day, that is accounted for!
-    /// let d = Date::constant(2024, 3, 31);
-    /// assert_eq!(d.checked_add(28.hours())?, Date::constant(2024, 4, 1));
+    /// let d = date(2024, 3, 31);
+    /// assert_eq!(d.checked_add(28.hours())?, date(2024, 4, 1));
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -1358,21 +1358,21 @@ impl Date {
     /// fails, it will result in a panic.
     ///
     /// ```
-    /// use jiff::{civil::Date, ToSpan};
+    /// use jiff::{civil::date, ToSpan};
     ///
-    /// let d = Date::constant(2024, 3, 31);
-    /// assert_eq!(d + 1.months(), Date::constant(2024, 4, 30));
+    /// let d = date(2024, 3, 31);
+    /// assert_eq!(d + 1.months(), date(2024, 4, 30));
     /// ```
     ///
     /// # Example: negative spans are supported
     ///
     /// ```
-    /// use jiff::{civil::Date, ToSpan};
+    /// use jiff::{civil::date, ToSpan};
     ///
-    /// let d = Date::constant(2024, 3, 31);
+    /// let d = date(2024, 3, 31);
     /// assert_eq!(
     ///     d.checked_add(-1.months())?,
-    ///     Date::constant(2024, 2, 29),
+    ///     date(2024, 2, 29),
     /// );
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -1380,9 +1380,9 @@ impl Date {
     /// # Example: error on overflow
     ///
     /// ```
-    /// use jiff::{civil::Date, ToSpan};
+    /// use jiff::{civil::date, ToSpan};
     ///
-    /// let d = Date::constant(2024, 3, 31);
+    /// let d = date(2024, 3, 31);
     /// assert!(d.checked_add(9000.years()).is_err());
     /// assert!(d.checked_add(-19000.years()).is_err());
     /// ```
@@ -1413,143 +1413,47 @@ impl Date {
         Ok(Date::from_unix_epoch_days(days))
     }
 
-    /// Subtract the given span of time from this date. If the difference would
-    /// overflow the minimum or maximum date values, then an error is returned.
-    ///
-    /// # Properties
-    ///
-    /// This routine is _not_ commutative because some additions may be
-    /// ambiguous. For example, adding `1 month` to the date `2024-03-31` will
-    /// produce `2024-04-30` since April has only 30 days in a month. Moreover,
-    /// subtracting `1 month` from `2024-04-30` will produce `2024-03-30`,
-    /// which is not the date we started with.
-    ///
-    /// If spans of time are limited to units of days (or less), then this
-    /// routine _is_ commutative.
+    /// This routine is identical to [`Date::checked_add`] with the duration
+    /// negated.
     ///
     /// # Errors
     ///
-    /// If the span subtracted from this date would result in a date that
-    /// exceeds the range of a `Date`, then this will return an error.
+    /// This has the same error conditions as [`Date::checked_add`].
     ///
-    /// # Examples
-    ///
-    /// This shows a few examples of subtracting spans of time to various
-    /// dates. We make use of the [`ToSpan`](crate::ToSpan) trait for
-    /// convenient creation of spans.
+    /// # Example
     ///
     /// ```
-    /// use jiff::{civil::Date, ToSpan};
+    /// use jiff::{civil::date, ToSpan};
     ///
-    /// let d = Date::constant(2024, 3, 31);
-    /// assert_eq!(d.checked_sub(1.months())?, Date::constant(2024, 2, 29));
+    /// let d = date(2024, 3, 31);
+    /// assert_eq!(d.checked_sub(1.months())?, date(2024, 2, 29));
     /// // Adding subtracting two months gives us Jan 31, not Jan 30.
-    /// let d = Date::constant(2024, 3, 31);
-    /// assert_eq!(d.checked_sub(2.months())?, Date::constant(2024, 1, 31));
+    /// let d = date(2024, 3, 31);
+    /// assert_eq!(d.checked_sub(2.months())?, date(2024, 1, 31));
     /// // Any time in the span that does not exceed a day is ignored.
-    /// let d = Date::constant(2024, 3, 31);
-    /// assert_eq!(d.checked_sub(23.hours())?, Date::constant(2024, 3, 31));
+    /// let d = date(2024, 3, 31);
+    /// assert_eq!(d.checked_sub(23.hours())?, date(2024, 3, 31));
     /// // But if the time exceeds a day, that is accounted for!
-    /// let d = Date::constant(2024, 3, 31);
-    /// assert_eq!(d.checked_sub(28.hours())?, Date::constant(2024, 3, 30));
+    /// let d = date(2024, 3, 31);
+    /// assert_eq!(d.checked_sub(28.hours())?, date(2024, 3, 30));
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
-    ///
-    /// # Example: available via subtraction operator
-    ///
-    /// This routine can be used via the `-` operator. Note though that if it
-    /// fails, it will result in a panic.
-    ///
-    /// ```
-    /// use jiff::{civil::Date, ToSpan};
-    ///
-    /// let d = Date::constant(2024, 3, 31);
-    /// assert_eq!(d - 1.months(), Date::constant(2024, 2, 29));
-    /// ```
-    ///
-    /// # Example: negative spans are supported
-    ///
-    /// ```
-    /// use jiff::{civil::Date, ToSpan};
-    ///
-    /// let d = Date::constant(2024, 3, 31);
-    /// assert_eq!(
-    ///     d.checked_sub(-1.months())?,
-    ///     Date::constant(2024, 4, 30),
-    /// );
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
-    ///
-    /// # Example: error on overflow
-    ///
-    /// ```
-    /// use jiff::{civil::Date, ToSpan};
-    ///
-    /// let d = Date::constant(2024, 3, 31);
-    /// assert!(d.checked_sub(19000.years()).is_err());
-    /// assert!(d.checked_sub(-9000.years()).is_err());
     /// ```
     #[inline]
     pub fn checked_sub(self, span: Span) -> Result<Date, Error> {
         self.checked_add(span.negate())
     }
 
-    /// Add the given span of time to this date. If the sum would overflow the
-    /// minimum or maximum date values, then the result saturates.
+    /// This routine is identical to [`Date::checked_add`], except the
+    /// result saturates on overflow. That is, instead of overflow, either
+    /// [`Date::MIN`] or [`Date::MAX`] is returned.
     ///
-    /// # Properties
-    ///
-    /// This routine is _not_ commutative (even putting aside cases where
-    /// saturation occurs) because some additions may be ambiguous. For
-    /// example, adding `1 month` to the date `2024-03-31` will produce
-    /// `2024-04-30` since April has only 30 days in a month. Moreover,
-    /// subtracting `1 month` from `2024-04-30` will produce `2024-03-30`,
-    /// which is not the date we started with.
-    ///
-    /// If spans of time are limited to units of days (or less), then this
-    /// routine _is_ commutative.
-    ///
-    /// # Examples
-    ///
-    /// This shows a few examples of adding spans of time to various dates.
-    /// We make use of the [`ToSpan`](crate::ToSpan) trait for convenient
-    /// creation of spans.
+    /// # Example
     ///
     /// ```
-    /// use jiff::{civil::Date, ToSpan};
+    /// use jiff::{civil::{Date, date}, ToSpan};
     ///
-    /// let d = Date::constant(2024, 3, 31);
-    /// assert_eq!(d.saturating_add(1.months()), Date::constant(2024, 4, 30));
-    /// // Adding two months gives us May 31, not May 30.
-    /// let d = Date::constant(2024, 3, 31);
-    /// assert_eq!(d.saturating_add(2.months()), Date::constant(2024, 5, 31));
-    /// // Any time in the span that does not exceed a day is ignored.
-    /// let d = Date::constant(2024, 3, 31);
-    /// assert_eq!(d.saturating_add(23.hours()), Date::constant(2024, 3, 31));
-    /// // But if the time exceeds a day, that is accounted for!
-    /// let d = Date::constant(2024, 3, 31);
-    /// assert_eq!(d.saturating_add(28.hours()), Date::constant(2024, 4, 1));
-    /// ```
-    ///
-    /// # Example: negative spans are supported
-    ///
-    /// ```
-    /// use jiff::{civil::Date, ToSpan};
-    ///
-    /// let d = Date::constant(2024, 3, 31);
-    /// assert_eq!(
-    ///     d.saturating_add(-1.months()),
-    ///     Date::constant(2024, 2, 29),
-    /// );
-    /// ```
-    ///
-    /// # Example: saturation on overflow
-    ///
-    /// ```
-    /// use jiff::{civil::Date, ToSpan};
-    ///
-    /// let d = Date::constant(2024, 3, 31);
+    /// let d = date(2024, 3, 31);
     /// assert_eq!(Date::MAX, d.saturating_add(9000.years()));
     /// assert_eq!(Date::MIN, d.saturating_add(-19000.years()));
     /// ```
@@ -1564,61 +1468,15 @@ impl Date {
         })
     }
 
-    /// Subtract the given span of time from this date. If the difference would
-    /// overflow the minimum or maximum date values, then the result saturates.
+    /// This routine is identical to [`Date::saturating_add`] with the span
+    /// parameter negated.
     ///
-    /// # Properties
-    ///
-    /// This routine is _not_ commutative (even putting aside cases where
-    /// saturation occurs) because some additions may be ambiguous. For
-    /// example, adding `1 month` to the date `2024-03-31` will produce
-    /// `2024-04-30` since April has only 30 days in a month. Moreover,
-    /// subtracting `1 month` from `2024-04-30` will produce `2024-03-30`,
-    /// which is not the date we started with.
-    ///
-    /// If spans of time are limited to units of days (or less), then this
-    /// routine _is_ commutative.
-    ///
-    /// # Examples
-    ///
-    /// This shows a few examples of subtracting spans of time to various
-    /// dates. We make use of the [`ToSpan`](crate::ToSpan) trait for
-    /// convenient creation of spans.
+    /// # Example
     ///
     /// ```
-    /// use jiff::{civil::Date, ToSpan};
+    /// use jiff::{civil::{Date, date}, ToSpan};
     ///
-    /// let d = Date::constant(2024, 3, 31);
-    /// assert_eq!(d.saturating_sub(1.months()), Date::constant(2024, 2, 29));
-    /// // Adding subtracting two months gives us Jan 31, not Jan 30.
-    /// let d = Date::constant(2024, 3, 31);
-    /// assert_eq!(d.saturating_sub(2.months()), Date::constant(2024, 1, 31));
-    /// // Any time in the span that does not exceed a day is ignored.
-    /// let d = Date::constant(2024, 3, 31);
-    /// assert_eq!(d.saturating_sub(23.hours()), Date::constant(2024, 3, 31));
-    /// // But if the time exceeds a day, that is accounted for!
-    /// let d = Date::constant(2024, 3, 31);
-    /// assert_eq!(d.saturating_sub(28.hours()), Date::constant(2024, 3, 30));
-    /// ```
-    ///
-    /// # Example: negative spans are supported
-    ///
-    /// ```
-    /// use jiff::{civil::Date, ToSpan};
-    ///
-    /// let d = Date::constant(2024, 3, 31);
-    /// assert_eq!(
-    ///     d.saturating_sub(-1.months()),
-    ///     Date::constant(2024, 4, 30),
-    /// );
-    /// ```
-    ///
-    /// # Example: saturation on overflow
-    ///
-    /// ```
-    /// use jiff::{civil::Date, ToSpan};
-    ///
-    /// let d = Date::constant(2024, 3, 31);
+    /// let d = date(2024, 3, 31);
     /// assert_eq!(Date::MIN, d.saturating_sub(19000.years()));
     /// assert_eq!(Date::MAX, d.saturating_sub(-9000.years()));
     /// ```
@@ -1669,15 +1527,15 @@ impl Date {
     /// # Examples
     ///
     /// ```
-    /// use jiff::{civil::Date, ToSpan};
+    /// use jiff::{civil::date, ToSpan};
     ///
-    /// let earlier = Date::constant(2006, 8, 24);
-    /// let later = Date::constant(2019, 1, 31);
+    /// let earlier = date(2006, 8, 24);
+    /// let later = date(2019, 1, 31);
     /// assert_eq!(earlier.until(later)?, 4543.days());
     ///
     /// // Flipping the dates is fine, but you'll get a negative span.
-    /// let earlier = Date::constant(2006, 8, 24);
-    /// let later = Date::constant(2019, 1, 31);
+    /// let earlier = date(2006, 8, 24);
+    /// let later = date(2019, 1, 31);
     /// assert_eq!(later.until(earlier)?, -4543.days());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1690,10 +1548,10 @@ impl Date {
     /// implementation.
     ///
     /// ```
-    /// use jiff::{civil::Date, Unit, ToSpan};
+    /// use jiff::{civil::date, Unit, ToSpan};
     ///
-    /// let d1 = Date::constant(1995, 12, 07);
-    /// let d2 = Date::constant(2019, 01, 31);
+    /// let d1 = date(1995, 12, 07);
+    /// let d2 = date(2019, 01, 31);
     ///
     /// // The default limits durations to using "days" as the biggest unit.
     /// let span = d1.until(d2)?;
@@ -1715,10 +1573,10 @@ impl Date {
     /// in order to gain full configurability.
     ///
     /// ```
-    /// use jiff::{civil::{Date, DateDifference}, Unit, ToSpan};
+    /// use jiff::{civil::{date, DateDifference}, Unit, ToSpan};
     ///
-    /// let d1 = Date::constant(1995, 12, 07);
-    /// let d2 = Date::constant(2019, 02, 06);
+    /// let d1 = date(1995, 12, 07);
+    /// let d2 = date(2019, 02, 06);
     ///
     /// let span = d1.until(DateDifference::from(d2).smallest(Unit::Month))?;
     /// assert_eq!(span, 277.months());
@@ -1743,16 +1601,16 @@ impl Date {
     /// original date. For example:
     ///
     /// ```
-    /// use jiff::{civil::Date, Unit, ToSpan};
+    /// use jiff::{civil::date, Unit, ToSpan};
     ///
-    /// let d1 = Date::constant(2024, 3, 2);
-    /// let d2 = Date::constant(2024, 5, 1);
+    /// let d1 = date(2024, 3, 2);
+    /// let d2 = date(2024, 5, 1);
     ///
     /// let span = d1.until((Unit::Month, d2))?;
     /// assert_eq!(span, 1.month().days(29));
     /// let maybe_original = d2.checked_sub(span)?;
     /// // Not the same as the original datetime!
-    /// assert_eq!(maybe_original, Date::constant(2024, 3, 3));
+    /// assert_eq!(maybe_original, date(2024, 3, 3));
     ///
     /// // But in the default configuration, days are always the biggest unit
     /// // and reversibility is guaranteed.
@@ -1783,162 +1641,28 @@ impl Date {
         }
     }
 
-    /// Returns a span representing the elapsed time from this date since
-    /// the given `other` date.
-    ///
-    /// When `other` occurs after this date, then the span returned will be
-    /// negative.
-    ///
-    /// Depending on the input provided, the span returned is rounded. It may
-    /// also be balanced up to bigger units than the default. By default, the
-    /// span returned is balanced such that the biggest and smallest possible
-    /// unit is days.
-    ///
-    /// This operation is configured by providing a [`DateDifference`]
-    /// value. Since this routine accepts anything that implements
-    /// `Into<DateDifference>`, once can pass a `Date` directly. One
-    /// can also pass a `(Unit, Date)`, where `Unit` is treated as
-    /// [`DateDifference::largest`].
-    ///
-    /// # Properties
-    ///
-    /// It is guaranteed that if the returned span is added to `other`, and if
-    /// no rounding is requested, and if the largest unit requested is at most
-    /// `Unit::Day`, then the original date will be returned.
-    ///
-    /// This routine is equivalent to `self.until(other).map(|span| -span)`
-    /// if no rounding options are set. If rounding options are set, then
-    /// it's equivalent to
-    /// `self.until(other_without_rounding_options).map(|span| -span)`,
-    /// followed by a call to [`Span::round`] with the appropriate rounding
-    /// options set. This is because the negation of a span can result in
-    /// different rounding results depending on the rounding mode.
+    /// This routine is identical to [`Date::until`], but the order of the
+    /// parameters is flipped.
     ///
     /// # Errors
     ///
-    /// An error can occur if `DateDifference` is misconfigured. For example,
-    /// if the smallest unit provided is bigger than the largest unit.
+    /// This has the same error conditions as [`Date::until`].
     ///
-    /// It is guaranteed that if one provides a date with the default
-    /// [`DateDifference`] configuration, then this routine will never fail.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use jiff::{civil::Date, ToSpan};
-    ///
-    /// let earlier = Date::constant(2006, 8, 24);
-    /// let later = Date::constant(2019, 1, 31);
-    /// assert_eq!(later.since(earlier)?, 4543.days());
-    ///
-    /// // Flipping the dates is fine, but you'll get a negative span.
-    /// let earlier = Date::constant(2006, 8, 24);
-    /// let later = Date::constant(2019, 1, 31);
-    /// assert_eq!(earlier.since(later)?, -4543.days());
-    ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
-    ///
-    /// # Example: available via subtraction operator
+    /// # Example
     ///
     /// This routine can be used via the `-` operator. Since the default
     /// configuration is used and because a `Span` can represent the difference
     /// between any two possible dates, it will never panic.
     ///
     /// ```
-    /// use jiff::{civil::Date, ToSpan};
+    /// use jiff::{civil::date, ToSpan};
     ///
-    /// let earlier = Date::constant(2006, 8, 24);
-    /// let later = Date::constant(2019, 1, 31);
+    /// let earlier = date(2006, 8, 24);
+    /// let later = date(2019, 1, 31);
     /// assert_eq!(later - earlier, 4543.days());
+    /// // Equivalent to:
+    /// assert_eq!(later.since(earlier).unwrap(), 4543.days());
     /// ```
-    ///
-    /// # Example: using bigger units
-    ///
-    /// This example shows how to expand the span returned to bigger units.
-    /// This makes use of a `From<(Unit, Date)> for DateDifference` trait
-    /// implementation.
-    ///
-    /// ```
-    /// use jiff::{civil::Date, Unit, ToSpan};
-    ///
-    /// let d1 = Date::constant(1995, 12, 07);
-    /// let d2 = Date::constant(2019, 01, 31);
-    ///
-    /// // The default limits durations to using "days" as the biggest unit.
-    /// let span = d2.since(d1)?;
-    /// assert_eq!(span.to_string(), "P8456d");
-    ///
-    /// // But we can ask for units all the way up to years.
-    /// let span = d2.since((Unit::Year, d1))?;
-    /// assert_eq!(span.to_string(), "P23y1m24d");
-    ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
-    ///
-    /// # Example: rounding the result
-    ///
-    /// This shows how one might find the difference between two dates and
-    /// have the result rounded to the nearest month.
-    ///
-    /// In this case, we need to hand-construct a [`DateDifference`]
-    /// in order to gain full configurability.
-    ///
-    /// ```
-    /// use jiff::{civil::{Date, DateDifference}, Unit, ToSpan};
-    ///
-    /// let d1 = Date::constant(1995, 12, 07);
-    /// let d2 = Date::constant(2019, 02, 06);
-    ///
-    /// let span = d2.since(DateDifference::from(d1).smallest(Unit::Month))?;
-    /// assert_eq!(span, 277.months());
-    ///
-    /// // Or even include years to make the span a bit more comprehensible.
-    /// let span = d2.since(
-    ///     DateDifference::from(d1)
-    ///         .smallest(Unit::Month)
-    ///         .largest(Unit::Year),
-    /// )?;
-    /// // Notice that we are one day shy of 23y2m. Rounding spans computed
-    /// // between dates uses truncation by default.
-    /// assert_eq!(span, 23.years().months(1));
-    ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
-    ///
-    /// # Example: units biggers than days inhibit reversibility
-    ///
-    /// If you ask for units bigger than days, then adding the span
-    /// returned to the `other` date is not guaranteed to result in the
-    /// original date. For example:
-    ///
-    /// ```
-    /// use jiff::{civil::Date, Unit, ToSpan};
-    ///
-    /// let d1 = Date::constant(2024, 3, 2);
-    /// let d2 = Date::constant(2024, 5, 1);
-    ///
-    /// let span = d2.since((Unit::Month, d1))?;
-    /// assert_eq!(span, 1.month().days(30));
-    /// let maybe_original = d1.checked_add(span)?;
-    /// // Not the same as the original datetime!
-    /// assert_eq!(maybe_original, Date::constant(2024, 5, 2));
-    ///
-    /// // But in the default configuration, days are always the biggest unit
-    /// // and reversibility is guaranteed.
-    /// let span = d2.since(d1)?;
-    /// assert_eq!(span, 60.days());
-    /// let is_original = d1.checked_add(span)?;
-    /// assert_eq!(is_original, d2);
-    ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
-    ///
-    /// This occurs because spans are added as if by adding the biggest units
-    /// first, and then the smaller units. Because months vary in length,
-    /// their meaning can change depending on how the span is added. In this
-    /// case, adding one month to `2024-03-02` corresponds to 31 days, but
-    /// subtracting one month from `2024-05-01` corresponds to 30 days.
     #[inline]
     pub fn since<A: Into<DateDifference>>(
         self,
@@ -1967,9 +1691,9 @@ impl Date {
     /// 2020s.
     ///
     /// ```
-    /// use jiff::{civil::{Date, Weekday}, ToSpan};
+    /// use jiff::{civil::{Weekday, date}, ToSpan};
     ///
-    /// let start = Date::constant(2020, 10, 31);
+    /// let start = date(2020, 10, 31);
     /// let mut halloween_days_of_week = vec![];
     /// for halloween in start.series(1.years()).take(10) {
     ///     halloween_days_of_week.push(
@@ -1997,10 +1721,10 @@ impl Date {
     /// 2024?
     ///
     /// ```
-    /// use jiff::{civil::Date, ToSpan};
+    /// use jiff::{ToSpan, civil::date};
     ///
-    /// let start = Date::constant(2024, 5, 1);
-    /// let end = Date::constant(2024, 10, 31);
+    /// let start = date(2024, 5, 1);
+    /// let end = date(2024, 10, 31);
     /// let mows = start
     ///     .series(1.weeks().days(3).hours(12))
     ///     .take_while(|&d| d <= end)
@@ -2014,19 +1738,19 @@ impl Date {
     /// granularity of a day, some dates may be repeated.
     ///
     /// ```
-    /// use jiff::{civil::Date, ToSpan};
+    /// use jiff::{civil::{Date, date}, ToSpan};
     ///
-    /// let start = Date::constant(2024, 3, 11);
+    /// let start = date(2024, 3, 11);
     /// let every_five_hours: Vec<Date> =
     ///     start.series(15.hours()).take(7).collect();
     /// assert_eq!(every_five_hours, vec![
-    ///     Date::constant(2024, 3, 11),
-    ///     Date::constant(2024, 3, 11),
-    ///     Date::constant(2024, 3, 12),
-    ///     Date::constant(2024, 3, 12),
-    ///     Date::constant(2024, 3, 13),
-    ///     Date::constant(2024, 3, 14),
-    ///     Date::constant(2024, 3, 14),
+    ///     date(2024, 3, 11),
+    ///     date(2024, 3, 11),
+    ///     date(2024, 3, 12),
+    ///     date(2024, 3, 12),
+    ///     date(2024, 3, 13),
+    ///     date(2024, 3, 14),
+    ///     date(2024, 3, 14),
     /// ]);
     /// ```
     ///
@@ -2035,9 +1759,9 @@ impl Date {
     /// When did the most recent Friday the 13th occur?
     ///
     /// ```
-    /// use jiff::{civil::{Date, Weekday}, ToSpan};
+    /// use jiff::{civil::{Weekday, date}, ToSpan};
     ///
-    /// let start = Date::constant(2024, 3, 13);
+    /// let start = date(2024, 3, 13);
     /// let mut found = None;
     /// for date in start.series(-1.months()) {
     ///     if date.weekday() == Weekday::Friday {
@@ -2045,7 +1769,7 @@ impl Date {
     ///         break;
     ///     }
     /// }
-    /// assert_eq!(found, Some(Date::constant(2023, 10, 13)));
+    /// assert_eq!(found, Some(date(2023, 10, 13)));
     /// ```
     #[inline]
     pub fn series(self, period: Span) -> DateSeries {
@@ -3551,29 +3275,29 @@ mod tests {
         }
 
         assert_eq!(
-            Date::constant(1970, 1, 1),
+            date(1970, 1, 1),
             date_from_timestamp(Timestamp::new(0, 0).unwrap()),
         );
         assert_eq!(
-            Date::constant(1969, 12, 31),
+            date(1969, 12, 31),
             date_from_timestamp(Timestamp::new(-1, 0).unwrap()),
         );
         assert_eq!(
-            Date::constant(1969, 12, 31),
+            date(1969, 12, 31),
             date_from_timestamp(Timestamp::new(-86_400, 0).unwrap()),
         );
         assert_eq!(
-            Date::constant(1969, 12, 30),
+            date(1969, 12, 30),
             date_from_timestamp(Timestamp::new(-86_401, 0).unwrap()),
         );
         assert_eq!(
-            Date::constant(-9999, 1, 2),
+            date(-9999, 1, 2),
             date_from_timestamp(
                 Timestamp::new(t::UnixSeconds::MIN_REPR, 0).unwrap()
             ),
         );
         assert_eq!(
-            Date::constant(9999, 12, 30),
+            date(9999, 12, 30),
             date_from_timestamp(
                 Timestamp::new(t::UnixSeconds::MAX_REPR, 0).unwrap()
             ),
@@ -3600,7 +3324,7 @@ mod tests {
             for month in Month::MIN_REPR..=Month::MAX_REPR {
                 let month = Month::new(month).unwrap();
                 for day in 1..=days_in_month(year, month).get() {
-                    let date = Date::constant(year.get(), month.get(), day);
+                    let date = date(year.get(), month.get(), day);
                     let rd = date.to_unix_epoch_days();
                     let got = Date::from_unix_epoch_days(rd);
                     assert_eq!(date, got, "for date {date:?}");
@@ -3619,7 +3343,7 @@ mod tests {
             for month in [1, 2, 4] {
                 let month = Month::new(month).unwrap();
                 for day in 20..=days_in_month(year, month).get() {
-                    let date = Date::constant(year.get(), month.get(), day);
+                    let date = date(year.get(), month.get(), day);
                     let wd = date.to_iso_week_date();
                     let got = wd.to_date();
                     assert_eq!(
@@ -3635,29 +3359,29 @@ mod tests {
     fn add_constrained() {
         use crate::ToSpan;
 
-        let d1 = Date::constant(2023, 3, 31);
+        let d1 = date(2023, 3, 31);
         let d2 = d1.checked_add(1.months().days(1)).unwrap();
-        assert_eq!(d2, Date::constant(2023, 5, 1));
+        assert_eq!(d2, date(2023, 5, 1));
     }
 
     #[test]
     fn since_years() {
-        let d1 = Date::constant(2023, 4, 15);
-        let d2 = Date::constant(2019, 2, 22);
+        let d1 = date(2023, 4, 15);
+        let d2 = date(2019, 2, 22);
         let span = d1.since((Unit::Year, d2)).unwrap();
         assert_eq!(span, 4.years().months(1).days(21));
         let span = d2.since((Unit::Year, d1)).unwrap();
         assert_eq!(span, -4.years().months(1).days(24));
 
-        let d1 = Date::constant(2023, 2, 22);
-        let d2 = Date::constant(2019, 4, 15);
+        let d1 = date(2023, 2, 22);
+        let d2 = date(2019, 4, 15);
         let span = d1.since((Unit::Year, d2)).unwrap();
         assert_eq!(span, 3.years().months(10).days(7));
         let span = d2.since((Unit::Year, d1)).unwrap();
         assert_eq!(span, -3.years().months(10).days(7));
 
-        let d1 = Date::constant(9999, 12, 31);
-        let d2 = Date::constant(-9999, 1, 1);
+        let d1 = date(9999, 12, 31);
+        let d2 = date(-9999, 1, 1);
         let span = d1.since((Unit::Year, d2)).unwrap();
         assert_eq!(span, 19998.years().months(11).days(30));
         let span = d2.since((Unit::Year, d1)).unwrap();
@@ -3666,8 +3390,8 @@ mod tests {
 
     #[test]
     fn since_months() {
-        let d1 = Date::constant(2024, 7, 24);
-        let d2 = Date::constant(2024, 2, 22);
+        let d1 = date(2024, 7, 24);
+        let d2 = date(2024, 2, 22);
         let span = d1.since((Unit::Month, d2)).unwrap();
         assert_eq!(span, 5.months().days(2));
         let span = d2.since((Unit::Month, d1)).unwrap();
@@ -3675,8 +3399,8 @@ mod tests {
         assert_eq!(d2, d1.checked_sub(5.months().days(2)).unwrap());
         assert_eq!(d1, d2.checked_sub(-5.months().days(2)).unwrap());
 
-        let d1 = Date::constant(2024, 7, 15);
-        let d2 = Date::constant(2024, 2, 22);
+        let d1 = date(2024, 7, 15);
+        let d2 = date(2024, 2, 22);
         let span = d1.since((Unit::Month, d2)).unwrap();
         assert_eq!(span, 4.months().days(22));
         let span = d2.since((Unit::Month, d1)).unwrap();
@@ -3684,8 +3408,8 @@ mod tests {
         assert_eq!(d2, d1.checked_sub(4.months().days(22)).unwrap());
         assert_eq!(d1, d2.checked_sub(-4.months().days(23)).unwrap());
 
-        let d1 = Date::constant(2023, 4, 15);
-        let d2 = Date::constant(2023, 2, 22);
+        let d1 = date(2023, 4, 15);
+        let d2 = date(2023, 2, 22);
         let span = d1.since((Unit::Month, d2)).unwrap();
         assert_eq!(span, 1.month().days(21));
         let span = d2.since((Unit::Month, d1)).unwrap();
@@ -3693,8 +3417,8 @@ mod tests {
         assert_eq!(d2, d1.checked_sub(1.month().days(21)).unwrap());
         assert_eq!(d1, d2.checked_sub(-1.month().days(24)).unwrap());
 
-        let d1 = Date::constant(2023, 4, 15);
-        let d2 = Date::constant(2019, 2, 22);
+        let d1 = date(2023, 4, 15);
+        let d2 = date(2019, 2, 22);
         let span = d1.since((Unit::Month, d2)).unwrap();
         assert_eq!(span, 49.months().days(21));
         let span = d2.since((Unit::Month, d1)).unwrap();
@@ -3703,8 +3427,8 @@ mod tests {
 
     #[test]
     fn since_weeks() {
-        let d1 = Date::constant(2024, 7, 15);
-        let d2 = Date::constant(2024, 6, 22);
+        let d1 = date(2024, 7, 15);
+        let d2 = date(2024, 6, 22);
         let span = d1.since((Unit::Week, d2)).unwrap();
         assert_eq!(span, 3.weeks().days(2));
         let span = d2.since((Unit::Week, d1)).unwrap();
@@ -3713,8 +3437,8 @@ mod tests {
 
     #[test]
     fn since_days() {
-        let d1 = Date::constant(2024, 7, 15);
-        let d2 = Date::constant(2024, 2, 22);
+        let d1 = date(2024, 7, 15);
+        let d2 = date(2024, 2, 22);
         let span = d1.since((Unit::Day, d2)).unwrap();
         assert_eq!(span, 144.days());
         let span = d2.since((Unit::Day, d1)).unwrap();
@@ -3723,9 +3447,9 @@ mod tests {
 
     #[test]
     fn until_month_lengths() {
-        let jan1 = Date::constant(2020, 1, 1);
-        let feb1 = Date::constant(2020, 2, 1);
-        let mar1 = Date::constant(2020, 3, 1);
+        let jan1 = date(2020, 1, 1);
+        let feb1 = date(2020, 2, 1);
+        let mar1 = date(2020, 3, 1);
 
         assert_eq!(jan1.until(feb1).unwrap(), 31.days());
         assert_eq!(jan1.until((Unit::Month, feb1)).unwrap(), 1.month());
@@ -3742,8 +3466,8 @@ mod tests {
         // // => P2M
         // Temporal.PlainDate.from("2020-02-29").until("2020-04-30", {largestUnit: "months"})
         // // => P2M1D
-        let d1 = Date::constant(2020, 4, 30);
-        let d2 = Date::constant(2020, 2, 29);
+        let d1 = date(2020, 4, 30);
+        let d2 = date(2020, 2, 29);
 
         let since = d1.since((Unit::Month, d2)).unwrap();
         assert_eq!(since, 2.months());
@@ -3757,8 +3481,8 @@ mod tests {
     fn until_weeks_round() {
         use crate::{RoundMode, SpanRound};
 
-        let earlier = Date::constant(2019, 1, 8);
-        let later = Date::constant(2021, 9, 7);
+        let earlier = date(2019, 1, 8);
+        let later = date(2021, 9, 7);
         let span = earlier.until((Unit::Week, later)).unwrap();
         assert_eq!(span, 139.weeks());
 

--- a/src/civil/datetime.rs
+++ b/src/civil/datetime.rs
@@ -1524,48 +1524,14 @@ impl DateTime {
         Ok(DateTime::from_parts(new_date, new_time))
     }
 
-    /// Subtract the given span of time from this datetime. If the difference
-    /// would overflow the minimum or maximum datetime values, then an error is
-    /// returned.
-    ///
-    /// # Properties
-    ///
-    /// This routine is _not_ reversible because some additions may
-    /// be ambiguous. For example, adding `1 month` to the datetime
-    /// `2024-03-31T00:00:00` will produce `2024-04-30T00:00:00` since April
-    /// has only 30 days in a month. Moreover, subtracting `1 month` from
-    /// `2024-04-30T00:00:00` will produce `2024-03-30T00:00:00`, which is not
-    /// the date we started with.
-    ///
-    /// If spans of time are limited to units of days (or less), then this
-    /// routine _is_ reversible.
+    /// This routine is identical to [`DateTime::checked_add`] with the
+    /// duration negated.
     ///
     /// # Errors
     ///
-    /// If the span subtracted from this datetime would result in a datetime
-    /// that exceeds the range of a `DateTime`, then this will return an error.
+    /// This has the same error conditions as [`DateTime::checked_add`].
     ///
     /// # Example
-    ///
-    /// This shows a few examples of subtracting spans of time to various
-    /// dates. We make use of the [`ToSpan`](crate::ToSpan) trait for
-    /// convenient creation of spans.
-    ///
-    /// ```
-    /// use jiff::{civil::date, ToSpan};
-    ///
-    /// let dt = date(1995, 12, 7).at(3, 24, 30, 3_500);
-    /// let got = dt.checked_sub(20.years().months(4).nanoseconds(500))?;
-    /// assert_eq!(got, date(1975, 8, 7).at(3, 24, 30, 3_000));
-    ///
-    /// let dt = date(2019, 2, 28).at(15, 30, 0, 0);
-    /// let got = dt.checked_sub(1.months())?;
-    /// assert_eq!(got, date(2019, 1, 28).at(15, 30, 0, 0));
-    ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
-    ///
-    /// # Example: available via subtraction operator
     ///
     /// This routine can be used via the `-` operator. Note though that if it
     /// fails, it will result in a panic.
@@ -1577,81 +1543,16 @@ impl DateTime {
     /// let got = dt - 20.years().months(4).nanoseconds(500);
     /// assert_eq!(got, date(1975, 8, 7).at(3, 24, 30, 3_000));
     /// ```
-    ///
-    /// # Example: negative spans are supported
-    ///
-    /// ```
-    /// use jiff::{civil::date, ToSpan};
-    ///
-    /// let dt = date(2024, 3, 31).at(19, 5, 59, 999_999_999);
-    /// assert_eq!(
-    ///     dt.checked_sub(-1.months())?,
-    ///     date(2024, 4, 30).at(19, 5, 59, 999_999_999),
-    /// );
-    ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
-    ///
-    /// # Example: error on overflow
-    ///
-    /// ```
-    /// use jiff::{civil::date, ToSpan};
-    ///
-    /// let dt = date(2024, 3, 31).at(13, 13, 13, 13);
-    /// assert!(dt.checked_sub(19000.years()).is_err());
-    /// assert!(dt.checked_sub(-9000.years()).is_err());
-    /// ```
     #[inline]
     pub fn checked_sub(self, span: Span) -> Result<DateTime, Error> {
         self.checked_add(-span)
     }
 
-    /// Add the given span of time to this datetime. If the sum would overflow
-    /// the minimum or maximum datetime values, then the result saturates.
-    ///
-    /// # Properties
-    ///
-    /// This routine is _not_ reversible because some additions may
-    /// be ambiguous. For example, adding `1 month` to the datetime
-    /// `2024-03-31T00:00:00` will produce `2024-04-30T00:00:00` since April
-    /// has only 30 days in a month. Moreover, subtracting `1 month` from
-    /// `2024-04-30T00:00:00` will produce `2024-03-30T00:00:00`, which is not
-    /// the date we started with.
-    ///
-    /// If spans of time are limited to units of days (or less), and no
-    /// saturation occurs, then this routine _is_ reversible.
+    /// This routine is identical to [`DateTime::checked_add`], except the
+    /// result saturates on overflow. That is, instead of overflow, either
+    /// [`DateTime::MIN`] or [`DateTime::MAX`] is returned.
     ///
     /// # Example
-    ///
-    /// This shows a few examples of adding spans of time to various dates.
-    /// We make use of the [`ToSpan`](crate::ToSpan) trait for convenient
-    /// creation of spans.
-    ///
-    /// ```
-    /// use jiff::{civil::date, ToSpan};
-    ///
-    /// let dt = date(1995, 12, 7).at(3, 24, 30, 3_500);
-    /// let got = dt.saturating_add(20.years().months(4).nanoseconds(500));
-    /// assert_eq!(got, date(2016, 4, 7).at(3, 24, 30, 4_000));
-    ///
-    /// let dt = date(2019, 1, 31).at(15, 30, 0, 0);
-    /// let got = dt.saturating_add(1.months());
-    /// assert_eq!(got, date(2019, 2, 28).at(15, 30, 0, 0));
-    /// ```
-    ///
-    /// # Example: negative spans are supported
-    ///
-    /// ```
-    /// use jiff::{civil::date, ToSpan};
-    ///
-    /// let dt = date(2024, 3, 31).at(19, 5, 59, 999_999_999);
-    /// assert_eq!(
-    ///     dt.saturating_add(-1.months()),
-    ///     date(2024, 2, 29).at(19, 5, 59, 999_999_999),
-    /// );
-    /// ```
-    ///
-    /// # Example: saturation on overflow
     ///
     /// ```
     /// use jiff::{civil::{DateTime, date}, ToSpan};
@@ -1671,53 +1572,10 @@ impl DateTime {
         })
     }
 
-    /// Subtract the given span of time from this datetime. If the difference
-    /// would overflow the minimum or maximum datetime values, then the result
-    /// saturates.
-    ///
-    /// # Properties
-    ///
-    /// This routine is _not_ reversible because some additions may
-    /// be ambiguous. For example, adding `1 month` to the datetime
-    /// `2024-03-31T00:00:00` will produce `2024-04-30T00:00:00` since April
-    /// has only 30 days in a month. Moreover, subtracting `1 month` from
-    /// `2024-04-30T00:00:00` will produce `2024-03-30T00:00:00`, which is not
-    /// the date we started with.
-    ///
-    /// If spans of time are limited to units of days (or less), and no
-    /// saturation occurs, then this routine _is_ reversible.
+    /// This routine is identical to [`DateTime::saturating_add`] with the span
+    /// parameter negated.
     ///
     /// # Example
-    ///
-    /// This shows a few examples of subtracting spans of time to various
-    /// dates. We make use of the [`ToSpan`](crate::ToSpan) trait for
-    /// convenient creation of spans.
-    ///
-    /// ```
-    /// use jiff::{civil::date, ToSpan};
-    ///
-    /// let dt = date(1995, 12, 7).at(3, 24, 30, 3_500);
-    /// let got = dt.saturating_sub(20.years().months(4).nanoseconds(500));
-    /// assert_eq!(got, date(1975, 8, 7).at(3, 24, 30, 3_000));
-    ///
-    /// let dt = date(2019, 2, 28).at(15, 30, 0, 0);
-    /// let got = dt.saturating_sub(1.months());
-    /// assert_eq!(got, date(2019, 1, 28).at(15, 30, 0, 0));
-    /// ```
-    ///
-    /// # Example: negative spans are supported
-    ///
-    /// ```
-    /// use jiff::{civil::date, ToSpan};
-    ///
-    /// let dt = date(2024, 3, 31).at(19, 5, 59, 999_999_999);
-    /// assert_eq!(
-    ///     dt.saturating_sub(-1.months()),
-    ///     date(2024, 4, 30).at(19, 5, 59, 999_999_999),
-    /// );
-    /// ```
-    ///
-    /// # Example: saturation on overflow
     ///
     /// ```
     /// use jiff::{civil::{DateTime, date}, ToSpan};
@@ -1887,68 +1745,14 @@ impl DateTime {
         }
     }
 
-    /// Returns a span representing the elapsed time from this datetime since
-    /// the given `other` datetime.
-    ///
-    /// When `other` occurs after this datetime, then the span returned will
-    /// be negative.
-    ///
-    /// Depending on the input provided, the span returned is rounded. It may
-    /// also be balanced up to bigger units than the default. By default, the
-    /// span returned is balanced such that the biggest possible unit is days.
-    ///
-    /// This operation is configured by providing a [`DateTimeDifference`]
-    /// value. Since this routine accepts anything that implements
-    /// `Into<DateTimeDifference>`, once can pass a `DateTime` directly.
-    /// One can also pass a `(Unit, DateTime)`, where `Unit` is treated as
-    /// [`DateTimeDifference::largest`].
-    ///
-    /// # Properties
-    ///
-    /// It is guaranteed that if the returned span is added to `other`, and if
-    /// no rounding is requested, and if the largest unit requested is at most
-    /// `Unit::Day`, then the original datetime will be returned.
-    ///
-    /// This routine is equivalent to `self.until(other).map(|span| -span)`
-    /// if no rounding options are set. If rounding options are set, then
-    /// it's equivalent to
-    /// `self.until(other_without_rounding_options).map(|span| -span)`,
-    /// followed by a call to [`Span::round`] with the appropriate rounding
-    /// options set. This is because the negation of a span can result in
-    /// different rounding results depending on the rounding mode.
+    /// This routine is identical to [`DateTime::until`], but the order of the
+    /// parameters is flipped.
     ///
     /// # Errors
     ///
-    /// An error can occur in some cases when the requested configuration
-    /// would result in a span that is beyond allowable limits. For example,
-    /// the nanosecond component of a span cannot represent the span of
-    /// time between the minimum and maximum datetime supported by Jiff.
-    /// Therefore, if one requests a span with its largest unit set to
-    /// [`Unit::Nanosecond`], then it's possible for this routine to fail.
-    ///
-    /// An error can also occur if `DateTimeDifference` is misconfigured. For
-    /// example, if the smallest unit provided is bigger than the largest unit.
-    ///
-    /// It is guaranteed that if one provides a datetime with the default
-    /// [`DateTimeDifference`] configuration, then this routine will never
-    /// fail.
+    /// This has the same error conditions as [`DateTime::until`].
     ///
     /// # Example
-    ///
-    /// ```
-    /// use jiff::{civil::date, ToSpan};
-    ///
-    /// let earlier = date(2006, 8, 24).at(22, 30, 0, 0);
-    /// let later = date(2019, 1, 31).at(21, 0, 0, 0);
-    /// assert_eq!(later.since(earlier)?, 4542.days().hours(22).minutes(30));
-    ///
-    /// // Flipping the dates is fine, but you'll get a negative span.
-    /// assert_eq!(earlier.since(later)?, -4542.days().hours(22).minutes(30));
-    ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
-    ///
-    /// # Example: available via subtraction operator
     ///
     /// This routine can be used via the `-` operator. Since the default
     /// configuration is used and because a `Span` can represent the difference
@@ -1961,91 +1765,6 @@ impl DateTime {
     /// let later = date(2019, 1, 31).at(21, 0, 0, 0);
     /// assert_eq!(later - earlier, 4542.days().hours(22).minutes(30));
     /// ```
-    ///
-    /// # Example: using bigger units
-    ///
-    /// This example shows how to expand the span returned to bigger units.
-    /// This makes use of a `From<(Unit, DateTime)> for DateTimeDifference`
-    /// trait implementation.
-    ///
-    /// ```
-    /// use jiff::{civil::date, Unit, ToSpan};
-    ///
-    /// let dt1 = date(1995, 12, 07).at(3, 24, 30, 3500);
-    /// let dt2 = date(2019, 01, 31).at(15, 30, 0, 0);
-    ///
-    /// // The default limits durations to using "days" as the biggest unit.
-    /// let span = dt2.since(dt1)?;
-    /// assert_eq!(span.to_string(), "P8456dT12h5m29.9999965s");
-    ///
-    /// // But we can ask for units all the way up to years.
-    /// let span = dt2.since((Unit::Year, dt1))?;
-    /// assert_eq!(span.to_string(), "P23y1m24dT12h5m29.9999965s");
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
-    ///
-    /// # Example: rounding the result
-    ///
-    /// This shows how one might find the difference between two datetimes and
-    /// have the result rounded such that sub-seconds are removed.
-    ///
-    /// In this case, we need to hand-construct a [`DateTimeDifference`]
-    /// in order to gain full configurability.
-    ///
-    /// ```
-    /// use jiff::{civil::{DateTimeDifference, date}, Unit, ToSpan};
-    ///
-    /// let dt1 = date(1995, 12, 07).at(3, 24, 30, 3500);
-    /// let dt2 = date(2019, 01, 31).at(15, 30, 0, 0);
-    ///
-    /// let span = dt2.since(
-    ///     DateTimeDifference::from(dt1).smallest(Unit::Second),
-    /// )?;
-    /// assert_eq!(span, 8456.days().hours(12).minutes(5).seconds(29));
-    ///
-    /// // We can combine smallest and largest units too!
-    /// let span = dt2.since(
-    ///     DateTimeDifference::from(dt1)
-    ///         .smallest(Unit::Second)
-    ///         .largest(Unit::Year),
-    /// )?;
-    /// assert_eq!(span, 23.years().months(1).days(24).hours(12).minutes(5).seconds(29));
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
-    ///
-    /// # Example: units biggers than days inhibit reversibility
-    ///
-    /// If you ask for units bigger than days, then adding the span
-    /// returned to the `other` datetime is not guaranteed to result in the
-    /// original datetime. For example:
-    ///
-    /// ```
-    /// use jiff::{civil::date, Unit, ToSpan};
-    ///
-    /// let dt1 = date(2024, 3, 2).at(0, 0, 0, 0);
-    /// let dt2 = date(2024, 5, 1).at(0, 0, 0, 0);
-    ///
-    /// let span = dt2.since((Unit::Month, dt1))?;
-    /// assert_eq!(span, 1.month().days(30));
-    /// let maybe_original = dt1.checked_add(span)?;
-    /// // Not the same as the original datetime!
-    /// assert_eq!(maybe_original, date(2024, 5, 2).at(0, 0, 0, 0));
-    ///
-    /// // But in the default configuration, days are always the biggest unit
-    /// // and reversibility is guaranteed.
-    /// let span = dt2.since(dt1)?;
-    /// assert_eq!(span, 60.days());
-    /// let is_original = dt1.checked_add(span)?;
-    /// assert_eq!(is_original, dt2);
-    ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
-    ///
-    /// This occurs because spans are added as if by adding the biggest units
-    /// first, and then the smaller units. Because months vary in length,
-    /// their meaning can change depending on how the span is added. In this
-    /// case, adding one month to `2024-03-02` corresponds to 31 days, but
-    /// subtracting one month from `2024-05-01` corresponds to 30 days.
     #[inline]
     pub fn since<A: Into<DateTimeDifference>>(
         self,

--- a/src/civil/datetime.rs
+++ b/src/civil/datetime.rs
@@ -2140,9 +2140,9 @@ impl DateTime {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[inline]
-    pub fn round(
+    pub fn round<R: Into<DateTimeRound>>(
         self,
-        options: impl Into<DateTimeRound>,
+        options: R,
     ) -> Result<DateTime, Error> {
         let options: DateTimeRound = options.into();
         options.round(t::NANOS_PER_CIVIL_DAY, self)

--- a/src/civil/mod.rs
+++ b/src/civil/mod.rs
@@ -98,13 +98,15 @@ support time zones.
 */
 
 pub use self::{
-    date::{Date, DateDifference, DateSeries, DateWith},
+    date::{Date, DateArithmetic, DateDifference, DateSeries, DateWith},
     datetime::{
-        DateTime, DateTimeDifference, DateTimeRound, DateTimeSeries,
-        DateTimeWith,
+        DateTime, DateTimeArithmetic, DateTimeDifference, DateTimeRound,
+        DateTimeSeries, DateTimeWith,
     },
     iso_week_date::ISOWeekDate,
-    time::{Time, TimeDifference, TimeRound, TimeSeries, TimeWith},
+    time::{
+        Time, TimeArithmetic, TimeDifference, TimeRound, TimeSeries, TimeWith,
+    },
     weekday::{Weekday, WeekdaysForward, WeekdaysReverse},
 };
 

--- a/src/civil/time.rs
+++ b/src/civil/time.rs
@@ -74,10 +74,10 @@ use crate::{
 /// of `60`, then it is automatically constrained to `59`:
 ///
 /// ```
-/// use jiff::civil::Time;
+/// use jiff::civil::{Time, time};
 ///
 /// let t: Time = "23:59:60".parse()?;
-/// assert_eq!(t, Time::constant(23, 59, 59, 0));
+/// assert_eq!(t, time(23, 59, 59, 0));
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
@@ -89,10 +89,10 @@ use crate::{
 /// then `t1 < t2`. For example:
 ///
 /// ```
-/// use jiff::civil::Time;
+/// use jiff::civil::time;
 ///
-/// let t1 = Time::constant(7, 30, 1, 0);
-/// let t2 = Time::constant(8, 10, 0, 0);
+/// let t1 = time(7, 30, 1, 0);
+/// let t2 = time(8, 10, 0, 0);
 /// assert!(t1 < t2);
 /// ```
 ///
@@ -117,16 +117,16 @@ use crate::{
 /// trait implementations:
 ///
 /// ```
-/// use jiff::{civil::Time, ToSpan};
+/// use jiff::{civil::time, ToSpan};
 ///
-/// let time = Time::constant(20, 10, 1, 0);
+/// let t = time(20, 10, 1, 0);
 /// let span = 1.hours().minutes(49).seconds(59);
-/// assert_eq!(time + span, Time::constant(22, 0, 0, 0));
+/// assert_eq!(t + span, time(22, 0, 0, 0));
 ///
 /// // Overflow will result in wrap-around unless using checked
 /// // arithmetic explicitly.
-/// let time = Time::constant(23, 59, 59, 999_999_999);
-/// assert_eq!(Time::constant(0, 0, 0, 0), time + 1.nanoseconds());
+/// let t = time(23, 59, 59, 999_999_999);
+/// assert_eq!(time(0, 0, 0, 0), t + 1.nanoseconds());
 /// ```
 ///
 /// Wrapping arithmetic is used by default because it corresponds to how clocks
@@ -137,10 +137,10 @@ use crate::{
 /// `Time` values directly via a `Sub` trait implementation:
 ///
 /// ```
-/// use jiff::{civil::Time, ToSpan};
+/// use jiff::{civil::time, ToSpan};
 ///
-/// let time1 = Time::constant(22, 0, 0, 0);
-/// let time2 = Time::constant(20, 10, 1, 0);
+/// let time1 = time(22, 0, 0, 0);
+/// let time2 = time(20, 10, 1, 0);
 /// assert_eq!(time1 - time2, 1.hours().minutes(49).seconds(59));
 /// ```
 ///
@@ -149,10 +149,10 @@ use crate::{
 /// (as exemplified above), but we can ask for smaller units:
 ///
 /// ```
-/// use jiff::{civil::Time, ToSpan, Unit};
+/// use jiff::{civil::time, ToSpan, Unit};
 ///
-/// let time1 = Time::constant(23, 30, 0, 0);
-/// let time2 = Time::constant(7, 0, 0, 0);
+/// let time1 = time(23, 30, 0, 0);
+/// let time2 = time(7, 0, 0, 0);
 /// assert_eq!(
 ///     time1.since((Unit::Minute, time2))?,
 ///     990.minutes(),
@@ -164,10 +164,10 @@ use crate::{
 /// Or even round the span returned:
 ///
 /// ```
-/// use jiff::{civil::{Time, TimeDifference}, RoundMode, ToSpan, Unit};
+/// use jiff::{civil::{TimeDifference, time}, RoundMode, ToSpan, Unit};
 ///
-/// let time1 = Time::constant(23, 30, 0, 0);
-/// let time2 = Time::constant(23, 35, 59, 0);
+/// let time1 = time(23, 30, 0, 0);
+/// let time2 = time(23, 35, 59, 0);
 /// assert_eq!(
 ///     time1.until(
 ///         TimeDifference::new(time2).smallest(Unit::Minute),
@@ -196,16 +196,16 @@ use crate::{
 /// to round to the nearest third hour:
 ///
 /// ```
-/// use jiff::{civil::{Time, TimeRound}, Unit};
+/// use jiff::{civil::{TimeRound, time}, Unit};
 ///
-/// let t = Time::constant(16, 27, 29, 999_999_999);
+/// let t = time(16, 27, 29, 999_999_999);
 /// assert_eq!(
 ///     t.round(TimeRound::new().smallest(Unit::Hour).increment(3))?,
-///     Time::constant(15, 0, 0, 0),
+///     time(15, 0, 0, 0),
 /// );
 /// // Or alternatively, make use of the `From<(Unit, i64)> for TimeRound`
 /// // trait implementation:
-/// assert_eq!(t.round((Unit::Hour, 3))?, Time::constant(15, 0, 0, 0));
+/// assert_eq!(t.round((Unit::Hour, 3))?, time(15, 0, 0, 0));
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
@@ -402,9 +402,9 @@ impl Time {
     /// # Example
     ///
     /// ```
-    /// use jiff::civil::Time;
+    /// use jiff::civil::time;
     ///
-    /// let t = Time::constant(13, 35, 56, 123_456_789);
+    /// let t = time(13, 35, 56, 123_456_789);
     /// assert_eq!(t.hour(), 13);
     /// ```
     #[inline]
@@ -417,9 +417,9 @@ impl Time {
     /// # Example
     ///
     /// ```
-    /// use jiff::civil::Time;
+    /// use jiff::civil::time;
     ///
-    /// let t = Time::constant(13, 35, 56, 123_456_789);
+    /// let t = time(13, 35, 56, 123_456_789);
     /// assert_eq!(t.minute(), 35);
     /// ```
     #[inline]
@@ -432,9 +432,9 @@ impl Time {
     /// # Example
     ///
     /// ```
-    /// use jiff::civil::Time;
+    /// use jiff::civil::time;
     ///
-    /// let t = Time::constant(13, 35, 56, 123_456_789);
+    /// let t = time(13, 35, 56, 123_456_789);
     /// assert_eq!(t.second(), 56);
     /// ```
     #[inline]
@@ -447,9 +447,9 @@ impl Time {
     /// # Example
     ///
     /// ```
-    /// use jiff::civil::Time;
+    /// use jiff::civil::time;
     ///
-    /// let t = Time::constant(13, 35, 56, 123_456_789);
+    /// let t = time(13, 35, 56, 123_456_789);
     /// assert_eq!(t.millisecond(), 123);
     /// ```
     #[inline]
@@ -462,9 +462,9 @@ impl Time {
     /// # Example
     ///
     /// ```
-    /// use jiff::civil::Time;
+    /// use jiff::civil::time;
     ///
-    /// let t = Time::constant(13, 35, 56, 123_456_789);
+    /// let t = time(13, 35, 56, 123_456_789);
     /// assert_eq!(t.microsecond(), 456);
     /// ```
     #[inline]
@@ -477,9 +477,9 @@ impl Time {
     /// # Example
     ///
     /// ```
-    /// use jiff::civil::Time;
+    /// use jiff::civil::time;
     ///
-    /// let t = Time::constant(13, 35, 56, 123_456_789);
+    /// let t = time(13, 35, 56, 123_456_789);
     /// assert_eq!(t.nanosecond(), 789);
     /// ```
     #[inline]
@@ -601,23 +601,23 @@ impl Time {
     /// This routine can be used via the `+` operator.
     ///
     /// ```
-    /// use jiff::{civil::Time, ToSpan};
+    /// use jiff::{civil::time, ToSpan};
     ///
-    /// let t = Time::constant(20, 10, 1, 0);
+    /// let t = time(20, 10, 1, 0);
     /// assert_eq!(
     ///     t + 1.hours().minutes(49).seconds(59),
-    ///     Time::constant(22, 0, 0, 0),
+    ///     time(22, 0, 0, 0),
     /// );
     /// ```
     ///
     /// # Example: add nanoseconds to a `Time`
     ///
     /// ```
-    /// use jiff::{civil::Time, ToSpan};
+    /// use jiff::{civil::time, ToSpan};
     ///
-    /// let t = Time::constant(22, 35, 1, 0);
+    /// let t = time(22, 35, 1, 0);
     /// assert_eq!(
-    ///     Time::constant(22, 35, 3, 500_000_000),
+    ///     time(22, 35, 3, 500_000_000),
     ///     t.wrapping_add(2_500_000_000i64.nanoseconds()),
     /// );
     /// ```
@@ -625,11 +625,11 @@ impl Time {
     /// # Example: add span with multiple units
     ///
     /// ```
-    /// use jiff::{civil::Time, ToSpan};
+    /// use jiff::{civil::time, ToSpan};
     ///
-    /// let t = Time::constant(20, 10, 1, 0);
+    /// let t = time(20, 10, 1, 0);
     /// assert_eq!(
-    ///     Time::constant(22, 0, 0, 0),
+    ///     time(22, 0, 0, 0),
     ///     t.wrapping_add(1.hours().minutes(49).seconds(59)),
     /// );
     /// ```
@@ -637,19 +637,19 @@ impl Time {
     /// # Example: adding an empty span is a no-op
     ///
     /// ```
-    /// use jiff::{civil::Time, Span};
+    /// use jiff::{civil::time, Span};
     ///
-    /// let t = Time::constant(20, 10, 1, 0);
+    /// let t = time(20, 10, 1, 0);
     /// assert_eq!(t, t.wrapping_add(Span::new()));
     /// ```
     ///
     /// # Example: addition wraps on overflow
     ///
     /// ```
-    /// use jiff::{civil::Time, ToSpan};
+    /// use jiff::{civil::time, ToSpan};
     ///
-    /// let t = Time::constant(23, 59, 59, 999_999_999);
-    /// assert_eq!(Time::constant(0, 0, 0, 0), t.wrapping_add(1.nanoseconds()));
+    /// let t = time(23, 59, 59, 999_999_999);
+    /// assert_eq!(time(0, 0, 0, 0), t.wrapping_add(1.nanoseconds()));
     /// ```
     ///
     /// Similarly, if there are any non-zero units greater than hours in the
@@ -657,10 +657,10 @@ impl Time {
     /// ignored):
     ///
     /// ```
-    /// use jiff::{civil::Time, ToSpan};
+    /// use jiff::{civil::time, ToSpan};
     ///
     /// // doesn't matter what our time value is in this example
-    /// let t = Time::constant(0, 0, 0, 0);
+    /// let t = time(0, 0, 0, 0);
     /// assert_eq!(t, t.wrapping_add(1.days()));
     /// ```
     #[inline]
@@ -696,86 +696,18 @@ impl Time {
         Time::from_nanosecond(civil_day_nanosecond)
     }
 
-    /// Subtract the given span from this time and wrap around on overflow.
+    /// This routine is identical to [`Time::wrapping_add`] with the duration
+    /// negated.
     ///
-    /// # Properties
-    ///
-    /// Given times `t1` and `t2`, and a span `s`, with `t2 = t1 - s`, it
-    /// follows then that `t1 = t2 + s` for all values of `t1` and `s` whose
-    /// difference is `t2`.
-    ///
-    /// In short, adding the given span from the difference returned by this
-    /// function is guaranteed to result in precisely the original time.
-    ///
-    /// # Example: available via subtraction operator
-    ///
-    /// This routine can be used via the `-` operator.
+    /// # Example
     ///
     /// ```
-    /// use jiff::{civil::Time, ToSpan};
+    /// use jiff::{civil::time, ToSpan};
     ///
-    /// let t = Time::constant(22, 0, 0, 0);
     /// assert_eq!(
-    ///     t - 1.hours().minutes(49).seconds(59),
-    ///     Time::constant(20, 10, 1, 0),
+    ///     time(0, 0, 0, 0).wrapping_sub(1.nanoseconds()),
+    ///     time(23, 59, 59, 999_999_999),
     /// );
-    /// ```
-    ///
-    /// # Example: subtract nanoseconds from a `Time`
-    ///
-    /// ```
-    /// use jiff::{civil::Time, ToSpan};
-    ///
-    /// let t = Time::constant(22, 35, 1, 0);
-    /// assert_eq!(
-    ///     Time::constant(22, 34, 58, 500_000_000),
-    ///     t.wrapping_sub(2_500_000_000i64.nanoseconds()),
-    /// );
-    /// ```
-    ///
-    /// # Example: subtract span with multiple units
-    ///
-    /// ```
-    /// use jiff::{civil::Time, ToSpan};
-    ///
-    /// let t = Time::constant(22, 0, 0, 0);
-    /// assert_eq!(
-    ///     Time::constant(20, 10, 1, 0),
-    ///     t.wrapping_sub(1.hours().minutes(49).seconds(59)),
-    /// );
-    /// ```
-    ///
-    /// # Example: addition wraps on overflow
-    ///
-    /// ```
-    /// use jiff::{civil::Time, Span};
-    ///
-    /// let t = Time::constant(20, 10, 1, 0);
-    /// assert_eq!(t, t.wrapping_sub(Span::new()));
-    /// ```
-    ///
-    /// # Example: subtraction wraps on overflow
-    ///
-    /// ```
-    /// use jiff::{civil::Time, ToSpan};
-    ///
-    /// let t = Time::constant(0, 0, 0, 0);
-    /// assert_eq!(
-    ///     Time::constant(23, 59, 59, 999_999_999),
-    ///     t.wrapping_sub(1.nanoseconds()),
-    /// );
-    /// ```
-    ///
-    /// Similarly, if there are any non-zero units greater than hours in the
-    /// given span, then they also result in wrapping behavior (i.e., they are
-    /// ignored):
-    ///
-    /// ```
-    /// use jiff::{civil::Time, ToSpan};
-    ///
-    /// // doesn't matter what our time value is in this example
-    /// let t = Time::constant(23, 59, 59, 999_999_999);
-    /// assert_eq!(t, t.wrapping_sub(1.days()));
     /// ```
     #[inline]
     pub fn wrapping_sub(self, span: Span) -> Time {
@@ -805,11 +737,11 @@ impl Time {
     /// # Example: add nanoseconds to a `Time`
     ///
     /// ```
-    /// use jiff::{civil::Time, ToSpan};
+    /// use jiff::{civil::time, ToSpan};
     ///
-    /// let t = Time::constant(22, 35, 1, 0);
+    /// let t = time(22, 35, 1, 0);
     /// assert_eq!(
-    ///     Time::constant(22, 35, 3, 500_000_000),
+    ///     time(22, 35, 3, 500_000_000),
     ///     t.checked_add(2_500_000_000i64.nanoseconds())?,
     /// );
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -818,11 +750,11 @@ impl Time {
     /// # Example: add span with multiple units
     ///
     /// ```
-    /// use jiff::{civil::Time, ToSpan};
+    /// use jiff::{civil::time, ToSpan};
     ///
-    /// let t = Time::constant(20, 10, 1, 0);
+    /// let t = time(20, 10, 1, 0);
     /// assert_eq!(
-    ///     Time::constant(22, 0, 0, 0),
+    ///     time(22, 0, 0, 0),
     ///     t.checked_add(1.hours().minutes(49).seconds(59))?,
     /// );
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -831,9 +763,9 @@ impl Time {
     /// # Example: adding an empty span is a no-op
     ///
     /// ```
-    /// use jiff::{civil::Time, Span};
+    /// use jiff::{civil::time, Span};
     ///
-    /// let t = Time::constant(20, 10, 1, 0);
+    /// let t = time(20, 10, 1, 0);
     /// assert_eq!(t, t.checked_add(Span::new())?);
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -862,10 +794,10 @@ impl Time {
     /// given span, then they also result in overflow (and thus an error):
     ///
     /// ```
-    /// use jiff::{civil::Time, ToSpan};
+    /// use jiff::{civil::time, ToSpan};
     ///
     /// // doesn't matter what our time value is in this example
-    /// let t = Time::constant(0, 0, 0, 0);
+    /// let t = time(0, 0, 0, 0);
     /// assert!(t.checked_add(1.days()).is_err());
     /// ```
     #[inline]
@@ -877,136 +809,35 @@ impl Time {
         Ok(time)
     }
 
-    /// Subtract the given span from this time and return an error if the
-    /// result would otherwise overflow.
-    ///
-    /// # Properties
-    ///
-    /// Given a time `t1` and a span `s`, and assuming `t2 = t1 - s` exists, it
-    /// follows then that `t1 = t2 + s` for all values of `t1` and `s` whose
-    /// difference is a valid `t2`.
-    ///
-    /// In short, adding the given span from the difference returned by this
-    /// function is guaranteed to result in precisely the original time.
+    /// This routine is identical to [`Time::checked_add`] with the duration
+    /// negated.
     ///
     /// # Errors
     ///
-    /// This returns an error in two cases:
+    /// This has the same error conditions as [`Time::checked_add`].
     ///
-    /// 1. When the given span's interval overflows the maximum allowed
-    /// duration.
-    /// 2. When subtracting the span to a time value would exceed the minimum
-    /// allowed value (`00:00:00.000000000`). This also automatically happens
-    /// whenever the given span has any non-zero values for units bigger than
-    /// hours.
-    ///
-    /// # Example: subtract nanoseconds to a `Time`
-    ///
-    /// ```
-    /// use jiff::{civil::Time, ToSpan};
-    ///
-    /// let t = Time::constant(22, 35, 1, 0);
-    /// assert_eq!(
-    ///     Time::constant(22, 34, 58, 500_000_000),
-    ///     t.checked_sub(2_500_000_000i64.nanoseconds())?,
-    /// );
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
-    ///
-    /// # Example: subtract span with multiple units
-    ///
-    /// ```
-    /// use jiff::{civil::Time, ToSpan};
-    ///
-    /// let t = Time::constant(22, 0, 0, 0);
-    /// assert_eq!(
-    ///     Time::constant(20, 10, 1, 0),
-    ///     t.checked_sub(1.hours().minutes(49).seconds(59))?,
-    /// );
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
-    ///
-    /// # Example: subtracting an empty span is a no-op
-    ///
-    /// ```
-    /// use jiff::{civil::Time, Span};
-    ///
-    /// let t = Time::constant(20, 10, 1, 0);
-    /// assert_eq!(t, t.checked_sub(Span::new())?);
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
-    ///
-    /// # Example: error on overflow
+    /// # Example
     ///
     /// ```
     /// use jiff::{civil::time, ToSpan};
     ///
-    /// // okay
-    /// let t = time(0, 0, 0, 1);
+    /// let t = time(22, 0, 0, 0);
     /// assert_eq!(
-    ///     t.with().nanosecond(0).build()?,
-    ///     t.checked_sub(1.nanoseconds())?,
+    ///     time(20, 10, 1, 0),
+    ///     t.checked_sub(1.hours().minutes(49).seconds(59))?,
     /// );
-    ///
-    /// // not okay
-    /// let t = time(0, 0, 0, 0);
-    /// assert!(t.checked_sub(1.nanoseconds()).is_err());
-    ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
-    ///
-    /// Similarly, if there are any non-zero units greater than hours in the
-    /// given span, then they also result in overflow (and thus an error):
-    ///
-    /// ```
-    /// use jiff::{civil::Time, ToSpan};
-    ///
-    /// // doesn't matter what our time value is in this example
-    /// let t = Time::constant(23, 59, 59, 999_999_999);
-    /// assert!(t.checked_sub(1.days()).is_err());
     /// ```
     #[inline]
     pub fn checked_sub(self, span: Span) -> Result<Time, Error> {
         self.checked_add(span.negate())
     }
 
-    /// Add the given span to this time and saturate if the addition would
-    /// otherwise overflow.
+    /// This routine is identical to [`Time::checked_add`], except the
+    /// result saturates on overflow. That is, instead of overflow, either
+    /// [`Time::MIN`] or [`Time::MAX`] is returned.
     ///
-    /// # Example: add nanoseconds to a `Time`
-    ///
-    /// ```
-    /// use jiff::{civil::Time, ToSpan};
-    ///
-    /// let t = Time::constant(22, 35, 1, 0);
-    /// assert_eq!(
-    ///     Time::constant(22, 35, 3, 500_000_000),
-    ///     t.saturating_add(2_500_000_000i64.nanoseconds()),
-    /// );
-    /// ```
-    ///
-    /// # Example: add span with multiple units
-    ///
-    /// ```
-    /// use jiff::{civil::Time, ToSpan};
-    ///
-    /// let t = Time::constant(20, 10, 1, 0);
-    /// assert_eq!(
-    ///     Time::constant(22, 0, 0, 0),
-    ///     t.saturating_add(1.hours().minutes(49).seconds(59)),
-    /// );
-    /// ```
-    ///
-    /// # Example: adding an empty span is a no-op
-    ///
-    /// ```
-    /// use jiff::{civil::Time, Span};
-    ///
-    /// let t = Time::constant(20, 10, 1, 0);
-    /// assert_eq!(t, t.saturating_add(Span::new()));
-    /// ```
-    ///
-    /// # Example: saturate on overflow
+    /// # Example
     ///
     /// ```
     /// use jiff::{civil::{Time, time}, ToSpan};
@@ -1046,43 +877,10 @@ impl Time {
         })
     }
 
-    /// Subtract the given span from this time and saturate if the subtraction
-    /// would otherwise overflow.
+    /// This routine is identical to [`Time::saturating_add`] with the duration
+    /// negated.
     ///
-    /// # Example: subtract nanoseconds to a `Time`
-    ///
-    /// ```
-    /// use jiff::{civil::Time, ToSpan};
-    ///
-    /// let t = Time::constant(22, 35, 1, 0);
-    /// assert_eq!(
-    ///     Time::constant(22, 34, 58, 500_000_000),
-    ///     t.saturating_sub(2_500_000_000i64.nanoseconds()),
-    /// );
-    /// ```
-    ///
-    /// # Example: subtract span with multiple units
-    ///
-    /// ```
-    /// use jiff::{civil::Time, ToSpan};
-    ///
-    /// let t = Time::constant(22, 0, 0, 0);
-    /// assert_eq!(
-    ///     Time::constant(20, 10, 1, 0),
-    ///     t.saturating_sub(1.hours().minutes(49).seconds(59)),
-    /// );
-    /// ```
-    ///
-    /// # Example: subtracting an empty span is a no-op
-    ///
-    /// ```
-    /// use jiff::{civil::Time, Span};
-    ///
-    /// let t = Time::constant(20, 10, 1, 0);
-    /// assert_eq!(t, t.saturating_sub(Span::new()));
-    /// ```
-    ///
-    /// # Example: saturate on overflow
+    /// # Example
     ///
     /// ```
     /// use jiff::{civil::{Time, time}, ToSpan};
@@ -1099,17 +897,6 @@ impl Time {
     /// assert_eq!(Time::MIN, t.saturating_sub(1.nanoseconds()));
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
-    ///
-    /// Similarly, if there are any non-zero units greater than hours in the
-    /// given span, then they also result in overflow (and thus saturation):
-    ///
-    /// ```
-    /// use jiff::{civil::{Time, time}, ToSpan};
-    ///
-    /// // doesn't matter what our time value is in this example
-    /// let t = time(23, 59, 59, 999_999_999);
-    /// assert_eq!(Time::MIN, t.saturating_sub(1.days()));
     /// ```
     #[inline]
     pub fn saturating_sub(self, span: Span) -> Time {
@@ -1171,10 +958,10 @@ impl Time {
     /// # Examples
     ///
     /// ```
-    /// use jiff::{civil::Time, ToSpan};
+    /// use jiff::{civil::time, ToSpan};
     ///
-    /// let t1 = Time::constant(22, 35, 1, 0);
-    /// let t2 = Time::constant(22, 35, 3, 500_000_000);
+    /// let t1 = time(22, 35, 1, 0);
+    /// let t2 = time(22, 35, 3, 500_000_000);
     /// assert_eq!(t1.until(t2)?, 2.seconds().milliseconds(500));
     /// // Flipping the dates is fine, but you'll get a negative span.
     /// assert_eq!(t2.until(t1)?, -2.seconds().milliseconds(500));
@@ -1189,10 +976,10 @@ impl Time {
     /// trait implementation.
     ///
     /// ```
-    /// use jiff::{civil::Time, Unit, ToSpan};
+    /// use jiff::{civil::time, Unit, ToSpan};
     ///
-    /// let t1 = Time::constant(3, 24, 30, 3500);
-    /// let t2 = Time::constant(15, 30, 0, 0);
+    /// let t1 = time(3, 24, 30, 3500);
+    /// let t2 = time(15, 30, 0, 0);
     ///
     /// // The default limits spans to using "hours" as the biggest unit.
     /// let span = t1.until(t2)?;
@@ -1219,87 +1006,25 @@ impl Time {
         }
     }
 
-    /// Returns a span representing the elapsed time from this time since
-    /// the given `other` time.
-    ///
-    /// When `other` is later than this time, the span returned will be
-    /// negative.
-    ///
-    /// Depending on the input provided, the span returned is rounded. It may
-    /// also be balanced down to smaller units than the default. By default,
-    /// the span returned is balanced such that the biggest possible unit is
-    /// hours.
-    ///
-    /// This operation is configured by providing a [`TimeDifference`]
-    /// value. Since this routine accepts anything that implements
-    /// `Into<TimeDifference>`, once can pass a `Time` directly. One
-    /// can also pass a `(Unit, Time)`, where `Unit` is treated as
-    /// [`TimeDifference::largest`].
-    ///
-    /// # Properties
-    ///
-    /// As long as no rounding is requested, it is guaranteed that adding the
-    /// span returned to the `other` time will always equal this time.
+    /// This routine is identical to [`Time::until`], but the order of the
+    /// parameters is flipped.
     ///
     /// # Errors
     ///
-    /// An error can occur if `TimeDifference` is misconfigured. For example,
-    /// if the smallest unit provided is bigger than the largest unit. Or if
-    /// a unit greater than `Unit::Hour` is provided.
+    /// This has the same error conditions as [`Time::until`].
     ///
-    /// It is guaranteed that if one provides a time with the default
-    /// [`TimeDifference`] configuration, then this routine will never fail.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use jiff::{civil::Time, ToSpan};
-    ///
-    /// let t1 = Time::constant(22, 35, 1, 0);
-    /// let t2 = Time::constant(22, 35, 3, 500_000_000);
-    /// assert_eq!(t2.since(t1)?, 2.seconds().milliseconds(500));
-    /// // Flipping the dates is fine, but you'll get a negative span.
-    /// assert_eq!(t1.since(t2)?, -2.seconds().milliseconds(500));
-    ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
-    ///
-    /// # Example: available via subtraction operator
+    /// # Example
     ///
     /// This routine can be used via the `-` operator. Since the default
     /// configuration is used and because a `Span` can represent the difference
     /// between any two possible times, it will never panic.
     ///
     /// ```
-    /// use jiff::{civil::Time, ToSpan};
+    /// use jiff::{civil::time, ToSpan};
     ///
-    /// let earlier = Time::constant(1, 0, 0, 0);
-    /// let later = Time::constant(22, 30, 0, 0);
+    /// let earlier = time(1, 0, 0, 0);
+    /// let later = time(22, 30, 0, 0);
     /// assert_eq!(later - earlier, 21.hours().minutes(30));
-    /// ```
-    ///
-    /// # Example: using smaller units
-    ///
-    /// This example shows how to contract the span returned to smaller units.
-    /// This makes use of a `From<(Unit, Time)> for TimeDifference`
-    /// trait implementation.
-    ///
-    /// ```
-    /// use jiff::{civil::Time, Unit, ToSpan};
-    ///
-    /// let t1 = Time::constant(3, 24, 30, 3500);
-    /// let t2 = Time::constant(15, 30, 0, 0);
-    ///
-    /// // The default limits spans to using "hours" as the biggest unit.
-    /// let span = t2.since(t1)?;
-    /// assert_eq!(span.to_string(), "PT12h5m29.9999965s");
-    ///
-    /// // But we can ask for smaller units, like capping the biggest unit
-    /// // to minutes instead of hours.
-    /// let span = t2.since((Unit::Minute, t1))?;
-    /// assert_eq!(span.to_string(), "PT725m29.9999965s");
-    ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[inline]
     pub fn since<A: Into<TimeDifference>>(
@@ -1357,17 +1082,17 @@ impl Time {
     /// smallest unit directly, instead of constructing a `TimeRound` manually.
     ///
     /// ```
-    /// use jiff::{civil::Time, Unit};
+    /// use jiff::{civil::time, Unit};
     ///
-    /// let t = Time::constant(15, 45, 10, 123_456_789);
+    /// let t = time(15, 45, 10, 123_456_789);
     /// assert_eq!(
     ///     t.round(Unit::Second)?,
-    ///     Time::constant(15, 45, 10, 0),
+    ///     time(15, 45, 10, 0),
     /// );
-    /// let t = Time::constant(15, 45, 10, 500_000_001);
+    /// let t = time(15, 45, 10, 500_000_001);
     /// assert_eq!(
     ///     t.round(Unit::Second)?,
-    ///     Time::constant(15, 45, 11, 0),
+    ///     time(15, 45, 11, 0),
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1380,12 +1105,12 @@ impl Time {
     /// [`RoundMode::Trunc`] can be used too:
     ///
     /// ```
-    /// use jiff::{civil::{Time, TimeRound}, RoundMode, Unit};
+    /// use jiff::{civil::{TimeRound, time}, RoundMode, Unit};
     ///
-    /// let t = Time::constant(15, 45, 10, 999_999_999);
+    /// let t = time(15, 45, 10, 999_999_999);
     /// assert_eq!(
     ///     t.round(Unit::Second)?,
-    ///     Time::constant(15, 45, 11, 0),
+    ///     time(15, 45, 11, 0),
     /// );
     /// // The default will round up to the next second for any fraction
     /// // greater than or equal to 0.5. But truncation will always round
@@ -1394,7 +1119,7 @@ impl Time {
     ///     t.round(
     ///         TimeRound::new().smallest(Unit::Second).mode(RoundMode::Trunc),
     ///     )?,
-    ///     Time::constant(15, 45, 10, 0),
+    ///     time(15, 45, 10, 0),
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1403,14 +1128,14 @@ impl Time {
     /// # Example: rounding to the nearest 5 minute increment
     ///
     /// ```
-    /// use jiff::{civil::Time, Unit};
+    /// use jiff::{civil::time, Unit};
     ///
     /// // rounds down
-    /// let t = Time::constant(15, 27, 29, 999_999_999);
-    /// assert_eq!(t.round((Unit::Minute, 5))?, Time::constant(15, 25, 0, 0));
+    /// let t = time(15, 27, 29, 999_999_999);
+    /// assert_eq!(t.round((Unit::Minute, 5))?, time(15, 25, 0, 0));
     /// // rounds up
-    /// let t = Time::constant(15, 27, 30, 0);
-    /// assert_eq!(t.round((Unit::Minute, 5))?, Time::constant(15, 30, 0, 0));
+    /// let t = time(15, 27, 30, 0);
+    /// assert_eq!(t.round((Unit::Minute, 5))?, time(15, 30, 0, 0));
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -1446,37 +1171,37 @@ impl Time {
     /// This shows how to visit each third hour of a 24 hour time interval:
     ///
     /// ```
-    /// use jiff::{civil::Time, ToSpan};
+    /// use jiff::{civil::{Time, time}, ToSpan};
     ///
     /// let start = Time::MIN;
     /// let mut every_third_hour = vec![];
-    /// for time in start.series(3.hours()) {
-    ///     every_third_hour.push(time);
+    /// for t in start.series(3.hours()) {
+    ///     every_third_hour.push(t);
     /// }
     /// assert_eq!(every_third_hour, vec![
-    ///     Time::constant(0, 0, 0, 0),
-    ///     Time::constant(3, 0, 0, 0),
-    ///     Time::constant(6, 0, 0, 0),
-    ///     Time::constant(9, 0, 0, 0),
-    ///     Time::constant(12, 0, 0, 0),
-    ///     Time::constant(15, 0, 0, 0),
-    ///     Time::constant(18, 0, 0, 0),
-    ///     Time::constant(21, 0, 0, 0),
+    ///     time(0, 0, 0, 0),
+    ///     time(3, 0, 0, 0),
+    ///     time(6, 0, 0, 0),
+    ///     time(9, 0, 0, 0),
+    ///     time(12, 0, 0, 0),
+    ///     time(15, 0, 0, 0),
+    ///     time(18, 0, 0, 0),
+    ///     time(21, 0, 0, 0),
     /// ]);
     /// ```
     ///
     /// Or go backwards every 6.5 hours:
     ///
     /// ```
-    /// use jiff::{civil::Time, ToSpan};
+    /// use jiff::{civil::{Time, time}, ToSpan};
     ///
-    /// let start = Time::constant(23, 0, 0, 0);
+    /// let start = time(23, 0, 0, 0);
     /// let times: Vec<Time> = start.series(-6.hours().minutes(30)).collect();
     /// assert_eq!(times, vec![
-    ///     Time::constant(23, 0, 0, 0),
-    ///     Time::constant(16, 30, 0, 0),
-    ///     Time::constant(10, 0, 0, 0),
-    ///     Time::constant(3, 30, 0, 0),
+    ///     time(23, 0, 0, 0),
+    ///     time(16, 30, 0, 0),
+    ///     time(10, 0, 0, 0),
+    ///     time(3, 30, 0, 0),
     /// ]);
     /// ```
     #[inline]
@@ -2264,13 +1989,13 @@ impl<'a> From<(Unit, &'a Zoned)> for TimeDifference {
 /// This example shows how to round a time to the nearest second:
 ///
 /// ```
-/// use jiff::{civil::Time, Unit};
+/// use jiff::{civil::{Time, time}, Unit};
 ///
 /// let t: Time = "16:24:59.5".parse()?;
 /// assert_eq!(
 ///     t.round(Unit::Second)?,
 ///     // The second rounds up and causes minutes to increase.
-///     Time::constant(16, 25, 0, 0),
+///     time(16, 25, 0, 0),
 /// );
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -2283,7 +2008,7 @@ impl<'a> From<(Unit, &'a Zoned)> for TimeDifference {
 /// [`RoundMode`].
 ///
 /// ```
-/// use jiff::{civil::{Time, TimeRound}, RoundMode, Unit};
+/// use jiff::{civil::{Time, TimeRound, time}, RoundMode, Unit};
 ///
 /// let t: Time = "2024-06-20 16:24:59.5".parse()?;
 /// assert_eq!(
@@ -2291,7 +2016,7 @@ impl<'a> From<(Unit, &'a Zoned)> for TimeDifference {
 ///         TimeRound::new().smallest(Unit::Second).mode(RoundMode::Trunc),
 ///     )?,
 ///     // The second just gets truncated as if it wasn't there.
-///     Time::constant(16, 24, 59, 0),
+///     time(16, 24, 59, 0),
 /// );
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -2331,15 +2056,15 @@ impl TimeRound {
     /// # Example
     ///
     /// ```
-    /// use jiff::{civil::{Time, TimeRound}, Unit};
+    /// use jiff::{civil::{TimeRound, time}, Unit};
     ///
-    /// let t = Time::constant(3, 25, 30, 0);
+    /// let t = time(3, 25, 30, 0);
     /// assert_eq!(
     ///     t.round(TimeRound::new().smallest(Unit::Minute))?,
-    ///     Time::constant(3, 26, 0, 0),
+    ///     time(3, 26, 0, 0),
     /// );
     /// // Or, utilize the `From<Unit> for TimeRound` impl:
-    /// assert_eq!(t.round(Unit::Minute)?, Time::constant(3, 26, 0, 0));
+    /// assert_eq!(t.round(Unit::Minute)?, time(3, 26, 0, 0));
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -2359,7 +2084,7 @@ impl TimeRound {
     /// This shows how to always round times up towards positive infinity.
     ///
     /// ```
-    /// use jiff::{civil::{Time, TimeRound}, RoundMode, Unit};
+    /// use jiff::{civil::{Time, TimeRound, time}, RoundMode, Unit};
     ///
     /// let t: Time = "03:25:01".parse()?;
     /// assert_eq!(
@@ -2368,7 +2093,7 @@ impl TimeRound {
     ///             .smallest(Unit::Minute)
     ///             .mode(RoundMode::Ceil),
     ///     )?,
-    ///     Time::constant(3, 26, 0, 0),
+    ///     time(3, 26, 0, 0),
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -2402,10 +2127,10 @@ impl TimeRound {
     /// increment.
     ///
     /// ```
-    /// use jiff::{civil::{Time, TimeRound}, RoundMode, Unit};
+    /// use jiff::{civil::{Time, TimeRound, time}, RoundMode, Unit};
     ///
     /// let t: Time = "03:24:59".parse()?;
-    /// assert_eq!(t.round((Unit::Minute, 10))?, Time::constant(3, 20, 0, 0));
+    /// assert_eq!(t.round((Unit::Minute, 10))?, time(3, 20, 0, 0));
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -2830,7 +2555,7 @@ impl TimeWith {
 
 #[cfg(test)]
 mod tests {
-    use crate::ToSpan;
+    use crate::{civil::time, ToSpan};
 
     use super::*;
 
@@ -2870,32 +2595,32 @@ mod tests {
 
     #[test]
     fn rounding_cross_midnight() {
-        let t1 = Time::constant(23, 59, 59, 999_999_999);
+        let t1 = time(23, 59, 59, 999_999_999);
 
         let t2 = t1.round(Unit::Nanosecond).unwrap();
         assert_eq!(t2, t1);
 
         let t2 = t1.round(Unit::Millisecond).unwrap();
-        assert_eq!(t2, Time::constant(0, 0, 0, 0));
+        assert_eq!(t2, time(0, 0, 0, 0));
 
         let t2 = t1.round(Unit::Microsecond).unwrap();
-        assert_eq!(t2, Time::constant(0, 0, 0, 0));
+        assert_eq!(t2, time(0, 0, 0, 0));
 
         let t2 = t1.round(Unit::Millisecond).unwrap();
-        assert_eq!(t2, Time::constant(0, 0, 0, 0));
+        assert_eq!(t2, time(0, 0, 0, 0));
 
         let t2 = t1.round(Unit::Second).unwrap();
-        assert_eq!(t2, Time::constant(0, 0, 0, 0));
+        assert_eq!(t2, time(0, 0, 0, 0));
 
         let t2 = t1.round(Unit::Minute).unwrap();
-        assert_eq!(t2, Time::constant(0, 0, 0, 0));
+        assert_eq!(t2, time(0, 0, 0, 0));
 
         let t2 = t1.round(Unit::Hour).unwrap();
-        assert_eq!(t2, Time::constant(0, 0, 0, 0));
+        assert_eq!(t2, time(0, 0, 0, 0));
 
-        let t1 = Time::constant(22, 15, 0, 0);
+        let t1 = time(22, 15, 0, 0);
         assert_eq!(
-            Time::constant(22, 30, 0, 0),
+            time(22, 30, 0, 0),
             t1.round(TimeRound::new().smallest(Unit::Minute).increment(30))
                 .unwrap()
         );
@@ -2985,15 +2710,15 @@ mod tests {
 
     #[test]
     fn overflowing_add() {
-        let t1 = Time::constant(23, 30, 0, 0);
+        let t1 = time(23, 30, 0, 0);
         let (t2, span) = t1.overflowing_add(5.hours()).unwrap();
-        assert_eq!(t2, Time::constant(4, 30, 0, 0));
+        assert_eq!(t2, time(4, 30, 0, 0));
         assert_eq!(span, 1.days());
     }
 
     #[test]
     fn overflowing_add_overflows() {
-        let t1 = Time::constant(23, 30, 0, 0);
+        let t1 = time(23, 30, 0, 0);
         let span = Span::new()
             .hours(t::SpanHours::MAX_REPR)
             .minutes(t::SpanMinutes::MAX_REPR)

--- a/src/civil/time.rs
+++ b/src/civil/time.rs
@@ -1478,7 +1478,7 @@ impl Time {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[inline]
-    pub fn round(self, options: impl Into<TimeRound>) -> Result<Time, Error> {
+    pub fn round<R: Into<TimeRound>>(self, options: R) -> Result<Time, Error> {
         let options: TimeRound = options.into();
         options.round(self)
     }

--- a/src/civil/weekday.rs
+++ b/src/civil/weekday.rs
@@ -408,7 +408,7 @@ impl Weekday {
     /// assert_eq!(1 + Weekday::Sunday, Weekday::Monday);
     /// ```
     #[inline]
-    pub fn wrapping_add(self, days: impl Into<i64>) -> Weekday {
+    pub fn wrapping_add<D: Into<i64>>(self, days: D) -> Weekday {
         let start = t::NoUnits::rfrom(self.to_monday_zero_offset_ranged());
         // OK because all i64 values fit in a NoUnits.
         let rhs = t::NoUnits::new(days.into()).unwrap();
@@ -452,7 +452,7 @@ impl Weekday {
     /// weekday has no semantic meaning, the weekday cannot be on the right
     /// hand side of the `-` operator.
     #[inline]
-    pub fn wrapping_sub(self, days: impl Into<i64>) -> Weekday {
+    pub fn wrapping_sub<D: Into<i64>>(self, days: D) -> Weekday {
         self.wrapping_add(-days.into())
     }
 

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -1,0 +1,146 @@
+use std::time::Duration as UnsignedDuration;
+
+use crate::{
+    error::{err, ErrorContext},
+    Error, SignedDuration, Span,
+};
+
+/// An internal type for abstracting over different duration types.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum Duration {
+    Span(Span),
+    Signed(SignedDuration),
+    Unsigned(UnsignedDuration),
+}
+
+impl Duration {
+    /// Convert this to a signed duration.
+    ///
+    /// This returns an error only in the case where this is an unsigned
+    /// duration with a number of whole seconds that exceeds `|i64::MIN|`.
+    pub(crate) fn to_signed(self) -> Result<SDuration, Error> {
+        match self {
+            Duration::Span(span) => Ok(SDuration::Span(span)),
+            Duration::Signed(sdur) => Ok(SDuration::Absolute(sdur)),
+            Duration::Unsigned(udur) => {
+                let sdur =
+                    SignedDuration::try_from(udur).with_context(|| {
+                        err!(
+                            "unsigned duration {udur:?} exceeds Jiff's limits"
+                        )
+                    })?;
+                Ok(SDuration::Absolute(sdur))
+            }
+        }
+    }
+
+    /// Negates this duration.
+    ///
+    /// When the duration is a span, this can never fail because a span defines
+    /// its min and max values such that negation is always possible.
+    ///
+    /// When the duration is signed, then this attempts to return a signed
+    /// duration and only falling back to an unsigned duration when the number
+    /// of seconds corresponds to `i64::MIN`.
+    ///
+    /// When the duration is unsigned, then this fails when the whole seconds
+    /// exceed the absolute value of `i64::MIN`. Otherwise, a signed duration
+    /// is returned.
+    ///
+    /// The failures for large unsigned durations here are okay because the
+    /// point at which absolute durations overflow on negation, they would also
+    /// cause overflow when adding or subtracting to *any* valid datetime value
+    /// for *any* datetime type in this crate. So while the error message may
+    /// be different, the actual end result is the same (failure).
+    ///
+    /// TODO: Write unit tests for this.
+    pub(crate) fn checked_neg(self) -> Result<Duration, Error> {
+        match self {
+            Duration::Span(span) => Ok(Duration::Span(span.negate())),
+            Duration::Signed(sdur) => {
+                // We try to stick with signed durations, but in the case
+                // where negation fails, we can represent its negation using
+                // an unsigned duration.
+                if let Some(sdur) = sdur.checked_neg() {
+                    Ok(Duration::Signed(sdur))
+                } else {
+                    let udur = UnsignedDuration::new(
+                        i64::MIN.unsigned_abs(),
+                        sdur.subsec_nanos().unsigned_abs(),
+                    );
+                    Ok(Duration::Unsigned(udur))
+                }
+            }
+            Duration::Unsigned(udur) => {
+                // We can permit negating i64::MIN.unsigned_abs() to
+                // i64::MIN, but we need to handle it specially since
+                // i64::MIN.unsigned_abs() exceeds i64::MAX.
+                let sdur = if udur.as_secs() == i64::MIN.unsigned_abs() {
+                    SignedDuration::new_without_nano_overflow(
+                        i64::MIN,
+                        // OK because `udur.subsec_nanos()` < 999_999_999.
+                        -i32::try_from(udur.subsec_nanos()).unwrap(),
+                    )
+                } else {
+                    // The negation here is always correct because it can only
+                    // panic with `sdur.as_secs() == i64::MIN`, which is
+                    // impossible because it must be positive.
+                    //
+                    // Otherwise, this is the only failure point in this entire
+                    // routine. And specifically, we fail here in precisely
+                    // the cases where `udur.as_secs() > |i64::MIN|`.
+                    -SignedDuration::try_from(udur).with_context(|| {
+                        err!("failed to negate unsigned duration {udur:?}")
+                    })?
+                };
+                Ok(Duration::Signed(sdur))
+            }
+        }
+    }
+
+    /// Returns true if and only if this duration is negative.
+    #[inline]
+    pub(crate) fn is_negative(&self) -> bool {
+        match *self {
+            Duration::Span(ref span) => span.is_negative(),
+            Duration::Signed(ref sdur) => sdur.is_negative(),
+            Duration::Unsigned(_) => false,
+        }
+    }
+}
+
+impl From<Span> for Duration {
+    fn from(span: Span) -> Duration {
+        Duration::Span(span)
+    }
+}
+
+impl From<SignedDuration> for Duration {
+    fn from(sdur: SignedDuration) -> Duration {
+        Duration::Signed(sdur)
+    }
+}
+
+impl From<UnsignedDuration> for Duration {
+    fn from(udur: UnsignedDuration) -> Duration {
+        Duration::Unsigned(udur)
+    }
+}
+
+/// An internal type for abstracting over signed durations.
+///
+/// This is typically converted to from a `Duration`. It enables callers
+/// downstream to implement datetime arithmetic on only two duration types
+/// instead of doing it for three duration types (including
+/// `std::time::Duration`).
+///
+/// The main thing making this idea work is that if an unsigned duration cannot
+/// fit into a signed duration, then it would overflow any calculation on any
+/// datetime type in Jiff anyway. If this weren't true, then we'd need to
+/// support doing actual arithmetic with unsigned durations separately from
+/// signed durations.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum SDuration {
+    Span(Span),
+    Absolute(SignedDuration),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,8 +78,11 @@ Jiff automatically embeds a copy of it.
 [`Zoned`]) and civil times ([`civil::DateTime`]).
 * Nanosecond precision.
 * Time zone and daylight saving time aware arithmetic.
-* A single time duration type, called [`Span`], which mixes calendar and clock
-units.
+* The primary duration type, [`Span`], mixes calendar and clock
+units to provide an all-in-one human friendly experience that is time zone
+aware.
+* An "absolute" duration type, [`SignedDuration`], is like
+[`std::time::Duration`] but signed.
 * Datetime rounding.
 * Span rounding, including calendar units and including taking time zones into
 account.
@@ -645,6 +648,7 @@ extern crate alloc;
 
 pub use crate::{
     error::Error,
+    signed_duration::SignedDuration,
     span::{
         Span, SpanArithmetic, SpanCompare, SpanRelativeTo, SpanRound,
         SpanTotal, ToSpan, Unit,
@@ -664,6 +668,7 @@ mod error;
 pub mod fmt;
 #[cfg(feature = "std")]
 mod now;
+mod signed_duration;
 mod span;
 mod timestamp;
 pub mod tz;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -654,16 +654,18 @@ pub use crate::{
         SpanTotal, ToSpan, Unit,
     },
     timestamp::{
-        Timestamp, TimestampDifference, TimestampRound, TimestampSeries,
+        Timestamp, TimestampArithmetic, TimestampDifference, TimestampRound,
+        TimestampSeries,
     },
     util::round::mode::RoundMode,
-    zoned::{Zoned, ZonedDifference, ZonedRound, ZonedWith},
+    zoned::{Zoned, ZonedArithmetic, ZonedDifference, ZonedRound, ZonedWith},
 };
 
 #[macro_use]
 mod logging;
 
 pub mod civil;
+mod duration;
 mod error;
 pub mod fmt;
 #[cfg(feature = "std")]

--- a/src/now.rs
+++ b/src/now.rs
@@ -44,7 +44,7 @@ mod sys {
         use std::time::Duration;
 
         #[cfg(not(feature = "std"))]
-        use crate::util::libm::F64;
+        use crate::util::libm::Float;
 
         let millis = js_sys::Date::new_0().get_time();
         let sign = millis.signum();

--- a/src/signed_duration.rs
+++ b/src/signed_duration.rs
@@ -117,8 +117,8 @@ use crate::util::libm::Float;
 /// to `i64::MAX`, which is less than `u64::MAX`.
 /// * There are some additional APIs that don't make sense on an unsigned
 /// duration, like [`SignedDuration::abs`] and [`SignedDuration::checked_neg`].
-/// * A [`SignedDuration::until`] routine is provided as a replacement for
-/// [`std::time::SystemTime::duration_since`], but with signed durations.
+/// * A [`SignedDuration::system_until`] routine is provided as a replacement
+/// for [`std::time::SystemTime::duration_since`], but with signed durations.
 /// * Constructors and getters for units of hours and minutes are provided,
 /// where as these routines are unstable in the standard library.
 /// * Unlike the standard library, this type implements the `std::fmt::Display`

--- a/src/signed_duration.rs
+++ b/src/signed_duration.rs
@@ -1,0 +1,1973 @@
+use core::time::Duration;
+
+use crate::{
+    error::{err, ErrorContext},
+    Error,
+};
+
+#[cfg(not(feature = "std"))]
+use crate::util::libm::Float;
+
+// BREADCRUMBS: Update relevant portions of crate documentation too.
+
+/// A signed duration of time represented as a 96-bit integer of nanoseconds.
+///
+/// Each duration is made up of a 64-bit integer of whole seconds and a
+/// 32-bit integer of fractional nanoseconds less than 1 whole second. Unlike
+/// [`std::time::Duration`], this duration is signed. The sign applies
+/// to the entire duration. That is, either _both_ the seconds and the
+/// fractional nanoseconds are negative or _neither_ are. Stated differently,
+/// it is guaranteed that the signs of [`SignedDuration::as_secs`] and
+/// [`SignedDuration::subsec_nanos`] are always the same.
+///
+/// # Parsing and printing
+///
+/// Like the [`Span`](crate::Span) type, the `SignedDuration` type
+/// provides convenient trait implementations of [`std::str::FromStr`] and
+/// [`std::fmt::Display`]:
+///
+/// ```
+/// use jiff::SignedDuration;
+///
+/// let duration: SignedDuration = "PT2h30m".parse()?;
+/// assert_eq!(duration.to_string(), "PT2h30m");
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+///
+/// Unlike the `Span` type, though, only uniform units are supported. This
+/// means that ISO 8601 durations with non-zero units of days or greater cannot
+/// be parsed directly into a `SignedDuration`:
+///
+/// ```
+/// use jiff::SignedDuration;
+///
+/// assert_eq!(
+///     "P1d".parse::<SignedDuration>().unwrap_err().to_string(),
+///     "failed to parse ISO 8601 duration string into `SignedDuration`: \
+///      parsing ISO 8601 duration into SignedDuration requires that the \
+///      duration contain a time component and no components of days or \
+///      greater",
+/// );
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+///
+/// To parse such durations, one should first parse them into a `Span` and
+/// then convert them to a `SignedDuration` by providing a relative date:
+///
+/// ```
+/// use jiff::{civil::date, SignedDuration, Span};
+///
+/// let span: Span = "P1d".parse()?;
+/// let relative = date(2024, 11, 3).intz("US/Eastern")?;
+/// let duration = span.to_jiff_duration(&relative)?;
+/// // This example also motivates *why* a relative date
+/// // is required. Not all days are the same length!
+/// assert_eq!(duration.to_string(), "PT25h");
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+///
+/// The format supported is a variation (nearly a subset) of the duration
+/// format specified in [ISO 8601]. Here are more examples:
+///
+/// ```
+/// use jiff::SignedDuration;
+///
+/// let durations = [
+///     ("PT2H30M", SignedDuration::from_secs(2 * 60 * 60 + 30 * 60)),
+///     ("PT2.5h", SignedDuration::from_secs(2 * 60 * 60 + 30 * 60)),
+///     ("PT1m", SignedDuration::from_mins(1)),
+///     ("PT1.5m", SignedDuration::from_secs(90)),
+///     ("PT0.0021s", SignedDuration::new(0, 2_100_000)),
+///     ("PT0s", SignedDuration::ZERO),
+///     ("PT0.000000001s", SignedDuration::from_nanos(1)),
+/// ];
+/// for (string, duration) in durations {
+///     let parsed: SignedDuration = string.parse()?;
+///     assert_eq!(duration, parsed, "result of parsing {string:?}");
+/// }
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+///
+/// For more details, see the [`fmt::temporal`](crate::fmt::temporal) module.
+///
+/// [ISO 8601]: https://www.iso.org/iso-8601-date-and-time-format.html
+///
+/// # API design
+///
+/// A `SignedDuration` is, as much as is possible, a replica of the
+/// `std::time::Duration` API. While there are probably some quirks in the API
+/// of `std::time::Duration` that could have been fixed here, it is probably
+/// more important that it behave "exactly like a `std::time::Duration` but
+/// with a sign." That is, this type mirrors the parallels between signed and
+/// unsigned integer types.
+///
+/// While the goal was to match the `std::time::Duration` API as much as
+/// possible, there are some differences worth highlighting:
+///
+/// * As stated, a `SignedDuration` has a sign. Therefore, it uses `i64` and
+/// `i32` instead of `u64` and `u32` to represent its 96-bit integer.
+/// * Because it's signed, the range of possible values is different. For
+/// example, a `SignedDuration::MAX` has a whole number of seconds equivalent
+/// to `i64::MAX`, which is less than `u64::MAX`.
+/// * There are some additional APIs that don't make sense on an unsigned
+/// duration, like [`SignedDuration::abs`] and [`SignedDuration::checked_neg`].
+/// * A [`SignedDuration::until`] routine is provided as a replacement for
+/// [`std::time::SystemTime::duration_since`], but with signed durations.
+/// * Constructors and getters for units of hours and minutes are provided,
+/// where as these routines are unstable in the standard library.
+/// * Unlike the standard library, this type implements the `std::fmt::Display`
+/// and `std::str::FromStr` traits via the ISO 8601 duration format, just
+/// like the [`Span`](crate::Span) type does. Also like `Span`, the ISO
+/// 8601 duration format is used to implement the serde `Serialize` and
+/// `Deserialize` traits when the `serde` crate feature is enabled.
+/// * The `std::fmt::Debug` trait implementation is a bit different. If you
+/// have a problem with it, please file an issue.
+/// * At present, there is no `SignedDuration::abs_diff` since there are some
+/// API design questions. If you want it, please file an issue.
+///
+/// # When should I use `SignedDuration` versus [`Span`](crate::Span)?
+///
+/// Jiff's primary duration type is `Span`. The key differences between it and
+/// `SignedDuration` are:
+///
+/// * A `Span` keeps track of each individual unit separately. That is, even
+/// though `1 hour 60 minutes` and `2 hours` are equivalent durations
+/// of time, representing each as a `Span` corresponds to two distinct values
+/// in memory. And serializing them to the ISO 8601 duration format will also
+/// preserve the units, for example, `PT1h60m` and `PT2h`.
+/// * A `Span` supports non-uniform units like days, weeks, months and years.
+/// Since not all days, weeks, months and years have the same length, they
+/// cannot be represented by a `SignedDuration`. In some cases, it may be
+/// appropriate, for example, to assume that all days are 24 hours long. But
+/// since Jiff sometimes assumes all days are 24 hours (for civil time) and
+/// sometimes doesn't (like for `Zoned` when respecting time zones), it would
+/// be inappropriate to bake one of those assumptions into a `SignedDuration`.
+/// * A `SignedDuration` is a much smaller type than a `Span`. Specifically,
+/// it's a 96-bit integer. In contrast, a `Span` is much larger since it needs
+/// to track each individual unit separately.
+///
+/// Those differences in turn motivate some approximate reasoning for when to
+/// use `Span` and when to use `SignedDuration`:
+///
+/// * If you don't care about keeping track of individual units separately or
+/// don't need the sophisticated rounding options available on a `Span`, it
+/// might be simpler and faster to use a `SignedDuration`.
+/// * If you specifically need performance on arithmetic operations involving
+/// datetimes and durations, even if it's not as convenient or correct, then it
+/// might make sense to use a `SignedDuration`.
+/// * If you need to perform arithmetic using a `std::time::Duration` and
+/// otherwise don't need the functionality of a `Span`, it might make sense
+/// to first convert the `std::time::Duration` to a `SignedDuration`, and then
+/// use one of the corresponding operations defined for `SignedDuration` on
+/// the datetime types. (They all support it.)
+///
+/// In general, a `Span` provides more functionality and is overall more
+/// flexible. A `Span` can also deserialize all forms of ISO 8601 durations
+/// (as long as they're within Jiff's limits), including durations with units
+/// of years, months, weeks and days. A `SignedDuration`, by contrast, only
+/// supports units up to and including hours.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct SignedDuration {
+    secs: i64,
+    nanos: i32,
+}
+
+const NANOS_PER_SEC: i32 = 1_000_000_000;
+const NANOS_PER_MILLI: i32 = 1_000_000;
+const NANOS_PER_MICRO: i32 = 1_000;
+const MILLIS_PER_SEC: i64 = 1_000;
+const MICROS_PER_SEC: i64 = 1_000_000;
+const SECS_PER_MINUTE: i64 = 60;
+const MINS_PER_HOUR: i64 = 60;
+
+impl SignedDuration {
+    /// A duration of zero time.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::ZERO;
+    /// assert!(duration.is_zero());
+    /// assert_eq!(duration.as_secs(), 0);
+    /// assert_eq!(duration.subsec_nanos(), 0);
+    /// ```
+    pub const ZERO: SignedDuration = SignedDuration { secs: 0, nanos: 0 };
+
+    /// The minimum possible duration. Or the "most negative" duration.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::MIN;
+    /// assert_eq!(duration.as_secs(), i64::MIN);
+    /// assert_eq!(duration.subsec_nanos(), -999_999_999);
+    /// ```
+    pub const MIN: SignedDuration =
+        SignedDuration { secs: i64::MIN, nanos: -(NANOS_PER_SEC - 1) };
+
+    /// The maximum possible duration.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::MAX;
+    /// assert_eq!(duration.as_secs(), i64::MAX);
+    /// assert_eq!(duration.subsec_nanos(), 999_999_999);
+    /// ```
+    pub const MAX: SignedDuration =
+        SignedDuration { secs: i64::MAX, nanos: NANOS_PER_SEC - 1 };
+
+    /// Creates a new `SignedDuration` from the given number of whole seconds
+    /// and additional nanoseconds.
+    ///
+    /// If the absolute value of the nanoseconds is greater than or equal to
+    /// 1 second, then the excess balances into the number of whole seconds.
+    ///
+    /// # Panics
+    ///
+    /// When the absolute value of the nanoseconds is greater than or equal
+    /// to 1 second and the excess that carries over to the number of whole
+    /// seconds overflows `i64`.
+    ///
+    /// This never panics when `nanos` is less than `1_000_000_000`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::new(12, 0);
+    /// assert_eq!(duration.as_secs(), 12);
+    /// assert_eq!(duration.subsec_nanos(), 0);
+    ///
+    /// let duration = SignedDuration::new(12, -1);
+    /// assert_eq!(duration.as_secs(), 11);
+    /// assert_eq!(duration.subsec_nanos(), 999_999_999);
+    ///
+    /// let duration = SignedDuration::new(12, 1_000_000_000);
+    /// assert_eq!(duration.as_secs(), 13);
+    /// assert_eq!(duration.subsec_nanos(), 0);
+    /// ```
+    #[inline]
+    pub const fn new(mut secs: i64, mut nanos: i32) -> SignedDuration {
+        // When |nanos| exceeds 1 second, we balance the excess up to seconds.
+        if !(-NANOS_PER_SEC < nanos && nanos < NANOS_PER_SEC) {
+            // Never wraps or panics because NANOS_PER_SEC!={0,-1}.
+            let addsecs = nanos / NANOS_PER_SEC;
+            secs = match secs.checked_add(addsecs as i64) {
+                Some(secs) => secs,
+                None => panic!(
+                    "nanoseconds overflowed seconds in SignedDuration::new"
+                ),
+            };
+            // Never wraps or panics because NANOS_PER_SEC!={0,-1}.
+            nanos = nanos % NANOS_PER_SEC;
+        }
+        // At this point, we're done if either unit is zero or if they have the
+        // same sign.
+        if nanos == 0 || secs == 0 || secs.signum() == (nanos.signum() as i64)
+        {
+            return SignedDuration { secs, nanos };
+        }
+        // Otherwise, the only work we have to do is to balance negative nanos
+        // into positive seconds, or positive nanos into negative seconds.
+        if secs < 0 {
+            debug_assert!(nanos > 0);
+            // Never wraps because adding +1 to a negative i64 never overflows.
+            //
+            // MSRV(1.79): Consider using `unchecked_add` here.
+            secs += 1;
+            // Never wraps because subtracting +1_000_000_000 from a positive
+            // i32 never overflows.
+            //
+            // MSRV(1.79): Consider using `unchecked_sub` here.
+            nanos -= NANOS_PER_SEC;
+        } else {
+            debug_assert!(secs > 0);
+            debug_assert!(nanos < 0);
+            // Never wraps because subtracting +1 from a positive i64 never
+            // overflows.
+            //
+            // MSRV(1.79): Consider using `unchecked_add` here.
+            secs -= 1;
+            // Never wraps because adding +1_000_000_000 to a negative i32
+            // never overflows.
+            //
+            // MSRV(1.79): Consider using `unchecked_add` here.
+            nanos += NANOS_PER_SEC;
+        }
+        SignedDuration { secs, nanos }
+    }
+
+    /// Creates a new `SignedDuration` from the given number of whole seconds.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::from_secs(12);
+    /// assert_eq!(duration.as_secs(), 12);
+    /// assert_eq!(duration.subsec_nanos(), 0);
+    /// ```
+    #[inline]
+    pub const fn from_secs(secs: i64) -> SignedDuration {
+        SignedDuration { secs, nanos: 0 }
+    }
+
+    /// Creates a new `SignedDuration` from the given number of whole
+    /// milliseconds.
+    ///
+    /// Note that since this accepts an `i64`, this method cannot be used
+    /// to construct the full range of possible signed duration values. In
+    /// particular, [`SignedDuration::as_millis`] returns an `i128`, and this
+    /// may be a value that would otherwise overflow an `i64`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::from_millis(12_456);
+    /// assert_eq!(duration.as_secs(), 12);
+    /// assert_eq!(duration.subsec_nanos(), 456_000_000);
+    ///
+    /// let duration = SignedDuration::from_millis(-12_456);
+    /// assert_eq!(duration.as_secs(), -12);
+    /// assert_eq!(duration.subsec_nanos(), -456_000_000);
+    /// ```
+    #[inline]
+    pub const fn from_millis(millis: i64) -> SignedDuration {
+        // OK because MILLIS_PER_SEC!={-1,0}.
+        let secs = millis / MILLIS_PER_SEC;
+        // OK because MILLIS_PER_SEC!={-1,0} and because
+        // millis % MILLIS_PER_SEC can be at most 999, and 999 * 1_000_000
+        // never overflows i32.
+        let nanos = (millis % MILLIS_PER_SEC) as i32 * NANOS_PER_MILLI;
+        SignedDuration { secs, nanos }
+    }
+
+    /// Creates a new `SignedDuration` from the given number of whole
+    /// microseconds.
+    ///
+    /// Note that since this accepts an `i64`, this method cannot be used
+    /// to construct the full range of possible signed duration values. In
+    /// particular, [`SignedDuration::as_micros`] returns an `i128`, and this
+    /// may be a value that would otherwise overflow an `i64`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::from_micros(12_000_456);
+    /// assert_eq!(duration.as_secs(), 12);
+    /// assert_eq!(duration.subsec_nanos(), 456_000);
+    ///
+    /// let duration = SignedDuration::from_micros(-12_000_456);
+    /// assert_eq!(duration.as_secs(), -12);
+    /// assert_eq!(duration.subsec_nanos(), -456_000);
+    /// ```
+    #[inline]
+    pub const fn from_micros(micros: i64) -> SignedDuration {
+        // OK because MICROS_PER_SEC!={-1,0}.
+        let secs = micros / MICROS_PER_SEC;
+        // OK because MICROS_PER_SEC!={-1,0} and because
+        // millis % MICROS_PER_SEC can be at most 999, and 999 * 1_000_000
+        // never overflows i32.
+        let nanos = (micros % MICROS_PER_SEC) as i32 * NANOS_PER_MICRO;
+        SignedDuration { secs, nanos }
+    }
+
+    /// Creates a new `SignedDuration` from the given number of whole
+    /// nanoseconds.
+    ///
+    /// Note that since this accepts an `i64`, this method cannot be used
+    /// to construct the full range of possible signed duration values. In
+    /// particular, [`SignedDuration::as_nanos`] returns an `i128`, and this
+    /// may be a value that would otherwise overflow an `i64`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::from_nanos(12_000_000_456);
+    /// assert_eq!(duration.as_secs(), 12);
+    /// assert_eq!(duration.subsec_nanos(), 456);
+    ///
+    /// let duration = SignedDuration::from_nanos(-12_000_000_456);
+    /// assert_eq!(duration.as_secs(), -12);
+    /// assert_eq!(duration.subsec_nanos(), -456);
+    /// ```
+    #[inline]
+    pub const fn from_nanos(nanos: i64) -> SignedDuration {
+        // OK because NANOS_PER_SEC!={-1,0}.
+        let secs = nanos / (NANOS_PER_SEC as i64);
+        // OK because NANOS_PER_SEC!={-1,0}.
+        let nanos = (nanos % (NANOS_PER_SEC as i64)) as i32;
+        SignedDuration { secs, nanos }
+    }
+
+    /// Creates a new `SignedDuration` from the given number of hours. Every
+    /// hour is exactly `3,600` seconds.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of hours, after being converted to nanoseconds,
+    /// overflows the minimum or maximum `SignedDuration` values.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::from_hours(24);
+    /// assert_eq!(duration.as_secs(), 86_400);
+    /// assert_eq!(duration.subsec_nanos(), 0);
+    ///
+    /// let duration = SignedDuration::from_hours(-24);
+    /// assert_eq!(duration.as_secs(), -86_400);
+    /// assert_eq!(duration.subsec_nanos(), 0);
+    /// ```
+    #[inline]
+    pub const fn from_hours(hours: i64) -> SignedDuration {
+        // OK because (SECS_PER_MINUTE*MINS_PER_HOUR)!={-1,0}.
+        const MIN_HOUR: i64 = i64::MIN / (SECS_PER_MINUTE * MINS_PER_HOUR);
+        // OK because (SECS_PER_MINUTE*MINS_PER_HOUR)!={-1,0}.
+        const MAX_HOUR: i64 = i64::MAX / (SECS_PER_MINUTE * MINS_PER_HOUR);
+        // OK because (SECS_PER_MINUTE*MINS_PER_HOUR)!={-1,0}.
+        if hours < MIN_HOUR {
+            panic!("hours overflowed minimum number of SignedDuration seconds")
+        }
+        // OK because (SECS_PER_MINUTE*MINS_PER_HOUR)!={-1,0}.
+        if hours > MAX_HOUR {
+            panic!("hours overflowed maximum number of SignedDuration seconds")
+        }
+        SignedDuration::from_secs(hours * MINS_PER_HOUR * SECS_PER_MINUTE)
+    }
+
+    /// Creates a new `SignedDuration` from the given number of minutes. Every
+    /// minute is exactly `60` seconds.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of minutes, after being converted to nanoseconds,
+    /// overflows the minimum or maximum `SignedDuration` values.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::from_mins(1_440);
+    /// assert_eq!(duration.as_secs(), 86_400);
+    /// assert_eq!(duration.subsec_nanos(), 0);
+    ///
+    /// let duration = SignedDuration::from_mins(-1_440);
+    /// assert_eq!(duration.as_secs(), -86_400);
+    /// assert_eq!(duration.subsec_nanos(), 0);
+    /// ```
+    #[inline]
+    pub const fn from_mins(minutes: i64) -> SignedDuration {
+        // OK because SECS_PER_MINUTE!={-1,0}.
+        const MIN_MINUTE: i64 = i64::MIN / SECS_PER_MINUTE;
+        // OK because SECS_PER_MINUTE!={-1,0}.
+        const MAX_MINUTE: i64 = i64::MAX / SECS_PER_MINUTE;
+        // OK because SECS_PER_MINUTE!={-1,0}.
+        if minutes < MIN_MINUTE {
+            panic!(
+                "minutes overflowed minimum number of SignedDuration seconds"
+            )
+        }
+        // OK because SECS_PER_MINUTE!={-1,0}.
+        if minutes > MAX_MINUTE {
+            panic!(
+                "minutes overflowed maximum number of SignedDuration seconds"
+            )
+        }
+        SignedDuration::from_secs(minutes * SECS_PER_MINUTE)
+    }
+
+    /// Returns true if this duration spans no time.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// assert!(SignedDuration::ZERO.is_zero());
+    /// assert!(!SignedDuration::MIN.is_zero());
+    /// assert!(!SignedDuration::MAX.is_zero());
+    /// ```
+    #[inline]
+    pub const fn is_zero(&self) -> bool {
+        self.secs == 0 && self.nanos == 0
+    }
+
+    /// Returns the number of whole seconds in this duration.
+    ///
+    /// The value returned is negative when the duration is negative.
+    ///
+    /// This does not include any fractional component corresponding to units
+    /// less than a second. To access those, use one of the `subsec` methods
+    /// such as [`SignedDuration::subsec_nanos`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::new(12, 999_999_999);
+    /// assert_eq!(duration.as_secs(), 12);
+    ///
+    /// let duration = SignedDuration::new(-12, -999_999_999);
+    /// assert_eq!(duration.as_secs(), -12);
+    /// ```
+    #[inline]
+    pub const fn as_secs(&self) -> i64 {
+        self.secs
+    }
+
+    /// Returns the fractional part of this duration in whole milliseconds.
+    ///
+    /// The value returned is negative when the duration is negative. It is
+    /// guaranteed that the range of the value returned is in the inclusive
+    /// range `-999..=999`.
+    ///
+    /// To get the length of the total duration represented in milliseconds,
+    /// use [`SignedDuration::as_millis`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::new(12, 123_456_789);
+    /// assert_eq!(duration.subsec_millis(), 123);
+    ///
+    /// let duration = SignedDuration::new(-12, -123_456_789);
+    /// assert_eq!(duration.subsec_millis(), -123);
+    /// ```
+    #[inline]
+    pub const fn subsec_millis(&self) -> i32 {
+        // OK because NANOS_PER_MILLI!={-1,0}.
+        self.nanos / NANOS_PER_MILLI
+    }
+
+    /// Returns the fractional part of this duration in whole microseconds.
+    ///
+    /// The value returned is negative when the duration is negative. It is
+    /// guaranteed that the range of the value returned is in the inclusive
+    /// range `-999_999..=999_999`.
+    ///
+    /// To get the length of the total duration represented in microseconds,
+    /// use [`SignedDuration::as_micros`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::new(12, 123_456_789);
+    /// assert_eq!(duration.subsec_micros(), 123_456);
+    ///
+    /// let duration = SignedDuration::new(-12, -123_456_789);
+    /// assert_eq!(duration.subsec_micros(), -123_456);
+    /// ```
+    #[inline]
+    pub const fn subsec_micros(&self) -> i32 {
+        // OK because NANOS_PER_MICRO!={-1,0}.
+        self.nanos / NANOS_PER_MICRO
+    }
+
+    /// Returns the fractional part of this duration in whole nanoseconds.
+    ///
+    /// The value returned is negative when the duration is negative. It is
+    /// guaranteed that the range of the value returned is in the inclusive
+    /// range `-999_999_999..=999_999_999`.
+    ///
+    /// To get the length of the total duration represented in nanoseconds,
+    /// use [`SignedDuration::as_nanos`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::new(12, 123_456_789);
+    /// assert_eq!(duration.subsec_nanos(), 123_456_789);
+    ///
+    /// let duration = SignedDuration::new(-12, -123_456_789);
+    /// assert_eq!(duration.subsec_nanos(), -123_456_789);
+    /// ```
+    #[inline]
+    pub const fn subsec_nanos(&self) -> i32 {
+        self.nanos
+    }
+
+    /// Returns the total duration in units of whole milliseconds.
+    ///
+    /// The value returned is negative when the duration is negative.
+    ///
+    /// To get only the fractional component of this duration in units of
+    /// whole milliseconds, use [`SignedDuration::subsec_millis`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::new(12, 123_456_789);
+    /// assert_eq!(duration.as_millis(), 12_123);
+    ///
+    /// let duration = SignedDuration::new(-12, -123_456_789);
+    /// assert_eq!(duration.as_millis(), -12_123);
+    /// ```
+    #[inline]
+    pub const fn as_millis(&self) -> i128 {
+        // OK because 1_000 times any i64 will never overflow i128.
+        let millis = (self.secs as i128) * (MILLIS_PER_SEC as i128);
+        // OK because NANOS_PER_MILLI!={-1,0}.
+        let subsec_millis = (self.nanos / NANOS_PER_MILLI) as i128;
+        // OK because subsec_millis maxes out at 999, and adding that to
+        // i64::MAX*1_000 will never overflow a i128.
+        millis + subsec_millis
+    }
+
+    /// Returns the total duration in units of whole microseconds.
+    ///
+    /// The value returned is negative when the duration is negative.
+    ///
+    /// To get only the fractional component of this duration in units of
+    /// whole microseconds, use [`SignedDuration::subsec_micros`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::new(12, 123_456_789);
+    /// assert_eq!(duration.as_micros(), 12_123_456);
+    ///
+    /// let duration = SignedDuration::new(-12, -123_456_789);
+    /// assert_eq!(duration.as_micros(), -12_123_456);
+    /// ```
+    #[inline]
+    pub const fn as_micros(&self) -> i128 {
+        // OK because 1_000_000 times any i64 will never overflow i128.
+        let micros = (self.secs as i128) * (MICROS_PER_SEC as i128);
+        // OK because NANOS_PER_MICRO!={-1,0}.
+        let subsec_micros = (self.nanos / NANOS_PER_MICRO) as i128;
+        // OK because subsec_micros maxes out at 999_999, and adding that to
+        // i64::MAX*1_000_000 will never overflow a i128.
+        micros + subsec_micros
+    }
+
+    /// Returns the total duration in units of whole nanoseconds.
+    ///
+    /// The value returned is negative when the duration is negative.
+    ///
+    /// To get only the fractional component of this duration in units of
+    /// whole nanoseconds, use [`SignedDuration::subsec_nanos`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::new(12, 123_456_789);
+    /// assert_eq!(duration.as_nanos(), 12_123_456_789);
+    ///
+    /// let duration = SignedDuration::new(-12, -123_456_789);
+    /// assert_eq!(duration.as_nanos(), -12_123_456_789);
+    /// ```
+    #[inline]
+    pub const fn as_nanos(&self) -> i128 {
+        // OK because 1_000_000_000 times any i64 will never overflow i128.
+        let nanos = (self.secs as i128) * (NANOS_PER_SEC as i128);
+        // OK because subsec_nanos maxes out at 999_999_999, and adding that to
+        // i64::MAX*1_000_000_000 will never overflow a i128.
+        nanos + (self.nanos as i128)
+    }
+
+    // NOTE: We don't provide `abs_diff` here because we can't represent the
+    // difference between all possible durations. For example,
+    // `abs_diff(SignedDuration::MAX, SignedDuration::MIN)`. It therefore seems
+    // like we should actually return a `std::time::Duration` here, but I'm
+    // trying to be conservative when divering from std.
+
+    /// Add two signed durations together. If overflow occurs, then `None` is
+    /// returned.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration1 = SignedDuration::new(12, 500_000_000);
+    /// let duration2 = SignedDuration::new(0, 500_000_000);
+    /// assert_eq!(
+    ///     duration1.checked_add(duration2),
+    ///     Some(SignedDuration::new(13, 0)),
+    /// );
+    ///
+    /// let duration1 = SignedDuration::MAX;
+    /// let duration2 = SignedDuration::new(0, 1);
+    /// assert_eq!(duration1.checked_add(duration2), None);
+    /// ```
+    #[inline]
+    pub const fn checked_add(
+        self,
+        rhs: SignedDuration,
+    ) -> Option<SignedDuration> {
+        let Some(mut secs) = self.secs.checked_add(rhs.secs) else {
+            return None;
+        };
+        // OK because `-999_999_999 <= nanos <= 999_999_999`, and so adding
+        // them together will never overflow an i32.
+        let mut nanos = self.nanos + rhs.nanos;
+        // The below is effectively SignedDuration::new, but with checked
+        // arithmetic. My suspicion is that there is probably a better way
+        // to do this. The main complexity here is that 1) `|nanos|` might
+        // now exceed 1 second and 2) the signs of `secs` and `nanos` might
+        // not be the same. The other difference from SignedDuration::new is
+        // that we know that `-1_999_999_998 <= nanos <= 1_999_999_998` since
+        // `|SignedDuration::nanos|` is guaranteed to be less than 1 second. So
+        // we can skip the div and modulus operations.
+
+        // When |nanos| exceeds 1 second, we balance the excess up to seconds.
+        if nanos >= NANOS_PER_SEC {
+            nanos -= NANOS_PER_SEC;
+            secs = match secs.checked_add(1) {
+                None => return None,
+                Some(secs) => secs,
+            };
+        } else if nanos <= -NANOS_PER_SEC {
+            nanos += NANOS_PER_SEC;
+            secs = match secs.checked_sub(1) {
+                None => return None,
+                Some(secs) => secs,
+            };
+        }
+        if secs != 0 && nanos != 0 && secs.signum() != (nanos.signum() as i64)
+        {
+            if secs < 0 {
+                debug_assert!(nanos > 0);
+                // OK because secs<0.
+                secs += 1;
+                // OK because nanos>0.
+                nanos -= NANOS_PER_SEC;
+            } else {
+                debug_assert!(secs > 0);
+                debug_assert!(nanos < 0);
+                // OK because secs>0.
+                secs -= 1;
+                // OK because nanos<0.
+                nanos += NANOS_PER_SEC;
+            }
+        }
+        Some(SignedDuration { secs, nanos })
+    }
+
+    /// Add two signed durations together. If overflow occurs, then arithmetic
+    /// saturates.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration1 = SignedDuration::MAX;
+    /// let duration2 = SignedDuration::new(0, 1);
+    /// assert_eq!(duration1.saturating_add(duration2), SignedDuration::MAX);
+    ///
+    /// let duration1 = SignedDuration::MIN;
+    /// let duration2 = SignedDuration::new(0, -1);
+    /// assert_eq!(duration1.saturating_add(duration2), SignedDuration::MIN);
+    /// ```
+    #[inline]
+    pub const fn saturating_add(self, rhs: SignedDuration) -> SignedDuration {
+        let Some(sum) = self.checked_add(rhs) else {
+            return if rhs.is_negative() {
+                SignedDuration::MIN
+            } else {
+                SignedDuration::MAX
+            };
+        };
+        sum
+    }
+
+    /// Subtract one signed duration from another. If overflow occurs, then
+    /// `None` is returned.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration1 = SignedDuration::new(12, 500_000_000);
+    /// let duration2 = SignedDuration::new(0, 500_000_000);
+    /// assert_eq!(
+    ///     duration1.checked_sub(duration2),
+    ///     Some(SignedDuration::new(12, 0)),
+    /// );
+    ///
+    /// let duration1 = SignedDuration::MIN;
+    /// let duration2 = SignedDuration::new(0, 1);
+    /// assert_eq!(duration1.checked_sub(duration2), None);
+    /// ```
+    #[inline]
+    pub const fn checked_sub(
+        self,
+        rhs: SignedDuration,
+    ) -> Option<SignedDuration> {
+        let Some(rhs) = rhs.checked_neg() else { return None };
+        self.checked_add(rhs)
+    }
+
+    /// Add two signed durations together. If overflow occurs, then arithmetic
+    /// saturates.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration1 = SignedDuration::MAX;
+    /// let duration2 = SignedDuration::new(0, -1);
+    /// assert_eq!(duration1.saturating_sub(duration2), SignedDuration::MAX);
+    ///
+    /// let duration1 = SignedDuration::MIN;
+    /// let duration2 = SignedDuration::new(0, 1);
+    /// assert_eq!(duration1.saturating_sub(duration2), SignedDuration::MIN);
+    /// ```
+    #[inline]
+    pub const fn saturating_sub(self, rhs: SignedDuration) -> SignedDuration {
+        let Some(diff) = self.checked_sub(rhs) else {
+            return if rhs.is_positive() {
+                SignedDuration::MIN
+            } else {
+                SignedDuration::MAX
+            };
+        };
+        diff
+    }
+
+    /// Multiply this signed duration by an integer. If the multiplication
+    /// overflows, then `None` is returned.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::new(12, 500_000_000);
+    /// assert_eq!(
+    ///     duration.checked_mul(2),
+    ///     Some(SignedDuration::new(25, 0)),
+    /// );
+    /// ```
+    #[inline]
+    pub const fn checked_mul(self, rhs: i32) -> Option<SignedDuration> {
+        let rhs = rhs as i64;
+        // Multiplying any two i32 values never overflows an i64.
+        let nanos = (self.nanos as i64) * rhs;
+        // OK since NANOS_PER_SEC!={-1,0}.
+        let addsecs = nanos / (NANOS_PER_SEC as i64);
+        // OK since NANOS_PER_SEC!={-1,0}.
+        let nanos = (nanos % (NANOS_PER_SEC as i64)) as i32;
+        let Some(secs) = self.secs.checked_mul(rhs) else { return None };
+        let Some(secs) = secs.checked_add(addsecs) else { return None };
+        Some(SignedDuration { secs, nanos })
+    }
+
+    /// Multiply this signed duration by an integer. If the multiplication
+    /// overflows, then the result saturates to either the minimum or maximum
+    /// duration depending on the sign of the product.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::new(i64::MAX, 0);
+    /// assert_eq!(duration.saturating_mul(2), SignedDuration::MAX);
+    /// assert_eq!(duration.saturating_mul(-2), SignedDuration::MIN);
+    ///
+    /// let duration = SignedDuration::new(i64::MIN, 0);
+    /// assert_eq!(duration.saturating_mul(2), SignedDuration::MIN);
+    /// assert_eq!(duration.saturating_mul(-2), SignedDuration::MAX);
+    /// ```
+    #[inline]
+    pub const fn saturating_mul(self, rhs: i32) -> SignedDuration {
+        let Some(product) = self.checked_mul(rhs) else {
+            let sign = (self.signum() as i64) * (rhs as i64).signum();
+            return if sign.is_negative() {
+                SignedDuration::MIN
+            } else {
+                SignedDuration::MAX
+            };
+        };
+        product
+    }
+
+    /// Divide this duration by an integer. If the division overflows, then
+    /// `None` is returned.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::new(12, 500_000_000);
+    /// assert_eq!(
+    ///     duration.checked_div(2),
+    ///     Some(SignedDuration::new(6, 250_000_000)),
+    /// );
+    /// assert_eq!(
+    ///     duration.checked_div(-2),
+    ///     Some(SignedDuration::new(-6, -250_000_000)),
+    /// );
+    ///
+    /// let duration = SignedDuration::new(-12, -500_000_000);
+    /// assert_eq!(
+    ///     duration.checked_div(2),
+    ///     Some(SignedDuration::new(-6, -250_000_000)),
+    /// );
+    /// assert_eq!(
+    ///     duration.checked_div(-2),
+    ///     Some(SignedDuration::new(6, 250_000_000)),
+    /// );
+    /// ```
+    #[inline]
+    pub const fn checked_div(self, rhs: i32) -> Option<SignedDuration> {
+        if rhs == 0 || (self.secs == i64::MIN && rhs == -1) {
+            return None;
+        }
+        // OK since rhs!={-1,0}.
+        let secs = self.secs / (rhs as i64);
+        // OK since rhs!={-1,0}.
+        let addsecs = self.secs % (rhs as i64);
+        // OK since rhs!=0 and self.nanos>i32::MIN.
+        let mut nanos = self.nanos / rhs;
+        // OK since rhs!=0 and self.nanos>i32::MIN.
+        let addnanos = self.nanos % rhs;
+        let leftover_nanos =
+            (addsecs * (NANOS_PER_SEC as i64)) + (addnanos as i64);
+        nanos += (leftover_nanos / (rhs as i64)) as i32;
+        debug_assert!(nanos < NANOS_PER_SEC);
+        Some(SignedDuration { secs, nanos })
+    }
+
+    /// Returns the number of seconds, with a possible fractional nanosecond
+    /// component, represented by this signed duration as a 64-bit float.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::new(12, 123_456_789);
+    /// assert_eq!(duration.as_secs_f64(), 12.123456789);
+    ///
+    /// let duration = SignedDuration::new(-12, -123_456_789);
+    /// assert_eq!(duration.as_secs_f64(), -12.123456789);
+    /// ```
+    #[inline]
+    pub fn as_secs_f64(&self) -> f64 {
+        (self.secs as f64) + ((self.nanos as f64) / (NANOS_PER_SEC as f64))
+    }
+
+    /// Returns the number of seconds, with a possible fractional nanosecond
+    /// component, represented by this signed duration as a 32-bit float.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::new(12, 123_456_789);
+    /// assert_eq!(duration.as_secs_f32(), 12.123456789);
+    ///
+    /// let duration = SignedDuration::new(-12, -123_456_789);
+    /// assert_eq!(duration.as_secs_f32(), -12.123456789);
+    /// ```
+    #[inline]
+    pub fn as_secs_f32(&self) -> f32 {
+        (self.secs as f32) + ((self.nanos as f32) / (NANOS_PER_SEC as f32))
+    }
+
+    /// Returns the number of milliseconds, with a possible fractional
+    /// nanosecond component, represented by this signed duration as a 64-bit
+    /// float.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::new(12, 123_456_789);
+    /// assert_eq!(duration.as_millis_f64(), 12123.456789);
+    ///
+    /// let duration = SignedDuration::new(-12, -123_456_789);
+    /// assert_eq!(duration.as_millis_f64(), -12123.456789);
+    /// ```
+    #[inline]
+    pub fn as_millis_f64(&self) -> f64 {
+        ((self.secs as f64) * (MILLIS_PER_SEC as f64))
+            + ((self.nanos as f64) / (NANOS_PER_MILLI as f64))
+    }
+
+    /// Returns the number of milliseconds, with a possible fractional
+    /// nanosecond component, represented by this signed duration as a 32-bit
+    /// float.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::new(12, 123_456_789);
+    /// assert_eq!(duration.as_millis_f32(), 12123.456789);
+    ///
+    /// let duration = SignedDuration::new(-12, -123_456_789);
+    /// assert_eq!(duration.as_millis_f32(), -12123.456789);
+    /// ```
+    #[inline]
+    pub fn as_millis_f32(&self) -> f32 {
+        ((self.secs as f32) * (MILLIS_PER_SEC as f32))
+            + ((self.nanos as f32) / (NANOS_PER_MILLI as f32))
+    }
+
+    /// Returns a signed duration corresponding to the number of seconds
+    /// represented as a 64-bit float. The number given may have a fractional
+    /// nanosecond component.
+    ///
+    /// # Panics
+    ///
+    /// If the given float overflows the minimum or maximum signed duration
+    /// values, then this panics.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::from_secs_f64(12.123456789);
+    /// assert_eq!(duration.as_secs(), 12);
+    /// assert_eq!(duration.subsec_nanos(), 123_456_789);
+    ///
+    /// let duration = SignedDuration::from_secs_f64(-12.123456789);
+    /// assert_eq!(duration.as_secs(), -12);
+    /// assert_eq!(duration.subsec_nanos(), -123_456_789);
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[inline]
+    pub fn from_secs_f64(secs: f64) -> SignedDuration {
+        SignedDuration::try_from_secs_f64(secs)
+            .expect("finite and in-bounds f64")
+    }
+
+    /// Returns a signed duration corresponding to the number of seconds
+    /// represented as a 32-bit float. The number given may have a fractional
+    /// nanosecond component.
+    ///
+    /// # Panics
+    ///
+    /// If the given float overflows the minimum or maximum signed duration
+    /// values, then this panics.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::from_secs_f32(12.123456789);
+    /// assert_eq!(duration.as_secs(), 12);
+    /// // loss of precision!
+    /// assert_eq!(duration.subsec_nanos(), 123_456_952);
+    ///
+    /// let duration = SignedDuration::from_secs_f32(-12.123456789);
+    /// assert_eq!(duration.as_secs(), -12);
+    /// // loss of precision!
+    /// assert_eq!(duration.subsec_nanos(), -123_456_952);
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[inline]
+    pub fn from_secs_f32(secs: f32) -> SignedDuration {
+        SignedDuration::try_from_secs_f32(secs)
+            .expect("finite and in-bounds f32")
+    }
+
+    /// Returns a signed duration corresponding to the number of seconds
+    /// represented as a 64-bit float. The number given may have a fractional
+    /// nanosecond component.
+    ///
+    /// If the given float overflows the minimum or maximum signed duration
+    /// values, then an error is returned.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::try_from_secs_f64(12.123456789)?;
+    /// assert_eq!(duration.as_secs(), 12);
+    /// assert_eq!(duration.subsec_nanos(), 123_456_789);
+    ///
+    /// let duration = SignedDuration::try_from_secs_f64(-12.123456789)?;
+    /// assert_eq!(duration.as_secs(), -12);
+    /// assert_eq!(duration.subsec_nanos(), -123_456_789);
+    ///
+    /// assert!(SignedDuration::try_from_secs_f64(f64::NAN).is_err());
+    /// assert!(SignedDuration::try_from_secs_f64(f64::INFINITY).is_err());
+    /// assert!(SignedDuration::try_from_secs_f64(f64::NEG_INFINITY).is_err());
+    /// assert!(SignedDuration::try_from_secs_f64(f64::MIN).is_err());
+    /// assert!(SignedDuration::try_from_secs_f64(f64::MAX).is_err());
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[inline]
+    pub fn try_from_secs_f64(secs: f64) -> Result<SignedDuration, Error> {
+        if !secs.is_finite() {
+            return Err(err!(
+                "could not convert non-finite seconds \
+                 {secs} to signed duration",
+            ));
+        }
+        if secs < (i64::MIN as f64) {
+            return Err(err!(
+                "floating point seconds {secs} overflows signed duration \
+                 minimum value of {:?}",
+                SignedDuration::MIN,
+            ));
+        }
+        if secs > (i64::MAX as f64) {
+            return Err(err!(
+                "floating point seconds {secs} overflows signed duration \
+                 maximum value of {:?}",
+                SignedDuration::MAX,
+            ));
+        }
+        let nanos = (secs.fract() * (NANOS_PER_SEC as f64)).round() as i32;
+        let secs = secs.trunc() as i64;
+        Ok(SignedDuration { secs, nanos })
+    }
+
+    /// Returns a signed duration corresponding to the number of seconds
+    /// represented as a 32-bit float. The number given may have a fractional
+    /// nanosecond component.
+    ///
+    /// If the given float overflows the minimum or maximum signed duration
+    /// values, then an error is returned.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::try_from_secs_f32(12.123456789)?;
+    /// assert_eq!(duration.as_secs(), 12);
+    /// // loss of precision!
+    /// assert_eq!(duration.subsec_nanos(), 123_456_952);
+    ///
+    /// let duration = SignedDuration::try_from_secs_f32(-12.123456789)?;
+    /// assert_eq!(duration.as_secs(), -12);
+    /// // loss of precision!
+    /// assert_eq!(duration.subsec_nanos(), -123_456_952);
+    ///
+    /// assert!(SignedDuration::try_from_secs_f32(f32::NAN).is_err());
+    /// assert!(SignedDuration::try_from_secs_f32(f32::INFINITY).is_err());
+    /// assert!(SignedDuration::try_from_secs_f32(f32::NEG_INFINITY).is_err());
+    /// assert!(SignedDuration::try_from_secs_f32(f32::MIN).is_err());
+    /// assert!(SignedDuration::try_from_secs_f32(f32::MAX).is_err());
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[inline]
+    pub fn try_from_secs_f32(secs: f32) -> Result<SignedDuration, Error> {
+        if !secs.is_finite() {
+            return Err(err!(
+                "could not convert non-finite seconds \
+                 {secs} to signed duration",
+            ));
+        }
+        if secs < (i64::MIN as f32) {
+            return Err(err!(
+                "floating point seconds {secs} overflows signed duration \
+                 minimum value of {:?}",
+                SignedDuration::MIN,
+            ));
+        }
+        if secs > (i64::MAX as f32) {
+            return Err(err!(
+                "floating point seconds {secs} overflows signed duration \
+                 maximum value of {:?}",
+                SignedDuration::MAX,
+            ));
+        }
+        let nanos = (secs.fract() * (NANOS_PER_SEC as f32)).round() as i32;
+        let secs = secs.trunc() as i64;
+        Ok(SignedDuration { secs, nanos })
+    }
+
+    /// Returns the result of multiplying this duration by the given 64-bit
+    /// float.
+    ///
+    /// # Panics
+    ///
+    /// This panics if the result is not finite or overflows a
+    /// `SignedDuration`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::new(12, 300_000_000);
+    /// assert_eq!(
+    ///     duration.mul_f64(2.0),
+    ///     SignedDuration::new(24, 600_000_000),
+    /// );
+    /// assert_eq!(
+    ///     duration.mul_f64(-2.0),
+    ///     SignedDuration::new(-24, -600_000_000),
+    /// );
+    /// ```
+    #[inline]
+    pub fn mul_f64(self, rhs: f64) -> SignedDuration {
+        SignedDuration::from_secs_f64(rhs * self.as_secs_f64())
+    }
+
+    /// Returns the result of multiplying this duration by the given 32-bit
+    /// float.
+    ///
+    /// # Panics
+    ///
+    /// This panics if the result is not finite or overflows a
+    /// `SignedDuration`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::new(12, 300_000_000);
+    /// assert_eq!(
+    ///     duration.mul_f32(2.0),
+    ///     // loss of precision!
+    ///     SignedDuration::new(24, 600_000_384),
+    /// );
+    /// assert_eq!(
+    ///     duration.mul_f32(-2.0),
+    ///     // loss of precision!
+    ///     SignedDuration::new(-24, -600_000_384),
+    /// );
+    /// ```
+    #[inline]
+    pub fn mul_f32(self, rhs: f32) -> SignedDuration {
+        SignedDuration::from_secs_f32(rhs * self.as_secs_f32())
+    }
+
+    /// Returns the result of dividing this duration by the given 64-bit
+    /// float.
+    ///
+    /// # Panics
+    ///
+    /// This panics if the result is not finite or overflows a
+    /// `SignedDuration`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::new(12, 300_000_000);
+    /// assert_eq!(
+    ///     duration.div_f64(2.0),
+    ///     SignedDuration::new(6, 150_000_000),
+    /// );
+    /// assert_eq!(
+    ///     duration.div_f64(-2.0),
+    ///     SignedDuration::new(-6, -150_000_000),
+    /// );
+    /// ```
+    #[inline]
+    pub fn div_f64(self, rhs: f64) -> SignedDuration {
+        SignedDuration::from_secs_f64(self.as_secs_f64() / rhs)
+    }
+
+    /// Returns the result of dividing this duration by the given 32-bit
+    /// float.
+    ///
+    /// # Panics
+    ///
+    /// This panics if the result is not finite or overflows a
+    /// `SignedDuration`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::new(12, 300_000_000);
+    /// assert_eq!(
+    ///     duration.div_f32(2.0),
+    ///     // loss of precision!
+    ///     SignedDuration::new(6, 150_000_096),
+    /// );
+    /// assert_eq!(
+    ///     duration.div_f32(-2.0),
+    ///     // loss of precision!
+    ///     SignedDuration::new(-6, -150_000_096),
+    /// );
+    /// ```
+    #[inline]
+    pub fn div_f32(self, rhs: f32) -> SignedDuration {
+        SignedDuration::from_secs_f32(self.as_secs_f32() / rhs)
+    }
+
+    /// Divides this signed duration by another signed duration and returns the
+    /// corresponding 64-bit float result.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration1 = SignedDuration::new(12, 600_000_000);
+    /// let duration2 = SignedDuration::new(6, 300_000_000);
+    /// assert_eq!(duration1.div_duration_f64(duration2), 2.0);
+    ///
+    /// let duration1 = SignedDuration::new(-12, -600_000_000);
+    /// let duration2 = SignedDuration::new(6, 300_000_000);
+    /// assert_eq!(duration1.div_duration_f64(duration2), -2.0);
+    ///
+    /// let duration1 = SignedDuration::new(-12, -600_000_000);
+    /// let duration2 = SignedDuration::new(-6, -300_000_000);
+    /// assert_eq!(duration1.div_duration_f64(duration2), 2.0);
+    /// ```
+    #[inline]
+    pub fn div_duration_f64(self, rhs: SignedDuration) -> f64 {
+        let lhs_nanos =
+            (self.secs as f64) * (NANOS_PER_SEC as f64) + (self.nanos as f64);
+        let rhs_nanos =
+            (rhs.secs as f64) * (NANOS_PER_SEC as f64) + (rhs.nanos as f64);
+        lhs_nanos / rhs_nanos
+    }
+
+    /// Divides this signed duration by another signed duration and returns the
+    /// corresponding 32-bit float result.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration1 = SignedDuration::new(12, 600_000_000);
+    /// let duration2 = SignedDuration::new(6, 300_000_000);
+    /// assert_eq!(duration1.div_duration_f32(duration2), 2.0);
+    ///
+    /// let duration1 = SignedDuration::new(-12, -600_000_000);
+    /// let duration2 = SignedDuration::new(6, 300_000_000);
+    /// assert_eq!(duration1.div_duration_f32(duration2), -2.0);
+    ///
+    /// let duration1 = SignedDuration::new(-12, -600_000_000);
+    /// let duration2 = SignedDuration::new(-6, -300_000_000);
+    /// assert_eq!(duration1.div_duration_f32(duration2), 2.0);
+    /// ```
+    #[inline]
+    pub fn div_duration_f32(self, rhs: SignedDuration) -> f32 {
+        let lhs_nanos =
+            (self.secs as f32) * (NANOS_PER_SEC as f32) + (self.nanos as f32);
+        let rhs_nanos =
+            (rhs.secs as f32) * (NANOS_PER_SEC as f32) + (rhs.nanos as f32);
+        lhs_nanos / rhs_nanos
+    }
+}
+
+/// Additional APIs not found in the standard library.
+///
+/// In most cases, these APIs exist as a result of the fact that this duration
+/// is signed.
+impl SignedDuration {
+    /// Returns the duration from `time1` until `time2`.
+    ///
+    /// # Errors
+    ///
+    /// This returns an error if the difference between the two time values
+    /// overflows the signed duration limits.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::time::{Duration, SystemTime};
+    /// use jiff::SignedDuration;
+    ///
+    /// let time1 = SystemTime::UNIX_EPOCH;
+    /// let time2 = time1.checked_add(Duration::from_secs(86_400)).unwrap();
+    /// assert_eq!(
+    ///     SignedDuration::until(time1, time2)?,
+    ///     SignedDuration::from_hours(24),
+    /// );
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[cfg(feature = "std")]
+    #[inline]
+    pub fn until(
+        time1: std::time::SystemTime,
+        time2: std::time::SystemTime,
+    ) -> Result<SignedDuration, Error> {
+        match time2.duration_since(time1) {
+            Ok(dur) => SignedDuration::try_from(dur).with_context(|| {
+                err!(
+                    "unsigned duration {dur:?} for system time since \
+                     Unix epoch overflowed signed duration"
+                )
+            }),
+            Err(err) => {
+                let dur = err.duration();
+                let dur =
+                    SignedDuration::try_from(dur).with_context(|| {
+                        err!(
+                        "unsigned duration {dur:?} for system time before \
+                         Unix epoch overflowed signed duration"
+                    )
+                    })?;
+                dur.checked_neg().ok_or_else(|| {
+                    err!("negating duration {dur:?} from before the Unix epoch \
+                     overflowed signed duration")
+                })
+            }
+        }
+    }
+
+    /// Returns the number of whole hours in this duration.
+    ///
+    /// The value returned is negative when the duration is negative.
+    ///
+    /// This does not include any fractional component corresponding to units
+    /// less than an hour.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::new(86_400, 999_999_999);
+    /// assert_eq!(duration.as_hours(), 24);
+    ///
+    /// let duration = SignedDuration::new(-86_400, -999_999_999);
+    /// assert_eq!(duration.as_hours(), -24);
+    /// ```
+    #[inline]
+    pub const fn as_hours(&self) -> i64 {
+        self.as_secs() / (MINS_PER_HOUR * SECS_PER_MINUTE)
+    }
+
+    /// Returns the number of whole minutes in this duration.
+    ///
+    /// The value returned is negative when the duration is negative.
+    ///
+    /// This does not include any fractional component corresponding to units
+    /// less than a minute.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::new(3_600, 999_999_999);
+    /// assert_eq!(duration.as_mins(), 60);
+    ///
+    /// let duration = SignedDuration::new(-3_600, -999_999_999);
+    /// assert_eq!(duration.as_mins(), -60);
+    /// ```
+    #[inline]
+    pub const fn as_mins(&self) -> i64 {
+        self.as_secs() / SECS_PER_MINUTE
+    }
+
+    /// Returns the absolute value of this signed duration.
+    ///
+    /// If this duration isn't negative, then this returns the original
+    /// duration unchanged.
+    ///
+    /// # Panics
+    ///
+    /// This panics when the seconds component of this signed duration is
+    /// equal to `i64::MIN`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::new(1, -1_999_999_999);
+    /// assert_eq!(duration.abs(), SignedDuration::new(0, 999_999_999));
+    /// ```
+    #[inline]
+    pub const fn abs(self) -> SignedDuration {
+        SignedDuration { secs: self.secs.abs(), nanos: self.nanos.abs() }
+    }
+
+    /// Returns the absolute value of this signed duration as a
+    /// [`std::time::Duration`]. More specifically, this routine cannot
+    /// panic because the absolute value of `SignedDuration::MIN` is
+    /// representable in a `std::time::Duration`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::time::Duration;
+    ///
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::MIN;
+    /// assert_eq!(
+    ///     duration.unsigned_abs(),
+    ///     Duration::new(i64::MIN.unsigned_abs(), 999_999_999),
+    /// );
+    /// ```
+    #[inline]
+    pub const fn unsigned_abs(self) -> Duration {
+        Duration::new(self.secs.unsigned_abs(), self.nanos.unsigned_abs())
+    }
+
+    /// Returns this duration with its sign flipped.
+    ///
+    /// If this duration is zero, then this returns the duration unchanged.
+    ///
+    /// This returns none if the negation does not exist. This occurs in
+    /// precisely the cases when [`SignedDuration::as_secs`] is equal to
+    /// `i64::MIN`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::new(12, 123_456_789);
+    /// assert_eq!(
+    ///     duration.checked_neg(),
+    ///     Some(SignedDuration::new(-12, -123_456_789)),
+    /// );
+    ///
+    /// let duration = SignedDuration::new(-12, -123_456_789);
+    /// assert_eq!(
+    ///     duration.checked_neg(),
+    ///     Some(SignedDuration::new(12, 123_456_789)),
+    /// );
+    ///
+    /// // Negating the minimum seconds isn't possible.
+    /// assert_eq!(SignedDuration::MIN.checked_neg(), None);
+    /// ```
+    #[inline]
+    pub const fn checked_neg(self) -> Option<SignedDuration> {
+        let Some(secs) = self.secs.checked_neg() else { return None };
+        Some(SignedDuration {
+            secs,
+            // Always OK because `-999_999_999 <= self.nanos <= 999_999_999`.
+            nanos: -self.nanos,
+        })
+    }
+
+    /// Returns a number that represents the sign of this duration.
+    ///
+    /// * When [`SignedDuration::is_zero`] is true, this returns `0`.
+    /// * When [`SignedDuration::is_positive`] is true, this returns `1`.
+    /// * When [`SignedDuration::is_negative`] is true, this returns `-1`.
+    ///
+    /// The above cases are mutually exclusive.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// assert_eq!(0, SignedDuration::ZERO.signum());
+    /// ```
+    #[inline]
+    pub const fn signum(self) -> i8 {
+        if self.is_zero() {
+            0
+        } else if self.is_positive() {
+            1
+        } else {
+            debug_assert!(self.is_negative());
+            -1
+        }
+    }
+
+    /// Returns true when this duration is positive. That is, greater than
+    /// [`SignedDuration::ZERO`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::new(0, 1);
+    /// assert!(duration.is_positive());
+    /// ```
+    #[inline]
+    pub const fn is_positive(&self) -> bool {
+        self.secs.is_positive() || self.nanos.is_positive()
+    }
+
+    /// Returns true when this duration is negative. That is, less than
+    /// [`SignedDuration::ZERO`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::SignedDuration;
+    ///
+    /// let duration = SignedDuration::new(0, -1);
+    /// assert!(duration.is_negative());
+    /// ```
+    #[inline]
+    pub const fn is_negative(&self) -> bool {
+        self.secs.is_negative() || self.nanos.is_negative()
+    }
+}
+
+impl core::fmt::Display for SignedDuration {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        use crate::fmt::{temporal::DEFAULT_SPAN_PRINTER, StdFmtWrite};
+
+        DEFAULT_SPAN_PRINTER
+            .print_duration(self, StdFmtWrite(f))
+            .map_err(|_| core::fmt::Error)
+    }
+}
+
+impl core::fmt::Debug for SignedDuration {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        // TODO: Replace with `jiff::fmt::friendly` printer when it exists.
+        if self.nanos == 0 {
+            write!(f, "{}s", self.secs)
+        } else if self.secs == 0 {
+            write!(f, "{}ns", self.nanos)
+        } else {
+            write!(f, "{}s{}ns", self.secs, self.nanos.abs())
+        }
+    }
+}
+
+impl TryFrom<Duration> for SignedDuration {
+    type Error = Error;
+
+    fn try_from(d: Duration) -> Result<SignedDuration, Error> {
+        let secs = i64::try_from(d.as_secs()).map_err(|_| {
+            err!("seconds in unsigned duration {d:?} overflowed i64")
+        })?;
+        // Guaranteed to succeed since 0<=nanos<=999,999,999.
+        let nanos = i32::try_from(d.subsec_nanos()).unwrap();
+        Ok(SignedDuration { secs, nanos })
+    }
+}
+
+impl TryFrom<SignedDuration> for Duration {
+    type Error = Error;
+
+    fn try_from(sd: SignedDuration) -> Result<Duration, Error> {
+        let secs = u64::try_from(sd.as_secs()).map_err(|_| {
+            err!("seconds in signed duration {sd:?} overflowed u64")
+        })?;
+        // Guaranteed to succeed because the above only succeeds
+        // when `sd` is non-negative. And when `sd` is non-negative,
+        // we are guaranteed that 0<=nanos<=999,999,999.
+        let nanos = u32::try_from(sd.subsec_nanos()).unwrap();
+        Ok(Duration::new(secs, nanos))
+    }
+}
+
+impl core::str::FromStr for SignedDuration {
+    type Err = Error;
+
+    #[inline]
+    fn from_str(string: &str) -> Result<SignedDuration, Error> {
+        use crate::fmt::temporal::DEFAULT_SPAN_PARSER;
+
+        DEFAULT_SPAN_PARSER.parse_duration(string)
+    }
+}
+
+impl core::ops::Neg for SignedDuration {
+    type Output = SignedDuration;
+
+    #[inline]
+    fn neg(self) -> SignedDuration {
+        self.checked_neg().expect("overflow when negating signed duration")
+    }
+}
+
+impl core::ops::Add for SignedDuration {
+    type Output = SignedDuration;
+
+    #[inline]
+    fn add(self, rhs: SignedDuration) -> SignedDuration {
+        self.checked_add(rhs).expect("overflow when adding signed durations")
+    }
+}
+
+impl core::ops::AddAssign for SignedDuration {
+    #[inline]
+    fn add_assign(&mut self, rhs: SignedDuration) {
+        *self = *self + rhs;
+    }
+}
+
+impl core::ops::Sub for SignedDuration {
+    type Output = SignedDuration;
+
+    #[inline]
+    fn sub(self, rhs: SignedDuration) -> SignedDuration {
+        self.checked_sub(rhs)
+            .expect("overflow when subtracting signed durations")
+    }
+}
+
+impl core::ops::SubAssign for SignedDuration {
+    #[inline]
+    fn sub_assign(&mut self, rhs: SignedDuration) {
+        *self = *self - rhs;
+    }
+}
+
+impl core::ops::Mul<i32> for SignedDuration {
+    type Output = SignedDuration;
+
+    #[inline]
+    fn mul(self, rhs: i32) -> SignedDuration {
+        self.checked_mul(rhs)
+            .expect("overflow when multiplying signed duration by scalar")
+    }
+}
+
+impl core::ops::Mul<SignedDuration> for i32 {
+    type Output = SignedDuration;
+
+    #[inline]
+    fn mul(self, rhs: SignedDuration) -> SignedDuration {
+        rhs * self
+    }
+}
+
+impl core::ops::MulAssign<i32> for SignedDuration {
+    #[inline]
+    fn mul_assign(&mut self, rhs: i32) {
+        *self = *self * rhs;
+    }
+}
+
+impl core::ops::Div<i32> for SignedDuration {
+    type Output = SignedDuration;
+
+    #[inline]
+    fn div(self, rhs: i32) -> SignedDuration {
+        self.checked_div(rhs)
+            .expect("overflow when dividing signed duration by scalar")
+    }
+}
+
+impl core::ops::DivAssign<i32> for SignedDuration {
+    #[inline]
+    fn div_assign(&mut self, rhs: i32) {
+        *self = *self / rhs;
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for SignedDuration {
+    #[inline]
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for SignedDuration {
+    #[inline]
+    fn deserialize<D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<SignedDuration, D::Error> {
+        use serde::de;
+
+        struct SignedDurationVisitor;
+
+        impl<'de> de::Visitor<'de> for SignedDurationVisitor {
+            type Value = SignedDuration;
+
+            fn expecting(
+                &self,
+                f: &mut core::fmt::Formatter,
+            ) -> core::fmt::Result {
+                f.write_str("a signed duration string")
+            }
+
+            #[inline]
+            fn visit_bytes<E: de::Error>(
+                self,
+                value: &[u8],
+            ) -> Result<SignedDuration, E> {
+                use crate::fmt::temporal::DEFAULT_SPAN_PARSER;
+
+                DEFAULT_SPAN_PARSER
+                    .parse_duration(value)
+                    .map_err(de::Error::custom)
+            }
+
+            #[inline]
+            fn visit_str<E: de::Error>(
+                self,
+                value: &str,
+            ) -> Result<SignedDuration, E> {
+                self.visit_bytes(value.as_bytes())
+            }
+        }
+
+        deserializer.deserialize_bytes(SignedDurationVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new() {
+        let d = SignedDuration::new(12, i32::MAX);
+        assert_eq!(d.as_secs(), 14);
+        assert_eq!(d.subsec_nanos(), 147_483_647);
+
+        let d = SignedDuration::new(-12, i32::MIN);
+        assert_eq!(d.as_secs(), -14);
+        assert_eq!(d.subsec_nanos(), -147_483_648);
+
+        let d = SignedDuration::new(i64::MAX, i32::MIN);
+        assert_eq!(d.as_secs(), i64::MAX - 3);
+        assert_eq!(d.subsec_nanos(), 852_516_352);
+
+        let d = SignedDuration::new(i64::MIN, i32::MAX);
+        assert_eq!(d.as_secs(), i64::MIN + 3);
+        assert_eq!(d.subsec_nanos(), -852_516_353);
+    }
+
+    #[test]
+    #[should_panic]
+    fn new_fail_positive() {
+        SignedDuration::new(i64::MAX, 1_000_000_000);
+    }
+
+    #[test]
+    #[should_panic]
+    fn new_fail_negative() {
+        SignedDuration::new(i64::MIN, -1_000_000_000);
+    }
+
+    #[test]
+    fn from_hours_limits() {
+        let d = SignedDuration::from_hours(2_562_047_788_015_215);
+        assert_eq!(d.as_secs(), 9223372036854774000);
+
+        let d = SignedDuration::from_hours(-2_562_047_788_015_215);
+        assert_eq!(d.as_secs(), -9223372036854774000);
+    }
+
+    #[test]
+    #[should_panic]
+    fn from_hours_fail_positive() {
+        SignedDuration::from_hours(2_562_047_788_015_216);
+    }
+
+    #[test]
+    #[should_panic]
+    fn from_hours_fail_negative() {
+        SignedDuration::from_hours(-2_562_047_788_015_216);
+    }
+
+    #[test]
+    fn from_minutes_limits() {
+        let d = SignedDuration::from_mins(153_722_867_280_912_930);
+        assert_eq!(d.as_secs(), 9223372036854775800);
+
+        let d = SignedDuration::from_mins(-153_722_867_280_912_930);
+        assert_eq!(d.as_secs(), -9223372036854775800);
+    }
+
+    #[test]
+    #[should_panic]
+    fn from_minutes_fail_positive() {
+        SignedDuration::from_mins(153_722_867_280_912_931);
+    }
+
+    #[test]
+    #[should_panic]
+    fn from_minutes_fail_negative() {
+        SignedDuration::from_mins(-153_722_867_280_912_931);
+    }
+
+    #[test]
+    fn add() {
+        let add = |(secs1, nanos1): (i64, i32),
+                   (secs2, nanos2): (i64, i32)|
+         -> (i64, i32) {
+            let d1 = SignedDuration::new(secs1, nanos1);
+            let d2 = SignedDuration::new(secs2, nanos2);
+            let sum = d1.checked_add(d2).unwrap();
+            (sum.as_secs(), sum.subsec_nanos())
+        };
+
+        assert_eq!(add((1, 1), (1, 1)), (2, 2));
+        assert_eq!(add((1, 1), (-1, -1)), (0, 0));
+        assert_eq!(add((-1, -1), (1, 1)), (0, 0));
+        assert_eq!(add((-1, -1), (-1, -1)), (-2, -2));
+
+        assert_eq!(add((1, 500_000_000), (1, 500_000_000)), (3, 0));
+        assert_eq!(add((-1, -500_000_000), (-1, -500_000_000)), (-3, 0));
+        assert_eq!(
+            add((5, 200_000_000), (-1, -500_000_000)),
+            (3, 700_000_000)
+        );
+        assert_eq!(
+            add((-5, -200_000_000), (1, 500_000_000)),
+            (-3, -700_000_000)
+        );
+    }
+
+    #[test]
+    fn add_overflow() {
+        let add = |(secs1, nanos1): (i64, i32),
+                   (secs2, nanos2): (i64, i32)|
+         -> Option<(i64, i32)> {
+            let d1 = SignedDuration::new(secs1, nanos1);
+            let d2 = SignedDuration::new(secs2, nanos2);
+            d1.checked_add(d2).map(|d| (d.as_secs(), d.subsec_nanos()))
+        };
+        assert_eq!(None, add((i64::MAX, 0), (1, 0)));
+        assert_eq!(None, add((i64::MIN, 0), (-1, 0)));
+        assert_eq!(None, add((i64::MAX, 1), (0, 999_999_999)));
+        assert_eq!(None, add((i64::MIN, -1), (0, -999_999_999)));
+    }
+}

--- a/src/span.rs
+++ b/src/span.rs
@@ -1559,9 +1559,9 @@ impl Span {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[inline]
-    pub fn checked_add<'a>(
+    pub fn checked_add<'a, A: Into<SpanArithmetic<'a>>>(
         &self,
-        options: impl Into<SpanArithmetic<'a>>,
+        options: A,
     ) -> Result<Span, Error> {
         let options: SpanArithmetic<'_> = options.into();
         options.checked_add(*self)
@@ -1687,9 +1687,9 @@ impl Span {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[inline]
-    pub fn checked_sub<'a>(
+    pub fn checked_sub<'a, A: Into<SpanArithmetic<'a>>>(
         &self,
-        options: impl Into<SpanArithmetic<'a>>,
+        options: A,
     ) -> Result<Span, Error> {
         let mut options: SpanArithmetic<'_> = options.into();
         options.duration = options.duration.checked_neg()?;
@@ -1780,9 +1780,9 @@ impl Span {
     /// See the examples for [`Span::total`] if you want to sort spans without
     /// an `unwrap()` call.
     #[inline]
-    pub fn compare<'a>(
+    pub fn compare<'a, C: Into<SpanCompare<'a>>>(
         &self,
-        options: impl Into<SpanCompare<'a>>,
+        options: C,
     ) -> Result<Ordering, Error> {
         let options: SpanCompare<'_> = options.into();
         options.compare(*self)
@@ -1910,9 +1910,9 @@ impl Span {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[inline]
-    pub fn total<'a>(
+    pub fn total<'a, T: Into<SpanTotal<'a>>>(
         &self,
-        options: impl Into<SpanTotal<'a>>,
+        options: T,
     ) -> Result<f64, Error> {
         let options: SpanTotal<'_> = options.into();
         options.total(*self)
@@ -2077,9 +2077,9 @@ impl Span {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[inline]
-    pub fn round<'a>(
+    pub fn round<'a, R: Into<SpanRound<'a>>>(
         self,
-        options: impl Into<SpanRound<'a>>,
+        options: R,
     ) -> Result<Span, Error> {
         let options: SpanRound<'a> = options.into();
         options.round(self)
@@ -2141,9 +2141,9 @@ impl Span {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[inline]
-    pub fn to_jiff_duration<'a>(
+    pub fn to_jiff_duration<'a, R: Into<SpanRelativeTo<'a>>>(
         &self,
-        relative: impl Into<SpanRelativeTo<'a>>,
+        relative: R,
     ) -> Result<SignedDuration, Error> {
         let max_unit = self.largest_unit();
         let relative: SpanRelativeTo<'a> = relative.into();
@@ -2289,9 +2289,9 @@ impl Span {
     /// ```
     #[deprecated(since = "0.1.5", note = "use Span::to_jiff_duration instead")]
     #[inline]
-    pub fn to_duration<'a>(
+    pub fn to_duration<'a, R: Into<SpanRelativeTo<'a>>>(
         &self,
-        relative: impl Into<SpanRelativeTo<'a>>,
+        relative: R,
     ) -> Result<UnsignedDuration, Error> {
         if self.is_negative() {
             return Err(err!(

--- a/src/span.rs
+++ b/src/span.rs
@@ -5202,7 +5202,7 @@ impl Nudge {
         mode: RoundMode,
     ) -> Result<Nudge, Error> {
         #[cfg(not(feature = "std"))]
-        use crate::util::libm::F64;
+        use crate::util::libm::Float;
 
         assert!(smallest >= Unit::Day);
         let sign = balanced.get_sign_ranged();

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -14,7 +14,7 @@ use crate::{
         },
     },
     zoned::Zoned,
-    RoundMode, Span, SpanRound, Unit,
+    RoundMode, SignedDuration, Span, SpanRound, Unit,
 };
 
 /// An instant in time represented as the number of nanoseconds since the Unix
@@ -649,47 +649,20 @@ impl Timestamp {
         Ok(Timestamp::from_nanosecond_ranged(nanosecond))
     }
 
-    /// Creates a new instant from a `Duration` since the Unix epoch.
-    ///
-    /// A `Duration` is always positive. If you need to construct
-    /// a timestamp before the Unix epoch with a `Duration`, use
-    /// [`Timestamp::from_signed_duration`].
-    ///
-    /// # Errors
-    ///
-    /// This returns an error if the given duration corresponds to a timestamp
-    /// greater than [`Timestamp::MAX`].
-    ///
-    /// # Example
-    ///
-    /// How one might construct a `Timestamp` from a `SystemTime` if one can
-    /// assume the time is after the Unix epoch:
-    ///
-    /// ```
-    /// use std::time::SystemTime;
-    /// use jiff::Timestamp;
-    ///
-    /// let elapsed = SystemTime::UNIX_EPOCH.elapsed()?;
-    /// assert!(Timestamp::from_duration(elapsed).is_ok());
-    ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
-    ///
-    /// Of course, one should just use [`Timestamp::try_from`] for this
-    /// instead.
-    #[cfg(feature = "std")]
-    #[inline]
-    pub fn from_duration(
-        duration: std::time::Duration,
-    ) -> Result<Timestamp, Error> {
-        Timestamp::from_signed_duration(1, duration)
-    }
-
     /// Creates a new timestamp from a `Duration` with the given sign since the
     /// Unix epoch.
     ///
     /// Positive durations result in a timestamp after the Unix epoch. Negative
     /// durations result in a timestamp before the Unix epoch.
+    ///
+    /// # Planned breaking change
+    ///
+    /// It is planned to rename this routine to `Timestamp::from_duration` in
+    /// `jiff 0.2`. The current `Timestamp::from_duration` routine, which
+    /// accepts a `std::time::Duration`, will be removed. If callers need to
+    /// build a `Timestamp` from a `std::time::Duration`, then they should
+    /// first convert it to a `SignedDuration` via
+    /// `TryFrom<Duration> for SignedDuration`.
     ///
     /// # Errors
     ///
@@ -732,27 +705,11 @@ impl Timestamp {
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    #[cfg(feature = "std")]
     #[inline]
-    pub fn from_signed_duration(
-        sign: i8,
-        duration: std::time::Duration,
+    pub fn from_jiff_duration(
+        duration: SignedDuration,
     ) -> Result<Timestamp, Error> {
-        let sign = sign.signum();
-        let seconds = i64::try_from(duration.as_secs()).map_err(|_| {
-            Error::unsigned(
-                "duration seconds",
-                duration.as_secs(),
-                UnixSeconds::MIN_REPR,
-                UnixSeconds::MAX_REPR,
-            )
-        })?;
-        let nanos = i32::try_from(duration.subsec_nanos())
-            .expect("nanoseconds in duration are less than 1,000,000,000");
-        // NOTE: Can multiplication actually fail here? I think if `seconds` is
-        // `i64::MIN`? But, no, I don't think so. Since `duration` is always
-        // positive.
-        Timestamp::new(seconds * i64::from(sign), nanos * i32::from(sign))
+        Timestamp::new(duration.as_secs(), duration.subsec_nanos())
     }
 
     /// Returns this timestamp as a number of seconds since the Unix epoch.
@@ -962,45 +919,44 @@ impl Timestamp {
         self.subsec_nanosecond_ranged().get()
     }
 
-    /// Returns this timestamp as a standard library
-    /// [`Duration`](std::time::Duration) since the Unix epoch.
+    /// Returns this timestamp as a [`SignedDuration`] since the Unix epoch.
     ///
-    /// Since a `Duration` is unsigned and a `Timestamp` is signed, this
-    /// also returns the sign of this timestamp (`-1`, `0` or `1`) along with
-    /// the unsigned `Duration`. A negative sign means the duration should be
-    /// subtracted from the Unix epoch. A positive sign means the duration
-    /// should be added to the Unix epoch. A zero sign means the duration is
-    /// the same precise instant as the Unix epoch.
+    /// # Planned breaking change
+    ///
+    /// It is planned to rename this routine to `Timestamp::as_duration` in
+    /// `jiff 0.2`. The current `Timestamp::as_duration` routine, which returns
+    /// a `std::time::Duration`, will be removed. If callers need a
+    /// `std::time::Duration` from a `Timestamp`, then they should call this
+    /// routine and then use `TryFrom<SignedDuration> for Duration` to convert
+    /// the result.
     ///
     /// # Example
     ///
     /// ```
-    /// use std::time::Duration;
-    /// use jiff::Timestamp;
+    /// use jiff::{SignedDuration, Timestamp};
     ///
     /// assert_eq!(
-    ///     Timestamp::UNIX_EPOCH.as_duration(),
-    ///     (0, Duration::ZERO),
+    ///     Timestamp::UNIX_EPOCH.as_jiff_duration(),
+    ///     SignedDuration::ZERO,
     /// );
     /// assert_eq!(
-    ///     Timestamp::new(5, 123_456_789)?.as_duration(),
-    ///     (1, Duration::new(5, 123_456_789)),
+    ///     Timestamp::new(5, 123_456_789)?.as_jiff_duration(),
+    ///     SignedDuration::new(5, 123_456_789),
     /// );
     /// assert_eq!(
-    ///     Timestamp::new(-5, -123_456_789)?.as_duration(),
-    ///     (-1, Duration::new(5, 123_456_789)),
+    ///     Timestamp::new(-5, -123_456_789)?.as_jiff_duration(),
+    ///     SignedDuration::new(-5, -123_456_789),
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    #[cfg(feature = "std")]
     #[inline]
-    pub fn as_duration(self) -> (i8, std::time::Duration) {
-        let second = u64::try_from(self.as_second().abs())
-            .expect("absolute value of seconds fits in u64");
-        let nanosecond = u32::try_from(self.subsec_nanosecond().abs())
-            .expect("nanosecond always fit in a u32");
-        (self.signum(), std::time::Duration::new(second, nanosecond))
+    pub fn as_jiff_duration(self) -> SignedDuration {
+        let second = i64::try_from(self.as_second())
+            .expect("value of seconds fits in i64");
+        let nanosecond = i32::try_from(self.subsec_nanosecond())
+            .expect("nanosecond always fit in a i32");
+        SignedDuration::new(second, nanosecond)
     }
 
     /// Returns the sign of this timestamp.
@@ -1972,6 +1928,166 @@ impl Timestamp {
     }
 }
 
+/// Deprecated APIs on `Timestamp`.
+impl Timestamp {
+    /// Creates a new instant from a `Duration` since the Unix epoch.
+    ///
+    /// A `Duration` is always positive. If you need to construct
+    /// a timestamp before the Unix epoch with a `Duration`, use
+    /// [`Timestamp::from_signed_duration`].
+    ///
+    /// # Errors
+    ///
+    /// This returns an error if the given duration corresponds to a timestamp
+    /// greater than [`Timestamp::MAX`].
+    ///
+    /// # Example
+    ///
+    /// How one might construct a `Timestamp` from a `SystemTime` if one can
+    /// assume the time is after the Unix epoch:
+    ///
+    /// ```
+    /// use std::time::SystemTime;
+    /// use jiff::Timestamp;
+    ///
+    /// let elapsed = SystemTime::UNIX_EPOCH.elapsed()?;
+    /// assert!(Timestamp::from_duration(elapsed).is_ok());
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// Of course, one should just use [`Timestamp::try_from`] for this
+    /// instead.
+    #[deprecated(
+        since = "0.1.5",
+        note = "use Timestamp::from_jiff_duration instead"
+    )]
+    #[inline]
+    pub fn from_duration(
+        duration: core::time::Duration,
+    ) -> Result<Timestamp, Error> {
+        #[allow(deprecated)]
+        Timestamp::from_signed_duration(1, duration)
+    }
+
+    /// Creates a new timestamp from a `Duration` with the given sign since the
+    /// Unix epoch.
+    ///
+    /// Positive durations result in a timestamp after the Unix epoch. Negative
+    /// durations result in a timestamp before the Unix epoch.
+    ///
+    /// # Errors
+    ///
+    /// This returns an error if the given duration corresponds to a timestamp
+    /// outside of the [`Timestamp::MIN`] and [`Timestamp::MAX`] boundaries.
+    ///
+    /// # Example
+    ///
+    /// How one might construct a `Timestamp` from a `SystemTime`:
+    ///
+    /// ```
+    /// use std::time::SystemTime;
+    /// use jiff::Timestamp;
+    ///
+    /// let unix_epoch = SystemTime::UNIX_EPOCH;
+    /// let now = SystemTime::now();
+    /// let (duration, sign) = match now.duration_since(unix_epoch) {
+    ///     Ok(duration) => (duration, 1),
+    ///     Err(err) => (err.duration(), -1),
+    /// };
+    ///
+    /// let ts = Timestamp::from_signed_duration(sign, duration)?;
+    /// assert!(ts > Timestamp::UNIX_EPOCH);
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// Of course, one should just use [`Timestamp::try_from`] for this
+    /// instead. Indeed, the above example is copied almost exactly from the
+    /// `TryFrom` implementation.
+    ///
+    /// # Example: a sign of 0 always results in `Timestamp::UNIX_EPOCH`
+    ///
+    /// ```
+    /// use jiff::Timestamp;
+    ///
+    /// let duration = std::time::Duration::new(5, 123_456_789);
+    /// let ts = Timestamp::from_signed_duration(0, duration)?;
+    /// assert_eq!(ts, Timestamp::UNIX_EPOCH);
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[deprecated(
+        since = "0.1.5",
+        note = "use Timestamp::from_jiff_duration instead"
+    )]
+    #[inline]
+    pub fn from_signed_duration(
+        sign: i8,
+        duration: core::time::Duration,
+    ) -> Result<Timestamp, Error> {
+        let sign = sign.signum();
+        let seconds = i64::try_from(duration.as_secs()).map_err(|_| {
+            Error::unsigned(
+                "duration seconds",
+                duration.as_secs(),
+                UnixSeconds::MIN_REPR,
+                UnixSeconds::MAX_REPR,
+            )
+        })?;
+        let nanos = i32::try_from(duration.subsec_nanos())
+            .expect("nanoseconds in duration are less than 1,000,000,000");
+        // NOTE: Can multiplication actually fail here? I think if `seconds` is
+        // `i64::MIN`? But, no, I don't think so. Since `duration` is always
+        // positive.
+        Timestamp::new(seconds * i64::from(sign), nanos * i32::from(sign))
+    }
+
+    /// Returns this timestamp as a standard library
+    /// [`Duration`](std::time::Duration) since the Unix epoch.
+    ///
+    /// Since a `Duration` is unsigned and a `Timestamp` is signed, this
+    /// also returns the sign of this timestamp (`-1`, `0` or `1`) along with
+    /// the unsigned `Duration`. A negative sign means the duration should be
+    /// subtracted from the Unix epoch. A positive sign means the duration
+    /// should be added to the Unix epoch. A zero sign means the duration is
+    /// the same precise instant as the Unix epoch.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::time::Duration;
+    /// use jiff::Timestamp;
+    ///
+    /// assert_eq!(
+    ///     Timestamp::UNIX_EPOCH.as_duration(),
+    ///     (0, Duration::ZERO),
+    /// );
+    /// assert_eq!(
+    ///     Timestamp::new(5, 123_456_789)?.as_duration(),
+    ///     (1, Duration::new(5, 123_456_789)),
+    /// );
+    /// assert_eq!(
+    ///     Timestamp::new(-5, -123_456_789)?.as_duration(),
+    ///     (-1, Duration::new(5, 123_456_789)),
+    /// );
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[deprecated(
+        since = "0.1.5",
+        note = "use Timestamp::as_signed_duration instead"
+    )]
+    #[inline]
+    pub fn as_duration(self) -> (i8, core::time::Duration) {
+        let second = u64::try_from(self.as_second().abs())
+            .expect("absolute value of seconds fits in u64");
+        let nanosecond = u32::try_from(self.subsec_nanosecond().abs())
+            .expect("nanosecond always fit in a u32");
+        (self.signum(), std::time::Duration::new(second, nanosecond))
+    }
+}
+
 /// Internal APIs using Jiff ranged integers.
 impl Timestamp {
     #[inline]
@@ -2292,18 +2408,15 @@ impl From<Timestamp> for std::time::SystemTime {
     #[inline]
     fn from(time: Timestamp) -> std::time::SystemTime {
         let unix_epoch = std::time::SystemTime::UNIX_EPOCH;
-        let (sign, duration) = time.as_duration();
+        let sdur = time.as_jiff_duration();
+        let dur = sdur.unsigned_abs();
         // These are guaranteed to succeed because we assume that SystemTime
         // uses at least 64 bits for the time, and our durations are capped via
         // the range on UnixSeconds.
-        if sign >= 0 {
-            unix_epoch
-                .checked_add(duration)
-                .expect("duration too big (positive)")
+        if sdur.is_negative() {
+            unix_epoch.checked_sub(dur).expect("duration too big (negative)")
         } else {
-            unix_epoch
-                .checked_sub(duration)
-                .expect("duration too big (negative)")
+            unix_epoch.checked_add(dur).expect("duration too big (positive)")
         }
     }
 }
@@ -2317,11 +2430,8 @@ impl TryFrom<std::time::SystemTime> for Timestamp {
         system_time: std::time::SystemTime,
     ) -> Result<Timestamp, Error> {
         let unix_epoch = std::time::SystemTime::UNIX_EPOCH;
-        let (duration, sign) = match system_time.duration_since(unix_epoch) {
-            Ok(duration) => (duration, 1),
-            Err(err) => (err.duration(), -1),
-        };
-        Timestamp::from_signed_duration(sign, duration)
+        let dur = SignedDuration::until(unix_epoch, system_time)?;
+        Timestamp::from_jiff_duration(dur)
     }
 }
 

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -952,11 +952,7 @@ impl Timestamp {
     /// ```
     #[inline]
     pub fn as_jiff_duration(self) -> SignedDuration {
-        let second = i64::try_from(self.as_second())
-            .expect("value of seconds fits in i64");
-        let nanosecond = i32::try_from(self.subsec_nanosecond())
-            .expect("nanosecond always fit in a i32");
-        SignedDuration::new(second, nanosecond)
+        SignedDuration::from_timestamp(self)
     }
 
     /// Returns the sign of this timestamp.
@@ -2430,7 +2426,7 @@ impl TryFrom<std::time::SystemTime> for Timestamp {
         system_time: std::time::SystemTime,
     ) -> Result<Timestamp, Error> {
         let unix_epoch = std::time::SystemTime::UNIX_EPOCH;
-        let dur = SignedDuration::until(unix_epoch, system_time)?;
+        let dur = SignedDuration::system_until(unix_epoch, system_time)?;
         Timestamp::from_jiff_duration(dur)
     }
 }

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -1820,9 +1820,9 @@ impl Timestamp {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[inline]
-    pub fn round(
+    pub fn round<R: Into<TimestampRound>>(
         self,
-        options: impl Into<TimestampRound>,
+        options: R,
     ) -> Result<Timestamp, Error> {
         let options: TimestampRound = options.into();
         options.round(self)

--- a/src/tz/mod.rs
+++ b/src/tz/mod.rs
@@ -99,7 +99,7 @@ use self::{posix::ReasonablePosixTimeZone, tzif::Tzif};
 
 pub use self::{
     db::{db, TimeZoneDatabase, TimeZoneNameIter},
-    offset::{Dst, Offset, OffsetConflict},
+    offset::{Dst, Offset, OffsetArithmetic, OffsetConflict},
 };
 
 mod db;

--- a/src/tz/offset.rs
+++ b/src/tz/offset.rs
@@ -596,21 +596,14 @@ impl Offset {
         Ok(Offset::from_seconds_ranged(seconds))
     }
 
-    /// Subtracts the given span of time from this offset.
-    ///
-    /// Since time zone offsets have second resolution, any fractional seconds
-    /// in the span given are ignored.
+    /// This routine is identical to [`Offset::checked_add`] with the duration
+    /// negated.
     ///
     /// # Errors
     ///
-    /// This returns an error if the result of subtracting the given span would
-    /// exceed the minimum or maximum allowed `Offset` value.
+    /// This has the same error conditions as [`Offset::checked_add`].
     ///
     /// # Example
-    ///
-    /// This example shows how to subtract one hour to an offset (if the offset
-    /// corresponds to DST, then subtracting an hour will usually give you
-    /// standard time):
     ///
     /// ```
     /// use jiff::{tz, ToSpan};
@@ -618,57 +611,14 @@ impl Offset {
     /// let off = tz::offset(-4);
     /// assert_eq!(off.checked_sub(1.hours()).unwrap(), tz::offset(-5));
     /// ```
-    ///
-    /// And note that while fractional seconds are ignored, units less than
-    /// seconds aren't ignored if they sum up to a duration at least as big
-    /// as one second:
-    ///
-    /// ```
-    /// use jiff::{tz, ToSpan};
-    ///
-    /// let off = tz::offset(5);
-    /// let span = 900.milliseconds()
-    ///     .microseconds(50_000)
-    ///     .nanoseconds(50_000_000);
-    /// assert_eq!(
-    ///     off.checked_sub(span).unwrap(),
-    ///     tz::Offset::from_seconds((5 * 60 * 60) - 1).unwrap(),
-    /// );
-    /// // Any leftover fractional part is ignored.
-    /// let span = 901.milliseconds()
-    ///     .microseconds(50_001)
-    ///     .nanoseconds(50_000_001);
-    /// assert_eq!(
-    ///     off.checked_sub(span).unwrap(),
-    ///     tz::Offset::from_seconds((5 * 60 * 60) - 1).unwrap(),
-    /// );
-    /// ```
-    ///
-    /// This example shows some cases where checked subtraction will fail.
-    ///
-    /// ```
-    /// use jiff::{tz::Offset, ToSpan};
-    ///
-    /// // Subtracting units above 'hour' always results in an error.
-    /// assert!(Offset::UTC.checked_sub(1.day()).is_err());
-    /// assert!(Offset::UTC.checked_sub(1.week()).is_err());
-    /// assert!(Offset::UTC.checked_sub(1.month()).is_err());
-    /// assert!(Offset::UTC.checked_sub(1.year()).is_err());
-    ///
-    /// // Adding even 1 second to the max, or subtracting 1 from the min,
-    /// // will result in overflow and thus an error will be returned.
-    /// assert!(Offset::MIN.checked_sub(1.seconds()).is_err());
-    /// assert!(Offset::MAX.checked_sub(-1.seconds()).is_err());
-    /// ```
     #[inline]
     pub fn checked_sub(self, span: Span) -> Result<Offset, Error> {
         self.checked_add(span.negate())
     }
 
-    /// Adds the given span of time to this offset, saturating on overflow.
-    ///
-    /// Since time zone offsets have second resolution, any fractional seconds
-    /// in the span given are ignored.
+    /// This routine is identical to [`Offset::checked_add`], except the
+    /// result saturates on overflow. That is, instead of overflow, either
+    /// [`Offset::MIN`] or [`Offset::MAX`] is returned.
     ///
     /// # Example
     ///
@@ -698,11 +648,8 @@ impl Offset {
         })
     }
 
-    /// Subtracts the given span of time from this offset, saturating on
-    /// overflow.
-    ///
-    /// Since time zone offsets have second resolution, any fractional seconds
-    /// in the span given are ignored.
+    /// This routine is identical to [`Offset::saturating_add`] with the span
+    /// parameter negated.
     ///
     /// # Example
     ///

--- a/src/tz/offset.rs
+++ b/src/tz/offset.rs
@@ -453,67 +453,6 @@ impl Offset {
             .checked_sub_seconds(i64::from(self.seconds()))
     }
 
-    /// Returns the span of time from this offset until the other given.
-    ///
-    /// When the `other` offset is more west (i.e., more negative) of the prime
-    /// meridian than this offset, then the span returned will be negative.
-    ///
-    /// # Properties
-    ///
-    /// Adding the span returned to this offset will always equal the `other`
-    /// offset given.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use jiff::{tz, ToSpan};
-    ///
-    /// assert_eq!(
-    ///     tz::offset(-5).until(tz::Offset::UTC),
-    ///     (5 * 60 * 60).seconds(),
-    /// );
-    /// // Flipping the operands in this case results in a negative span.
-    /// assert_eq!(
-    ///     tz::Offset::UTC.until(tz::offset(-5)),
-    ///     -(5 * 60 * 60).seconds(),
-    /// );
-    /// ```
-    #[inline]
-    pub fn until(self, other: Offset) -> Span {
-        Span::new()
-            .seconds_ranged(other.seconds_ranged() - self.seconds_ranged())
-    }
-
-    /// Returns the span of time since the other offset given from this offset.
-    ///
-    /// When the `other` is more east (i.e., more positive) of the prime
-    /// meridian than this offset, then the span returned will be negative.
-    ///
-    /// # Properties
-    ///
-    /// Adding the span returned to the `other` offset will always equal this
-    /// offset.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use jiff::{tz, ToSpan};
-    ///
-    /// assert_eq!(
-    ///     tz::Offset::UTC.since(tz::offset(-5)),
-    ///     (5 * 60 * 60).seconds(),
-    /// );
-    /// // Flipping the operands in this case results in a negative span.
-    /// assert_eq!(
-    ///     tz::offset(-5).since(tz::Offset::UTC),
-    ///     -(5 * 60 * 60).seconds(),
-    /// );
-    /// ```
-    #[inline]
-    pub fn since(self, other: Offset) -> Span {
-        self.until(other).negate()
-    }
-
     /// Adds the given span of time to this offset.
     ///
     /// Since time zone offsets have second resolution, any fractional seconds
@@ -671,6 +610,67 @@ impl Offset {
     #[inline]
     pub fn saturating_sub(self, span: Span) -> Offset {
         self.saturating_add(span.negate())
+    }
+
+    /// Returns the span of time from this offset until the other given.
+    ///
+    /// When the `other` offset is more west (i.e., more negative) of the prime
+    /// meridian than this offset, then the span returned will be negative.
+    ///
+    /// # Properties
+    ///
+    /// Adding the span returned to this offset will always equal the `other`
+    /// offset given.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use jiff::{tz, ToSpan};
+    ///
+    /// assert_eq!(
+    ///     tz::offset(-5).until(tz::Offset::UTC),
+    ///     (5 * 60 * 60).seconds(),
+    /// );
+    /// // Flipping the operands in this case results in a negative span.
+    /// assert_eq!(
+    ///     tz::Offset::UTC.until(tz::offset(-5)),
+    ///     -(5 * 60 * 60).seconds(),
+    /// );
+    /// ```
+    #[inline]
+    pub fn until(self, other: Offset) -> Span {
+        Span::new()
+            .seconds_ranged(other.seconds_ranged() - self.seconds_ranged())
+    }
+
+    /// Returns the span of time since the other offset given from this offset.
+    ///
+    /// When the `other` is more east (i.e., more positive) of the prime
+    /// meridian than this offset, then the span returned will be negative.
+    ///
+    /// # Properties
+    ///
+    /// Adding the span returned to the `other` offset will always equal this
+    /// offset.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use jiff::{tz, ToSpan};
+    ///
+    /// assert_eq!(
+    ///     tz::Offset::UTC.since(tz::offset(-5)),
+    ///     (5 * 60 * 60).seconds(),
+    /// );
+    /// // Flipping the operands in this case results in a negative span.
+    /// assert_eq!(
+    ///     tz::offset(-5).since(tz::Offset::UTC),
+    ///     -(5 * 60 * 60).seconds(),
+    /// );
+    /// ```
+    #[inline]
+    pub fn since(self, other: Offset) -> Span {
+        self.until(other).negate()
     }
 
     /// Returns this offset as a [`Span`].

--- a/src/tz/offset.rs
+++ b/src/tz/offset.rs
@@ -453,36 +453,6 @@ impl Offset {
             .checked_sub_seconds(i64::from(self.seconds()))
     }
 
-    /// Returns the span of time since the other offset given from this offset.
-    ///
-    /// When the `other` is more east (i.e., more positive) of the prime
-    /// meridian than this offset, then the span returned will be negative.
-    ///
-    /// # Properties
-    ///
-    /// Adding the span returned to the `other` offset will always equal this
-    /// offset.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use jiff::{tz, ToSpan};
-    ///
-    /// assert_eq!(
-    ///     tz::Offset::UTC.since(tz::offset(-5)),
-    ///     (5 * 60 * 60).seconds(),
-    /// );
-    /// // Flipping the operands in this case results in a negative span.
-    /// assert_eq!(
-    ///     tz::offset(-5).since(tz::Offset::UTC),
-    ///     -(5 * 60 * 60).seconds(),
-    /// );
-    /// ```
-    #[inline]
-    pub fn since(self, other: Offset) -> Span {
-        self.until(other).negate()
-    }
-
     /// Returns the span of time from this offset until the other given.
     ///
     /// When the `other` offset is more west (i.e., more negative) of the prime
@@ -512,6 +482,36 @@ impl Offset {
     pub fn until(self, other: Offset) -> Span {
         Span::new()
             .seconds_ranged(other.seconds_ranged() - self.seconds_ranged())
+    }
+
+    /// Returns the span of time since the other offset given from this offset.
+    ///
+    /// When the `other` is more east (i.e., more positive) of the prime
+    /// meridian than this offset, then the span returned will be negative.
+    ///
+    /// # Properties
+    ///
+    /// Adding the span returned to the `other` offset will always equal this
+    /// offset.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use jiff::{tz, ToSpan};
+    ///
+    /// assert_eq!(
+    ///     tz::Offset::UTC.since(tz::offset(-5)),
+    ///     (5 * 60 * 60).seconds(),
+    /// );
+    /// // Flipping the operands in this case results in a negative span.
+    /// assert_eq!(
+    ///     tz::offset(-5).since(tz::Offset::UTC),
+    ///     -(5 * 60 * 60).seconds(),
+    /// );
+    /// ```
+    #[inline]
+    pub fn since(self, other: Offset) -> Span {
+        self.until(other).negate()
     }
 
     /// Adds the given span of time to this offset.

--- a/src/util/libm.rs
+++ b/src/util/libm.rs
@@ -14,14 +14,14 @@ floating point. And now it's also used in parts of `SignedDuration`.
 [`libm`]: https://github.com/rust-lang/libm
 */
 
-pub(crate) trait F64 {
-    fn abs(self) -> f64;
-    fn ceil(self) -> f64;
-    fn floor(self) -> f64;
-    fn round(self) -> f64;
-    fn signum(self) -> f64;
-    fn trunc(self) -> f64;
-    fn fract(self) -> f64;
+pub(crate) trait Float {
+    fn abs(self) -> Self;
+    fn ceil(self) -> Self;
+    fn floor(self) -> Self;
+    fn round(self) -> Self;
+    fn signum(self) -> Self;
+    fn trunc(self) -> Self;
+    fn fract(self) -> Self;
 }
 
 macro_rules! force_eval {
@@ -30,9 +30,9 @@ macro_rules! force_eval {
     };
 }
 
-const TOINT: f64 = 1. / f64::EPSILON;
+const TOINT64: f64 = 1. / f64::EPSILON;
 
-impl F64 for f64 {
+impl Float for f64 {
     fn abs(self) -> f64 {
         if self.is_sign_negative() {
             -self
@@ -52,9 +52,9 @@ impl F64 for f64 {
         }
         // y = int(x) - x, where int(x) is an integer neighbor of x
         y = if (u >> 63) != 0 {
-            x - TOINT + TOINT - x
+            x - TOINT64 + TOINT64 - x
         } else {
-            x + TOINT - TOINT - x
+            x + TOINT64 - TOINT64 - x
         };
         // special case because of non-nearest rounding modes
         if e < 0x3ff {
@@ -80,9 +80,9 @@ impl F64 for f64 {
         }
         /* y = int(x) - x, where int(x) is an integer neighbor of x */
         let y = if (ui >> 63) != 0 {
-            x - TOINT + TOINT - x
+            x - TOINT64 + TOINT64 - x
         } else {
-            x + TOINT - TOINT - x
+            x + TOINT64 - TOINT64 - x
         };
         /* special case because of non-nearest rounding modes */
         if e < 0x3ff {
@@ -99,14 +99,14 @@ impl F64 for f64 {
     }
 
     fn round(self) -> f64 {
-        (self + copysign(0.5 - 0.25 * f64::EPSILON, self)).trunc()
+        (self + copysign64(0.5 - 0.25 * f64::EPSILON, self)).trunc()
     }
 
     fn signum(self) -> f64 {
         if self.is_nan() {
             Self::NAN
         } else {
-            copysign(1.0, self)
+            copysign64(1.0, self)
         }
     }
 
@@ -140,7 +140,7 @@ impl F64 for f64 {
     }
 }
 
-fn copysign(x: f64, y: f64) -> f64 {
+fn copysign64(x: f64, y: f64) -> f64 {
     let mut ux = x.to_bits();
     let uy = y.to_bits();
     ux &= (!0) >> 1;

--- a/src/util/libm.rs
+++ b/src/util/libm.rs
@@ -6,10 +6,10 @@ wouldn't necessarily mind depending on `libm`, but I don't think there's a
 way to express "only depend on a crate if some on-by-default feature is not
 enabled."
 
-We also very intentionally have very minimal floating point requirements.
-It's used for `Span::total` where it's part of the API and thus necessary.
-It's also used when rounding in some cases, although I would like to remove
-that use of floating point.
+We also very intentionally have very minimal floating point requirements. It's
+used for `Span::total` where it's part of the API and thus necessary. It's also
+used when rounding in some cases, although I would like to remove that use of
+floating point. And now it's also used in parts of `SignedDuration`.
 
 [`libm`]: https://github.com/rust-lang/libm
 */
@@ -21,6 +21,7 @@ pub(crate) trait F64 {
     fn round(self) -> f64;
     fn signum(self) -> f64;
     fn trunc(self) -> f64;
+    fn fract(self) -> f64;
 }
 
 macro_rules! force_eval {
@@ -132,6 +133,10 @@ impl F64 for f64 {
         }
         i &= !m;
         f64::from_bits(i)
+    }
+
+    fn fract(self) -> f64 {
+        self - self.trunc()
     }
 }
 

--- a/src/util/libm.rs
+++ b/src/util/libm.rs
@@ -140,10 +140,135 @@ impl Float for f64 {
     }
 }
 
+impl Float for f32 {
+    fn abs(self) -> f32 {
+        if self.is_sign_negative() {
+            -self
+        } else {
+            self
+        }
+    }
+
+    fn ceil(self) -> f32 {
+        let x = self;
+        let mut ui = x.to_bits();
+        let e = (((ui >> 23) & 0xff).wrapping_sub(0x7f)) as i32;
+
+        if e >= 23 {
+            return x;
+        }
+        if e >= 0 {
+            let m = 0x007fffff >> e;
+            if (ui & m) == 0 {
+                return x;
+            }
+            unsafe {
+                force_eval!(x + f32::from_bits(0x7b800000));
+            }
+            if ui >> 31 == 0 {
+                ui += m;
+            }
+            ui &= !m;
+        } else {
+            unsafe {
+                force_eval!(x + f32::from_bits(0x7b800000));
+            }
+            if ui >> 31 != 0 {
+                return -0.0;
+            } else if ui << 1 != 0 {
+                return 1.0;
+            }
+        }
+        f32::from_bits(ui)
+    }
+
+    fn floor(self) -> f32 {
+        let x = self;
+        let mut ui = x.to_bits();
+        let e = (((ui >> 23) as i32) & 0xff) - 0x7f;
+
+        if e >= 23 {
+            return x;
+        }
+        if e >= 0 {
+            let m: u32 = 0x007fffff >> e;
+            if (ui & m) == 0 {
+                return x;
+            }
+            unsafe {
+                force_eval!(x + f32::from_bits(0x7b800000));
+            }
+            if ui >> 31 != 0 {
+                ui += m;
+            }
+            ui &= !m;
+        } else {
+            unsafe {
+                force_eval!(x + f32::from_bits(0x7b800000));
+            }
+            if ui >> 31 == 0 {
+                ui = 0;
+            } else if ui << 1 != 0 {
+                return -1.0;
+            }
+        }
+        f32::from_bits(ui)
+    }
+
+    fn round(self) -> f32 {
+        (self + copysign32(0.5 - 0.25 * f32::EPSILON, self)).trunc()
+    }
+
+    fn signum(self) -> f32 {
+        if self.is_nan() {
+            Self::NAN
+        } else {
+            copysign32(1.0, self)
+        }
+    }
+
+    fn trunc(self) -> f32 {
+        let x = self;
+        let x1p120 = f32::from_bits(0x7b800000); // 0x1p120f === 2 ^ 120
+
+        let mut i: u32 = x.to_bits();
+        let mut e: i32 = (i >> 23 & 0xff) as i32 - 0x7f + 9;
+        let m: u32;
+
+        if e >= 23 + 9 {
+            return x;
+        }
+        if e < 9 {
+            e = 1;
+        }
+        m = -1i32 as u32 >> e;
+        if (i & m) == 0 {
+            return x;
+        }
+        unsafe {
+            force_eval!(x + x1p120);
+        }
+        i &= !m;
+        f32::from_bits(i)
+    }
+
+    fn fract(self) -> f32 {
+        self - self.trunc()
+    }
+}
+
 fn copysign64(x: f64, y: f64) -> f64 {
     let mut ux = x.to_bits();
     let uy = y.to_bits();
     ux &= (!0) >> 1;
     ux |= uy & (1 << 63);
     f64::from_bits(ux)
+}
+
+fn copysign32(x: f32, y: f32) -> f32 {
+    let mut ux = x.to_bits();
+    let uy = y.to_bits();
+    ux &= 0x7fffffff;
+    ux |= uy & 0x80000000;
+    f32::from_bits(ux)
 }

--- a/src/util/round/mode.rs
+++ b/src/util/round/mode.rs
@@ -178,7 +178,7 @@ impl RoundMode {
         increment: NoUnits128,
     ) -> NoUnits128 {
         #[cfg(not(feature = "std"))]
-        use crate::util::libm::F64;
+        use crate::util::libm::Float;
 
         let quotient = quantity / (increment.get() as f64);
         let rounded = match self {

--- a/src/util/t.rs
+++ b/src/util/t.rs
@@ -19,6 +19,12 @@ pub(crate) type Sign = ri8<-1, 1>;
 /// everything uniform.
 pub(crate) type NoUnits = ri64<{ i64::MIN as i128 }, { i64::MAX as i128 }>;
 
+/// A type alias for a ranged 96-bit integer with no units.
+///
+/// This is like `NoUnits`, but useful in contexts where one wants to limit
+/// values to what can be represented to 96 bits.
+pub(crate) type NoUnits96 = ri128<{ -(1 << 95) }, { (1 << 95) - 1 }>;
+
 /// A type alias for a ranged 128-bit integer with no units.
 ///
 /// This is like `NoUnits`, but useful in contexts where one wants to limit

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -2788,9 +2788,9 @@ impl Zoned {
     /// timestamp would result in rounding up to the next day. But the next day
     /// is greater than the maximum, and so this returns an error.
     #[inline]
-    pub fn round(
+    pub fn round<R: Into<ZonedRound>>(
         &self,
-        options: impl Into<ZonedRound>,
+        options: R,
     ) -> Result<Zoned, Error> {
         let options: ZonedRound = options.into();
         options.round(self)


### PR DESCRIPTION
This PR adds a new top-level `SignedDuration` type to Jiff. This PR also
does the work to integrate it into all Jiff datetime APIs. For example,
`Zoned::checked_add` now accepts a `jiff::Span`, `jiff::SignedDuration`
or a `std::time::Duration`. To achieve this, we add a new target type,
`ZonedArithmetic`, with `From` trait implementations for each of the
corresponding duration types. We then changed the `span: Span`
parameter type to `duration: impl Into<ZonedArithmetic>`. We also add
new `Arithmetic` target types for each datetime type, for example,
`TimestampArithmetic`.

This design was chosen over using one target type shared across all
datetime types to allow for future extensibility. For example, maybe in
the future we want to add extra options to `Zoned::checked_add`. We can
now do that via `ZonedArithmetic` in a way that is distinct from other
datetime types. Moreover, this also avoids defining a new type that
*looks* a lot like a duration. Instead, the target types are purpose
built and constrained to arithmetic operations involving datetimes and
durations.

The main motivation for this was to facilitate faster arithmetic
operations in cases where folks need them and tighter integration with
the standard library `std::time::Duration` type. The `Span` type is
still the primary duration type in Jiff that almost everyone should be
using most of the time.

Closes #21