### PR TITLE
fmt/strtime: add set_offset and set_iana_time_zone to BrokenDownTime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ TODO
 
 Enhancements:
 
+* [#78](https://github.com/BurntSushi/jiff/issues/78):
+Add `BrokenDownTime::set_{offset,iana_time_zone}` APIs.
 * [#93](https://github.com/BurntSushi/jiff/issues/93):
 Add note about using `Timestamp::now().to_zoned()` instead of
 `Zoned::now().with_time_zone()`.


### PR DESCRIPTION
These have been added so that they can be set explicitly, like other
fields. This also includes an accessor for the IANA time zone
identifier.

I'm not sure why I didn't add these initially since there isn't anything
subtle going on here. I think it might have just been an oversight.

Fixes #78
