### PR TITLE
tz: attempt to read TZ symlink as IANA time zone identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+0.1.10 (2024-08-23)
+===================
+This release features a small bug fix where Jiff will detect an IANA time
+zone identifier in some cases where it wouldn't before. While Jiff would
+previously read the symlink metadata on `/etc/localtime` by default to discover
+the system configured time zone on Unix systems, it *wouldn't* do so when
+`TZ=/etc/localtime`. There's really no reason not to, so this release of Jiff
+is fixed to use symlink sniffing on file paths provided by thw `TZ` environment
+variable.
+
+Bug fixes:
+
+* [#113](https://github.com/BurntSushi/jiff/issues/113):
+When `TZ=/etc/localtime`, use symlink metadata to detect IANA identifier.
+
+
 0.1.9 (2024-08-23)
 ==================
 This release introduces new options for controlling the precision

--- a/src/tz/system/wasm_js.rs
+++ b/src/tz/system/wasm_js.rs
@@ -45,3 +45,13 @@ pub(super) fn get(db: &TimeZoneDatabase) -> Option<TimeZone> {
     };
     Some(tz)
 }
+
+pub(super) fn read(_db: &TimeZoneDatabase, path: &str) -> Option<TimeZone> {
+    match super::read_unnamed_tzif_file(path) {
+        Ok(tz) => Some(tz),
+        Err(_err) => {
+            trace!("failed to read {path} as unnamed time zone: {_err}");
+            None
+        }
+    }
+}

--- a/src/tz/system/windows/mod.rs
+++ b/src/tz/system/windows/mod.rs
@@ -62,6 +62,16 @@ pub(super) fn get(db: &TimeZoneDatabase) -> Option<TimeZone> {
     Some(tz)
 }
 
+pub(super) fn read(_db: &TimeZoneDatabase, path: &str) -> Option<TimeZone> {
+    match super::read_unnamed_tzif_file(path) {
+        Ok(tz) => Some(tz),
+        Err(_err) => {
+            trace!("failed to read {path} as unnamed time zone: {_err}");
+            None
+        }
+    }
+}
+
 fn windows_to_iana(tz_key_name: &str) -> Result<&'static str, Error> {
     let result = WINDOWS_TO_IANA.binary_search_by(|(win_name, _)| {
         cmp_ignore_ascii_case(win_name, &tz_key_name)


### PR DESCRIPTION
Previously, we would only attempt to use symlink metadata when reading
from /etc/localtime explicitly. We didn't do this when `TZ` is set to a
path. And in particular, `TZ` might actually be set to `/etc/localtime`,
in which case, it's likely a symlink. And we can detect the IANA time
zone identifier from the symlink in most cases. Just like we would by
default if `TZ` wasn't set.

I originally didn't do this because the code for handling `TZ` was
actually completely platform independent, so it didn't occur to me to do
something platform specific on Unix. But it's not too hard to do.

While setting `TZ=/etc/localtime` is odd, apparently this is given as
advice to folks for libc to avoid repeatedly reading `/etc/localtime` to
check for updates. Seems weird to me, but whatever. Jiff should try to
detect symlink metadata regardless of libc shenanigans.

Fixes #113
