### PR TITLE
use threads to update default time zone cache asynchronously

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ keywords = ["date", "time", "temporal", "zone", "iana"]
 edition = "2021"
 exclude = ["/.github", "/tmp"]
 autotests = false
-autoexamples = false
 rust-version = "1.70"
 
 [workspace]
@@ -23,7 +22,6 @@ members = [
   "jiff-cli",
   "jiff-tzdb",
   "jiff-tzdb-platform",
-  "examples/*",
 ]
 
 # Features are documented in the "Crate features" section of the crate docs:

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -19,6 +19,11 @@ name = "jiff-bench"
 harness = false
 path = "src/bench.rs"
 
+[[bench]]
+name = "default_time_zone_benchmark"
+harness = false
+path = "src/default_time_zone_benchmark.rs"
+
 [dependencies]
 criterion = "0.5.1"
 jiff = { version = "0.1.0", path = ".." }

--- a/bench/src/default_time_zone_benchmark.rs
+++ b/bench/src/default_time_zone_benchmark.rs
@@ -1,0 +1,35 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use jiff::tz::TimeZone;
+use std::sync::RwLock;
+use std::time::Instant;
+
+fn default_time_zone_benchmark(c: &mut Criterion) {
+    c.bench_function("Get default TimeZone::system()", |b| {
+        b.iter(|| {
+            TimeZone::system();
+        })
+    });
+
+    c.bench_function("Clone a TimeZone", |b| {
+        let tz = TimeZone::system();
+        b.iter(|| {
+            let _ = tz.clone();
+        })
+    });
+
+    c.bench_function("Read lock", |b| {
+        let cache: RwLock<usize> = RwLock::new(0);
+        b.iter(|| {
+            let a = cache.read().unwrap();
+        })
+    });
+
+    c.bench_function("Instant::now", |b| {
+        b.iter(|| {
+            let _ = Instant::now();
+        })
+    });
+}
+
+criterion_group!(benches, default_time_zone_benchmark);
+criterion_main!(benches);

--- a/examples/default_time_zone_demo/main.rs
+++ b/examples/default_time_zone_demo/main.rs
@@ -1,0 +1,36 @@
+use jiff::tz::TimeZone;
+use std::thread::sleep;
+use std::time::Duration;
+
+fn main() {
+    // The time zone is updated by async thread each 20 seconds.
+    // And we get the default time zone continuously,
+    // so we can see the log: `cache is still using, so update the tz.`
+    for i in 1..=50 {
+        sleep(Duration::from_secs(1));
+        TimeZone::system();
+        println!("round 1------{i}");
+    }
+
+    // Stop the get the default time zone for a while, so we can see the log :
+    // `cache is not used so far, so stop this thread.`
+    for i in 1..=35 {
+        sleep(Duration::from_secs(1));
+        println!("round 2------{i}");
+    }
+
+    // Get the default time zone again, we can see
+    // `try_update_time_zone` log to start the thread again.
+    // And see the `cache is still using, so update the tz.` log later.
+    for i in 1..=50 {
+        sleep(Duration::from_secs(1));
+        TimeZone::system();
+        println!("round 3------{i}");
+    }
+
+    // See the `cache is not used so far, so stop this thread.` log later.
+    for i in 1..=50 {
+        sleep(Duration::from_secs(1));
+        println!("round 4------{i}");
+    }
+}


### PR DESCRIPTION
close #96 

# Background

`TimeZone::system()` obtains the default time zone, and it may be called frequently by users. 

Especially, `Zoned::now` will call it. In some systems, `Zoned::now` is frequently used to obtain the current time. For example, log system will call it for each log item.

# How long does `TimeZone::system()` need? and why?a

After run the benchmark on my Mac, I found `TimeZone::system()` needs `61.665 ns`, its cost mainly consists of 3 parts:

1. TimeZone.clone[1] costs ***9.3 ns***, it clones the TimeZone from cache.
2. Request the read lock[2] costs ***16.88 ns***. (The read lock of cache.)
3. Obtain current time via `Instant::now`[3] costs ***37.3 ns***, the Instant is used for checking whether the cache is expired.

So the `Instant::now`(part 3) takes most of time.

# The idea of optimization

Don't call `Instant::now` during call `TimeZone::system()`, and we could start a light async thread to update the default time zone cache periodically.

Note: if the default time zone is obtained by async thread, we could update it more frequently. For example: update the default TTL from 5 minutes to 20 seconds or less.

[1] https://github.com/BurntSushi/jiff/blob/c659069a2765a5e28ba503ea37e8a2eee4b10a92/src/tz/system/mod.rs#L119
[2] https://github.com/BurntSushi/jiff/blob/c659069a2765a5e28ba503ea37e8a2eee4b10a92/src/tz/system/mod.rs#L104
[3] https://github.com/BurntSushi/jiff/blob/c659069a2765a5e28ba503ea37e8a2eee4b10a92/src/tz/system/mod.rs#L106

This PR is a draft PR due to it includes some temporary benchmark code or use case.

I will polish this PR if the solution makes sense. 