### PR TITLE
api: introducing the now_with_time_zone for Zoned

### DIFF
--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -413,6 +413,44 @@ impl Zoned {
             .expect("system time is valid")
     }
 
+    /// Returns the current system time with the specific time zone.
+    ///
+    /// This is a convenience function for
+    /// `Zoned::new(Timestamp::now(), time_zone)`.
+    ///
+    /// # Panics
+    ///
+    /// This panics if the system clock is set to a time value outside of the
+    /// range `-009999-01-01T00:00:00Z..=9999-12-31T11:59:59.999999999Z`. The
+    /// justification here is that it is reasonable to expect the system clock
+    /// to be set to a somewhat sane, if imprecise, value.
+    ///
+    /// If you want to get the current Unix time fallibly, use
+    /// [`Zoned::try_from`] with a `std::time::SystemTime` as input.
+    ///
+    /// This may also panic when `SystemTime::now()` itself panics. The most
+    /// common context in which this happens is on the `wasm32-unknown-unknown`
+    /// target. If you're using that target in the context of the web (for
+    /// example, via `wasm-pack`), and you're an application, then you should
+    /// enable Jiff's `js` feature. This will automatically instruct Jiff in
+    /// this very specific circumstance to execute JavaScript code to determine
+    /// the current time from the web browser.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::{Timestamp, Zoned};
+    /// use jiff::tz::TimeZone;
+    ///
+    /// let zdt = Zoned::now_with_time_zone(TimeZone::UTC);
+    /// assert!(zdt.timestamp() > Timestamp::UNIX_EPOCH);
+    /// ```
+    #[cfg(feature = "std")]
+    #[inline]
+    pub fn now_with_time_zone(time_zone: TimeZone) -> Zoned {
+        Zoned::new(Timestamp::now(), time_zone)
+    }
+
     /// Creates a new `Zoned` value from a specific instant in a particular
     /// time zone. The time zone determines how to render the instant in time
     /// into civil time. (Also known as "clock," "wall," "local" or "naive"


### PR DESCRIPTION
close #93 

Currently, Zoned has now funcation to return the current system time in this system's time zone. I propose to introduce the now_with_time_zone for Zoned.

It's needed for some reasons:

1. How to create a now Zoned with specific time zone for current code?

    ```rust
    // solution 1
    Zoned::new(Timestamp::now(), time_zone)
    
    // Solution 2, logforth[1] is using this solution.
    Zoned::now().with_time_zone(tz)
    ```

    `Zoned::now` (Solution2) has clearer semantics for developers, but it requires repeated creation of TimeZone objects. (Zoned::now needs to clone a default TimeZone, and with_time_zone also requires a TimeZone).

    I have a benchmark for them[2]:
        - The avg time solution 1 is 297.61 ns
        - The avg time solution 2 is 443.87 ns
        - 297.61 ns * 151% = 443.87 ns, so performance of solution 1 is totally better than solution2. 

2. The ZonedDateTime[3] of Java has 3 now functions, it includes now(), now(ZoneId) and now(Clock). It's useful for developers.


[1] https://github.com/fast/logforth/blob/b2d5e7e664595f58d35377136b4936fc4ac22c3f/src/layout/text.rs#L89
[2] https://github.com/1996fanrui/fanrui-learning/blob/aacfa73de1a2299745241806f61aa098d0b66a23/rust-learning/benches/jiff_benchmark.rs#L6
[3] https://docs.oracle.com/en%2Fjava%2Fjavase%2F11%2Fdocs%2Fapi%2F%2F/java.base/java/time/ZonedDateTime.html#now(java.time.ZoneId)

