### PR TITLE
tz: add `TimeZone::try_system`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+0.1.13 (TBD)
+============
+This release introduces a new `jiff::tz::TimeZone::try_system` API. It is like
+`TimeZone::system`, but returns an error instead of an automatic fall back to
+UTC when the system time zone could not be discovered.
+
+Enhancements:
+
+* [#65](https://github.com/BurntSushi/jiff/issues/65):
+Add `TimeZone::try_system` for fallibly determining the system's time zone.
+
+
 0.1.12 (2024-08-31)
 ===================
 This release introduces some new minor APIs that support formatting
@@ -61,7 +73,7 @@ assert_eq!(
 
 Enhancements:
 
-* [#122](https://github.com/BurntSushi/jiff/issues/122):
+* [#122](https://github.com/BurntSushi/jiff/pull/122):
 Support formatting `Timestamp` to an RFC 3339 string with a specific offset.
 
 


### PR DESCRIPTION
This API is like `TimeZone::system`, but turns "get system configured
time zone" into a fallible operation instead of automatically falling
back to UTC.

The error message here is pretty generic and uninformative. All of the
interesting bits are emitting as log messages. In #65, I talked about
improving this, but it's not quite clear the best way to do that. I
think we'd probably need to invent some smarter infrastructure for
collecting a "trace" of what was attempted, and then either emit them as
log messages or tie them up into a single error message. But the latter
case could result in a very big error message.

So for now, this just returns a pretty generic error message, but all of
the log statements are still there for when you need to understand more
deeply what went wrong.
