### PR TITLE
cargo: permit windows-sys >=0.52.0 and <=0.59.*

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ serde = { version = "1.0.203", optional = true }
 jiff-tzdb-platform = { version = "0.1.0", path = "jiff-tzdb-platform", optional = true }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.52.0"
+version = ">=0.52.0, <=0.59.*"
 default-features = false
 features = ["Win32_Foundation", "Win32_System_Time"]
 optional = true


### PR DESCRIPTION
This matches a similar change made by @ChrisDenton for winapi-util in:
https://github.com/BurntSushi/winapi-util/pull/19

The benefit is that this should hopefully put less constraints on the
ecosystem and to enable fewer copies of windows-sys to appear in
dependency trees.

I am somewhat miffed that this is necessary. IMO, the windows-sys
maintainers should find a way to make a stable release with infrequent
or ~zero breaking change releases.
