### PR TITLE
improvement: ReasonablePosixTimeZone#to_offset returns default value directly when dst is none

### DIFF
--- a/src/tz/posix.rs
+++ b/src/tz/posix.rs
@@ -286,6 +286,10 @@ impl ReasonablePosixTimeZone {
         &self,
         timestamp: Timestamp,
     ) -> (Offset, Dst, &str) {
+        if self.dst.is_none() {
+            return (self.std_offset(), Dst::No, &self.std_abbrev);
+        }
+
         let dt = Offset::UTC.to_datetime(timestamp);
         self.dst_info_utc(dt.date().year_ranged())
             .filter(|dst_info| dst_info.in_dst(dt))


### PR DESCRIPTION
The subsequent optimization of https://github.com/BurntSushi/jiff/pull/103

## The logic inside of `ReasonablePosixTimeZone#to_offset` when `self.dst` is None.

`dst_info_utc` returns None when `self.dst` is None, then `unwrap_or_else` will return the std offset as the result. 

The `let dt = Offset::UTC.to_datetime(timestamp);` takes a lot of time, but it isn't used when `self.dst` is None. So we can skip it when `self.dst` is None.

## Performance change

This code takes 30% time of `Zoned::new`, when TimeZone doesn't have DST(daylight saving time). So after this change, the performance of `instant_to_civil_datetime_static-Asia/Shanghai` is improved by 30% on my Mac.

The time changed from 99.3±1.35ns  to 68.4±5.85ns on my Mac, and following is the detailed result:

```
# before this PR(master branch)
group                                                base/chrono-tzfile/                    base/chrono/                           base/jiff/
-----                                                -------------------                    ------------                           ----------
instant_to_civil_datetime_static-Asia/Shanghai       1.00     34.7±0.51ns        ? ?/sec    1.08     37.4±0.62ns        ? ?/sec    2.87     99.3±1.35ns        ? ?/sec

# After this PR
group                                                base/chrono-tzfile/                    base/chrono/                           base/jiff/
-----                                                -------------------                    ------------                           ----------
instant_to_civil_datetime_static-Asia/Shanghai       1.00     34.5±0.98ns        ? ?/sec    1.10     38.1±2.72ns        ? ?/sec    1.98     68.4±5.85ns        ? ?/sec

```