### PR TITLE
fmt: simplify integer formatting slightly

### DIFF
--- a/src/fmt/util.rs
+++ b/src/fmt/util.rs
@@ -18,7 +18,7 @@ use crate::{
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct DecimalFormatter {
     force_sign: Option<bool>,
-    minimum_digits: Option<u8>,
+    minimum_digits: u8,
     padding_byte: u8,
 }
 
@@ -27,7 +27,7 @@ impl DecimalFormatter {
     pub(crate) const fn new() -> DecimalFormatter {
         DecimalFormatter {
             force_sign: None,
-            minimum_digits: None,
+            minimum_digits: 0,
             padding_byte: b'0',
         }
     }
@@ -62,7 +62,7 @@ impl DecimalFormatter {
         if digits > Decimal::MAX_I64_DIGITS {
             digits = Decimal::MAX_I64_DIGITS;
         }
-        DecimalFormatter { minimum_digits: Some(digits), ..self }
+        DecimalFormatter { minimum_digits: digits, ..self }
     }
 
     /// The padding byte to use when `padding` is set.
@@ -122,11 +122,9 @@ impl Decimal {
                 break;
             }
         }
-        if let Some(minimum_digits) = formatter.minimum_digits {
-            while decimal.len() < minimum_digits {
-                decimal.start -= 1;
-                decimal.buf[decimal.start as usize] = formatter.padding_byte;
-            }
+        while decimal.len() < formatter.minimum_digits {
+            decimal.start -= 1;
+            decimal.buf[decimal.start as usize] = formatter.padding_byte;
         }
         if sign < 0 {
             decimal.start -= 1;


### PR DESCRIPTION
It turns out that "no padding set" and "padding is zero" result in the
same behavior. I think this might have been different back when I was
(ab)using the integer formatting to also do fractional formatting. But
either way, eliminating a redundant internal state is a win.

I discovered this while wondering whether I could unconditionally set
the padding to `0` and if it would be the same as not setting it.
