### PR TITLE
api: add options for controlling precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+0.1.9 (2024-08-23)
+==================
+This release introduces new options for controlling the precision
+of fractional seconds when printing `Zoned`, `Timestamp`,
+`civil::DateTime` or `civil::Time` values. This is principally exposed
+via `jiff::fmt::temporal::DateTimePrinter::precision`, but it's also
+available via the standard library's formatting machinery. For example,
+if `zdt` is a `jiff::Zoned`, then `format!("{zdt:.6}")` will format
+it into a string with microsecond precision, even if its fractional
+component is zero.
+
+Enhancements:
+
+* [#92](https://github.com/BurntSushi/jiff/issues/92):
+Support setting the precision of fractional seconds when printing datetimes.
+
+
 0.1.8 (2024-08-19)
 ==================
 This releases fixes a build error in Jiff's `alloc`-only configuration. This

--- a/src/fmt/temporal/mod.rs
+++ b/src/fmt/temporal/mod.rs
@@ -885,6 +885,70 @@ impl DateTimePrinter {
         self
     }
 
+    /// Set the precision to use for formatting the fractional second component
+    /// of a time.
+    ///
+    /// The default is `None`, which will automatically set the precision based
+    /// on the value.
+    ///
+    /// When the precision is set to `N`, you'll always get precisely `N`
+    /// digits after a decimal point (unless `N==0`, then no fractional
+    /// component is printed), even if they are `0`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::{civil::date, fmt::temporal::DateTimePrinter};
+    ///
+    /// const PRINTER: DateTimePrinter =
+    ///     DateTimePrinter::new().precision(Some(3));
+    ///
+    /// let zdt = date(2024, 6, 15).at(7, 0, 0, 123_456_789).intz("US/Eastern")?;
+    ///
+    /// let mut buf = String::new();
+    /// // Printing to a `String` can never fail.
+    /// PRINTER.print_zoned(&zdt, &mut buf).unwrap();
+    /// assert_eq!(buf, "2024-06-15T07:00:00.123-04:00[US/Eastern]");
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// # Example: available via formatting machinery
+    ///
+    /// When formatting datetime types that may contain a fractional second
+    /// component, this can be set via Rust's formatting DSL. Specifically,
+    /// it corresponds to the [`std::fmt::Formatter::precision`] setting.
+    ///
+    /// ```
+    /// use jiff::civil::date;
+    ///
+    /// let zdt = date(2024, 6, 15).at(7, 0, 0, 123_000_000).intz("US/Eastern")?;
+    /// assert_eq!(
+    ///     format!("{zdt:.6}"),
+    ///     "2024-06-15T07:00:00.123000-04:00[US/Eastern]",
+    /// );
+    /// // Precision values greater than 9 are clamped to 9.
+    /// assert_eq!(
+    ///     format!("{zdt:.300}"),
+    ///     "2024-06-15T07:00:00.123000000-04:00[US/Eastern]",
+    /// );
+    /// // A precision of 0 implies the entire fractional
+    /// // component is always truncated.
+    /// assert_eq!(
+    ///     format!("{zdt:.0}"),
+    ///     "2024-06-15T07:00:00-04:00[US/Eastern]",
+    /// );
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub const fn precision(
+        mut self,
+        precision: Option<u8>,
+    ) -> DateTimePrinter {
+        self.p = self.p.precision(precision);
+        self
+    }
+
     /// Print a `Zoned` datetime to the given writer.
     ///
     /// # Errors

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -6,7 +6,7 @@ use crate::{
     error::{err, Error, ErrorContext},
     fmt::{
         self,
-        temporal::{DEFAULT_DATETIME_PARSER, DEFAULT_DATETIME_PRINTER},
+        temporal::{self, DEFAULT_DATETIME_PARSER},
     },
     tz::{AmbiguousOffset, Disambiguation, Offset, OffsetConflict, TimeZone},
     util::{
@@ -2979,17 +2979,85 @@ impl Default for Zoned {
     }
 }
 
+/// Converts a `Zoned` datetime into a human readable datetime string.
+///
+/// (This `Debug` representation currently emits the same string as the
+/// `Display` representation, but this is not a guarantee.)
+///
+/// Options currently supported:
+///
+/// * [`std::fmt::Formatter::precision`] can be set to control the precision
+/// of the fractional second component.
+///
+/// # Example
+///
+/// ```
+/// use jiff::civil::date;
+///
+/// let zdt = date(2024, 6, 15).at(7, 0, 0, 123_000_000).intz("US/Eastern")?;
+/// assert_eq!(
+///     format!("{zdt:.6?}"),
+///     "2024-06-15T07:00:00.123000-04:00[US/Eastern]",
+/// );
+/// // Precision values greater than 9 are clamped to 9.
+/// assert_eq!(
+///     format!("{zdt:.300?}"),
+///     "2024-06-15T07:00:00.123000000-04:00[US/Eastern]",
+/// );
+/// // A precision of 0 implies the entire fractional
+/// // component is always truncated.
+/// assert_eq!(
+///     format!("{zdt:.0?}"),
+///     "2024-06-15T07:00:00-04:00[US/Eastern]",
+/// );
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
 impl core::fmt::Debug for Zoned {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         core::fmt::Display::fmt(self, f)
     }
 }
 
+/// Converts a `Zoned` datetime into a RFC 9557 compliant string.
+///
+/// Options currently supported:
+///
+/// * [`std::fmt::Formatter::precision`] can be set to control the precision
+/// of the fractional second component.
+///
+/// # Example
+///
+/// ```
+/// use jiff::civil::date;
+///
+/// let zdt = date(2024, 6, 15).at(7, 0, 0, 123_000_000).intz("US/Eastern")?;
+/// assert_eq!(
+///     format!("{zdt:.6}"),
+///     "2024-06-15T07:00:00.123000-04:00[US/Eastern]",
+/// );
+/// // Precision values greater than 9 are clamped to 9.
+/// assert_eq!(
+///     format!("{zdt:.300}"),
+///     "2024-06-15T07:00:00.123000000-04:00[US/Eastern]",
+/// );
+/// // A precision of 0 implies the entire fractional
+/// // component is always truncated.
+/// assert_eq!(
+///     format!("{zdt:.0}"),
+///     "2024-06-15T07:00:00-04:00[US/Eastern]",
+/// );
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
 impl core::fmt::Display for Zoned {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         use crate::fmt::StdFmtWrite;
 
-        DEFAULT_DATETIME_PRINTER
+        let precision =
+            f.precision().map(|p| u8::try_from(p).unwrap_or(u8::MAX));
+        temporal::DateTimePrinter::new()
+            .precision(precision)
             .print_zoned(self, StdFmtWrite(f))
             .map_err(|_| core::fmt::Error)
     }


### PR DESCRIPTION
This PR introduces new options for controlling the precision
of fractional seconds when printing `Zoned`, `Timestamp`,
`civil::DateTime` or `civil::Time` values. This is principally exposed
via `jiff::fmt::temporal::DateTimePrinter::precision`, but it's also
available via the standard library's formatting machinery. For example,
if `zdt` is a `jiff::Zoned`, then `format!("{zdt:.6}")` will format
it into a string with microsecond precision, even if its fractional
component is zero.

This is useful when one wants a datetime to use a "fixed width" format.
Or at least, as close to one as possible. For `Zoned` in particular, a
fixed width format is somewhat difficult to accomplish because of the
variable length IANA time zone identifier. But if the time zone
identifier is the same for all `Zoned` values in a particular context,
then setting the precision will provide fixed width. (Unless the years
are negative.)

Closes #92
