### PR TITLE
bench: add the zoned benchmark for Asia/Shanghai

### DIFF
--- a/bench/src/bench.rs
+++ b/bench/src/bench.rs
@@ -577,16 +577,16 @@ fn parse_strptime(c: &mut Criterion) {
 
 criterion::criterion_group!(
     benches,
-    // civil_datetime_to_instant_with_tzdb_lookup,
-    // civil_datetime_to_instant_static,
+    civil_datetime_to_instant_with_tzdb_lookup,
+    civil_datetime_to_instant_static,
     instant_to_civil_datetime_static,
-    // instant_to_civil_datetime_offset,
-    // offset_to_civil_datetime,
-    // offset_to_timestamp,
-    // zoned_add_time_duration,
-    // parse_civil_datetime,
-    // parse_rfc2822,
-    // parse_strptime,
-    // print_civil_datetime,
+    instant_to_civil_datetime_offset,
+    offset_to_civil_datetime,
+    offset_to_timestamp,
+    zoned_add_time_duration,
+    parse_civil_datetime,
+    parse_rfc2822,
+    parse_strptime,
+    print_civil_datetime,
 );
 criterion::criterion_main!(benches);

--- a/bench/src/bench.rs
+++ b/bench/src/bench.rs
@@ -2,6 +2,10 @@ use std::hint::black_box as bb;
 
 use criterion::Criterion;
 
+const TZ_NEW_YORK: &str = "America/New_York";
+
+const TZ_SHANGHAI: &str = "Asia/Shanghai";
+
 /// This benchmarks the time it takes to convert a civil datetime to a specific
 /// instant, *including* the time it takes to lookup a time zone in the system
 /// zoneinfo database. (Lookups may be cached by the library, but that is part
@@ -115,15 +119,31 @@ fn civil_datetime_to_instant_static(c: &mut Criterion) {
 /// human readable representation (i.e., what you might see on a clock) in a
 /// specific time zone.
 fn instant_to_civil_datetime_static(c: &mut Criterion) {
-    const NAME: &str = "instant_to_civil_datetime_static";
-    const TZNAME: &str = "America/New_York";
-    const STAMP: i64 = 1719755160;
+    instant_to_civil_datetime_static_with_specific_tz(
+        c,
+        TZ_NEW_YORK,
+        1719755160,
+    );
+    instant_to_civil_datetime_static_with_specific_tz(
+        c,
+        TZ_SHANGHAI,
+        1719711960,
+    );
+}
 
-    if let Ok(tz) = jiff::tz::TimeZone::get(TZNAME) {
+fn instant_to_civil_datetime_static_with_specific_tz(
+    c: &mut Criterion,
+    tz_name: &str,
+    timestamp: i64,
+) {
+    const NAME: &str = "instant_to_civil_datetime_static";
+
+    if let Ok(tz) = jiff::tz::TimeZone::get(tz_name) {
         let expected = jiff::civil::date(2024, 6, 30).at(9, 46, 0, 0);
 
-        let ts = jiff::Timestamp::from_second(STAMP).unwrap();
-        c.bench_function(&format!("jiff/{NAME}"), |b| {
+        let ts = jiff::Timestamp::from_second(timestamp).unwrap();
+
+        c.bench_function(&format!("jiff/{NAME}-{tz_name}"), |b| {
             b.iter(|| {
                 let zdt = bb(ts).to_zoned(bb(&tz).clone());
                 assert_eq!(zdt.datetime(), expected);
@@ -133,37 +153,52 @@ fn instant_to_civil_datetime_static(c: &mut Criterion) {
 
     #[cfg(unix)]
     {
-        if let Ok(tz) = tzfile::Tz::named(TZNAME) {
+        if let Ok(tz) = tzfile::Tz::named(tz_name) {
             let expected = chrono::NaiveDateTime::new(
                 chrono::NaiveDate::from_ymd_opt(2024, 6, 30).unwrap(),
                 chrono::NaiveTime::from_hms_opt(9, 46, 0).unwrap(),
             );
-            c.bench_function(&format!("chrono-tzfile/{NAME}"), |b| {
-                use chrono::TimeZone;
+            c.bench_function(
+                &format!("chrono-tzfile/{NAME}-{tz_name}"),
+                |b| {
+                    use chrono::TimeZone;
 
-                b.iter(|| {
-                    let mapped = (&tz).timestamp_opt(bb(STAMP), 0);
-                    let zdt = mapped.single().unwrap();
-                    assert_eq!(zdt.naive_local(), expected);
-                })
-            });
+                    b.iter(|| {
+                        let mapped = (&tz).timestamp_opt(bb(timestamp), 0);
+                        let zdt = mapped.single().unwrap();
+                        assert_eq!(zdt.naive_local(), expected);
+                    })
+                },
+            );
         }
     }
 
-    let expected = chrono::NaiveDateTime::new(
-        chrono::NaiveDate::from_ymd_opt(2024, 6, 30).unwrap(),
-        chrono::NaiveTime::from_hms_opt(9, 46, 0).unwrap(),
-    );
-    c.bench_function(&format!("chrono/{NAME}"), |b| {
-        use chrono::TimeZone;
-        use chrono_tz::America::New_York;
+    use chrono_tz::America::New_York;
+    use chrono_tz::Asia::Shanghai;
+    use chrono_tz::Tz;
 
-        b.iter(|| {
-            let mapped = New_York.timestamp_opt(bb(STAMP), 0);
-            let zdt = mapped.single().unwrap();
-            assert_eq!(zdt.naive_local(), expected);
-        })
-    });
+    let tz: Option<Tz> = match tz_name {
+        TZ_NEW_YORK => Some(New_York),
+        TZ_SHANGHAI => Some(Shanghai),
+        _ => None,
+    };
+
+    if let Some(tz) = tz {
+        let expected = chrono::NaiveDateTime::new(
+            chrono::NaiveDate::from_ymd_opt(2024, 6, 30).unwrap(),
+            chrono::NaiveTime::from_hms_opt(9, 46, 0).unwrap(),
+        );
+
+        c.bench_function(&format!("chrono/{NAME}-{tz_name}"), |b| {
+            use chrono::TimeZone;
+
+            b.iter(|| {
+                let mapped = tz.timestamp_opt(bb(timestamp), 0);
+                let zdt = mapped.single().unwrap();
+                assert_eq!(zdt.naive_local(), expected);
+            })
+        });
+    }
 
     // The `time` crate doesn't support this.
 }

--- a/bench/src/bench.rs
+++ b/bench/src/bench.rs
@@ -115,9 +115,11 @@ fn civil_datetime_to_instant_static(c: &mut Criterion) {
 /// human readable representation (i.e., what you might see on a clock) in a
 /// specific time zone.
 fn instant_to_civil_datetime_static(c: &mut Criterion) {
-    fn define(c: &mut Criterion, tz_name: &str, timestamp: i64) {
-        const NAME: &str = "instant_to_civil_datetime_static";
+    const NAME: &str = "instant_to_civil_datetime_static";
+    const TZ_NEW_YORK: &str = "America/New_York";
+    const TZ_SHANGHAI: &str = "Asia/Shanghai";
 
+    fn define(c: &mut Criterion, tz_name: &str, timestamp: i64) {
         if let Ok(tz) = jiff::tz::TimeZone::get(tz_name) {
             let expected = jiff::civil::date(2024, 6, 30).at(9, 46, 0, 0);
 
@@ -175,9 +177,6 @@ fn instant_to_civil_datetime_static(c: &mut Criterion) {
 
         // The `time` crate doesn't support this.
     }
-
-    const TZ_NEW_YORK: &str = "America/New_York";
-    const TZ_SHANGHAI: &str = "Asia/Shanghai";
 
     define(c, TZ_NEW_YORK, 1719755160);
     define(c, TZ_SHANGHAI, 1719711960);


### PR DESCRIPTION
Some timezones have DST(daylight saving time) and others do not. For example:

- "America/New_York" time zone has DST
- "Asia/Shanghai" had DST a long time ago, but it was cancelled long ago.

When I look into Zoned::new, I found the code path with DST is very different from the code path without DST. And their performance is totally different.

So I propose to improve the instant_to_civil_datetime_static to bench DST and Non-DST separately.

Here is the benchmark result on my Mac:

```
cargo bench --bench jiff-bench
critcmp -g '^[^/]+/(.*)$' -f '^(chrono|chrono-tzfile|jiff)/' base

group                                                base/chrono-tzfile/                    base/chrono/                           base/jiff/
-----                                                -------------------                    ------------                           ----------
instant_to_civil_datetime_static-America/New_York    1.19     46.2±1.01ns        ? ?/sec    1.00     38.8±0.98ns        ? ?/sec    1.92     74.6±2.27ns        ? ?/sec
instant_to_civil_datetime_static-Asia/Shanghai       1.00     34.7±0.51ns        ? ?/sec    1.08     37.4±0.62ns        ? ?/sec    2.87     99.3±1.35ns        ? ?/sec
```

Note: I will submit some PR to optimize their performance later. (Merging this PR first is useful to observe the performance change.)