### PR TITLE
fmt: support formatting `Timestamp` with a specific offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# CHANGELOG
+
 0.1.12 (2024-08-31)
 ===================
 This release introduces some new minor APIs that support formatting
@@ -20,7 +22,7 @@ a `Timestamp` with a specific offset. While this isn't as expressive
 as formatting a datetime with a time zone (e.g., with an IANA time
 zone identifier), it may be useful in contexts where you just want to
 "hint" at what a user's local time is. To that end, there is a new
-[`Timestamp::display_with_offset`] method that makes this possible:
+`Timestamp::display_with_offset` method that makes this possible:
 
 ```rust
 use jiff::{tz, Timestamp};
@@ -42,7 +44,7 @@ were using the RFC 2822 printer to format a `Timestamp`, you had to do this:
 use jiff::{fmt::rfc2822::DateTimePrinter, Timestamp};
 
 let mut buf = String::new();
-DateTimePrinter::new().print_timestamp(&Timestamp::UNIX_EPOCH, &mut buf)?;
+DateTimePrinter::new().print_timestamp(&Timestamp::UNIX_EPOCH, &mut buf).unwrap();
 assert_eq!(buf, "Thu, 1 Jan 1970 00:00:00 -0000");
 ```
 
@@ -52,7 +54,7 @@ But now you can just do this:
 use jiff::{fmt::rfc2822::DateTimePrinter, Timestamp};
 
 assert_eq!(
-    DateTimePrinter::new().timestamp_to_string(&Timestamp::UNIX_EPOCH)?;
+    DateTimePrinter::new().timestamp_to_string(&Timestamp::UNIX_EPOCH).unwrap(),
     "Thu, 1 Jan 1970 00:00:00 -0000",
 );
 ```
@@ -75,15 +77,16 @@ or nanoseconds. For example:
 ```rust
 use jiff::Timestamp;
 
+#[derive(serde::Serialize, serde::Deserialize)]
 struct Record {
     #[serde(with = "jiff::fmt::serde::timestamp::second::required")]
     timestamp: Timestamp,
 }
 
 let json = r#"{"timestamp":1517644800}"#;
-let got: Record = serde_json::from_str(&json)?;
-assert_eq!(got.timestamp, Timestamp::from_second(1517644800)?);
-assert_eq!(serde_json::to_string(&got)?, json);
+let got: Record = serde_json::from_str(&json).unwrap();
+assert_eq!(got.timestamp, Timestamp::from_second(1517644800).unwrap());
+assert_eq!(serde_json::to_string(&got).unwrap(), json);
 ```
 
 If you need to support optional timestamps via `Option<Timestamp>`, then use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,68 @@
+0.1.12 (2024-08-31)
+===================
+This release introduces some new minor APIs that support formatting
+`Timestamp` values as RFC 3339 strings with a specific offset.
+
+Previously, using the standard formatting routines that Jiff provides, it was
+only possible to format a `Timestamp` using Zulu time. For example:
+
+```rust
+use jiff::Timestamp;
+
+assert_eq!(
+    Timestamp::UNIX_EPOCH.to_string(),
+    "1970-01-01T00:00:00Z",
+);
+```
+
+This is fine most use cases, but it can be useful on occasion to format
+a `Timestamp` with a specific offset. While this isn't as expressive
+as formatting a datetime with a time zone (e.g., with an IANA time
+zone identifier), it may be useful in contexts where you just want to
+"hint" at what a user's local time is. To that end, there is a new
+[`Timestamp::display_with_offset`] method that makes this possible:
+
+```rust
+use jiff::{tz, Timestamp};
+
+assert_eq!(
+    Timestamp::UNIX_EPOCH.display_with_offset(tz::offset(-5)).to_string(),
+    "1969-12-31T19:00:00-05:00",
+);
+```
+
+A corresponding API was added to `jiff::fmt::temporal::DateTimePrinter` for
+lower level use.
+
+Moreover, this release also includes new convenience APIs on the Temporal and
+RFC 2822 printer types for returning strings. For example, previously, if you
+were using the RFC 2822 printer to format a `Timestamp`, you had to do this:
+
+```rust
+use jiff::{fmt::rfc2822::DateTimePrinter, Timestamp};
+
+let mut buf = String::new();
+DateTimePrinter::new().print_timestamp(&Timestamp::UNIX_EPOCH, &mut buf)?;
+assert_eq!(buf, "Thu, 1 Jan 1970 00:00:00 -0000");
+```
+
+But now you can just do this:
+
+```rust
+use jiff::{fmt::rfc2822::DateTimePrinter, Timestamp};
+
+assert_eq!(
+    DateTimePrinter::new().timestamp_to_string(&Timestamp::UNIX_EPOCH)?;
+    "Thu, 1 Jan 1970 00:00:00 -0000",
+);
+```
+
+Enhancements:
+
+* [#122](https://github.com/BurntSushi/jiff/issues/122):
+Support formatting `Timestamp` to an RFC 3339 string with a specific offset.
+
+
 0.1.11 (2024-08-28)
 ===================
 This release includes a few small enhancements that have been requested over

--- a/src/fmt/rfc2822.rs
+++ b/src/fmt/rfc2822.rs
@@ -105,6 +105,7 @@ pub(crate) static DEFAULT_DATETIME_PRINTER: DateTimePrinter =
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
+#[inline]
 pub fn to_string(zdt: &Zoned) -> Result<String, Error> {
     let mut buf = String::new();
     DEFAULT_DATETIME_PRINTER.print_zoned(zdt, &mut buf)?;
@@ -168,6 +169,7 @@ pub fn to_string(zdt: &Zoned) -> Result<String, Error> {
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
+#[inline]
 pub fn parse(string: &str) -> Result<Zoned, Error> {
     DEFAULT_DATETIME_PARSER.parse_zoned(string)
 }
@@ -222,6 +224,7 @@ pub struct DateTimeParser {
 
 impl DateTimeParser {
     /// Create a new RFC 2822 datetime parser with the default configuration.
+    #[inline]
     pub const fn new() -> DateTimeParser {
         DateTimeParser { relaxed_weekday: false }
     }
@@ -259,6 +262,7 @@ impl DateTimeParser {
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    #[inline]
     pub const fn relaxed_weekday(self, yes: bool) -> DateTimeParser {
         DateTimeParser { relaxed_weekday: yes, ..self }
     }
@@ -1090,6 +1094,7 @@ pub struct DateTimePrinter {
 
 impl DateTimePrinter {
     /// Create a new RFC 2822 datetime printer with the default configuration.
+    #[inline]
     pub const fn new() -> DateTimePrinter {
         DateTimePrinter { _private: () }
     }

--- a/src/fmt/temporal/mod.rs
+++ b/src/fmt/temporal/mod.rs
@@ -244,6 +244,7 @@ pub struct DateTimeParser {
 
 impl DateTimeParser {
     /// Create a new Temporal datetime parser with the default configuration.
+    #[inline]
     pub const fn new() -> DateTimeParser {
         DateTimeParser {
             p: parser::DateTimeParser::new(),
@@ -283,6 +284,7 @@ impl DateTimeParser {
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    #[inline]
     pub const fn offset_conflict(
         self,
         strategy: OffsetConflict,
@@ -363,6 +365,7 @@ impl DateTimeParser {
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    #[inline]
     pub const fn disambiguation(
         self,
         strategy: Disambiguation,
@@ -849,6 +852,7 @@ impl DateTimePrinter {
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    #[inline]
     pub const fn lowercase(mut self, yes: bool) -> DateTimePrinter {
         self.p = self.p.lowercase(yes);
         self
@@ -880,6 +884,7 @@ impl DateTimePrinter {
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    #[inline]
     pub const fn separator(mut self, ascii_char: u8) -> DateTimePrinter {
         self.p = self.p.separator(ascii_char);
         self
@@ -941,6 +946,7 @@ impl DateTimePrinter {
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    #[inline]
     pub const fn precision(
         mut self,
         precision: Option<u8>,
@@ -1231,6 +1237,7 @@ pub struct SpanParser {
 
 impl SpanParser {
     /// Create a new Temporal datetime printer with the default configuration.
+    #[inline]
     pub const fn new() -> SpanParser {
         SpanParser { p: parser::SpanParser::new() }
     }
@@ -1389,6 +1396,7 @@ pub struct SpanPrinter {
 
 impl SpanPrinter {
     /// Create a new Temporal span printer with the default configuration.
+    #[inline]
     pub const fn new() -> SpanPrinter {
         SpanPrinter { p: printer::SpanPrinter::new() }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -688,8 +688,8 @@ pub use crate::{
         SpanTotal, ToSpan, Unit,
     },
     timestamp::{
-        Timestamp, TimestampArithmetic, TimestampDifference, TimestampRound,
-        TimestampSeries,
+        Timestamp, TimestampArithmetic, TimestampDifference,
+        TimestampDisplayWithOffset, TimestampRound, TimestampSeries,
     },
     util::round::mode::RoundMode,
     zoned::{Zoned, ZonedArithmetic, ZonedDifference, ZonedRound, ZonedWith},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ documentation:
 * [Comparison with other Rust datetime crates](crate::_documentation::comparison)
 * [The API design rationale for Jiff](crate::_documentation::design)
 * [Platform support](crate::_documentation::platform)
+* [CHANGELOG](crate::_documentation::changelog)
 
 # Features
 
@@ -719,6 +720,8 @@ pub mod _documentation {
     pub mod design {}
     #[doc = include_str!("../PLATFORM.md")]
     pub mod platform {}
+    #[doc = include_str!("../CHANGELOG.md")]
+    pub mod changelog {}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR does a couple things.

First, it adds a new
`jiff::fmt::DateTimePrinter::print_timestamp_with_offset` routine for
formatting a `jiff::Timestamp` as an RFC 3339 string with a specific
offset. In particular, this draws a contrast between the existing
`print_timestamp` method which will always use Zulu time. (Zulu is UTC,
but where the offset is unknown.)

Secondly, we add new helper methods on the datetime and span printers
to format datetimes and spans directly into a string. This is just
for convenience, since otherwise creating a `String` and passing
it in as a buffer can be a bit annoying. Also, since it's fixed to
a `String`, these methods are infallible and can never fail, which
further simplifies their use.
