### PR TITLE
span: improve invalid units error message

### DIFF
--- a/src/span.rs
+++ b/src/span.rs
@@ -2722,17 +2722,22 @@ impl Span {
     pub(crate) fn smallest_non_time_non_zero_unit_error(
         &self,
     ) -> Option<Error> {
-        if self.days != 0 {
-            Some(t::SpanDays::error("days", self.days.get()))
+        let non_time_unit = if self.days != 0 {
+            Unit::Day
         } else if self.weeks != 0 {
-            Some(t::SpanWeeks::error("weeks", self.weeks.get()))
+            Unit::Week
         } else if self.months != 0 {
-            Some(t::SpanMonths::error("months", self.months.get()))
+            Unit::Month
         } else if self.years != 0 {
-            Some(t::SpanYears::error("years", self.years.get()))
+            Unit::Year
         } else {
-            None
-        }
+            return None;
+        };
+        Some(err!(
+            "operation can only be performed with units of hours \
+             or smaller, but found non-zero {unit} units",
+            unit = non_time_unit.singular(),
+        ))
     }
 
     /// Returns the largest non-zero unit in this span.


### PR DESCRIPTION
Previously, we would report a range error when trying to use units of
days or greater in a span when adding to a `Timestamp`. But this error
doesn't really do a good job of explaining anything. It was a hold-over
from the days where I was using many different error types and it was
difficult to improve messages on an ad hoc basis. But now, we can just
write a message.

The error message doesn't explain *why* days-and-greater are banned, but
it's hard to fit all of that into an error. At some point, we just have
to rely on folks reading the docs.

Closes #90
