### PR TITLE
cargo: fix alloc-only build

### DIFF
--- a/src/duration.rs
+++ b/src/duration.rs
@@ -1,4 +1,4 @@
-use std::time::Duration as UnsignedDuration;
+use core::time::Duration as UnsignedDuration;
 
 use crate::{
     error::{err, ErrorContext},

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -2106,7 +2106,7 @@ impl Timestamp {
             .expect("absolute value of seconds fits in u64");
         let nanosecond = u32::try_from(self.subsec_nanosecond().abs())
             .expect("nanosecond always fit in a u32");
-        (self.signum(), std::time::Duration::new(second, nanosecond))
+        (self.signum(), core::time::Duration::new(second, nanosecond))
     }
 }
 

--- a/test
+++ b/test
@@ -25,6 +25,7 @@ features=(
 )
 for f in "${features[@]}"; do
     echo "===== FEATURE: $f ====="
+    cargo build --no-default-features --features "$f"
     cargo test --lib --no-default-features --features "$f"
     cargo test --test integration --no-default-features --features "$f"
 done


### PR DESCRIPTION
I was lured into a false sense of confidence with CI testing. Because
tests unconditionally enable `std`, this

    cargo test --lib --no-default-features --features alloc

doesn't actually fail when there is an errant `std` reference. But this
does:

    cargo build --no-default-features --features alloc

We fix our `test` script to catch this case and also fix the build
errors.

Fixes #108
