### PR TITLE
fmt: rejigger internal precision setting

### DIFF
--- a/src/fmt/strtime/format.rs
+++ b/src/fmt/strtime/format.rs
@@ -569,10 +569,7 @@ impl Extension {
     ) -> Result<(), Error> {
         let number = number.into();
 
-        let mut formatter = FractionalFormatter::new();
-        if let Some(precision) = self.width {
-            formatter = formatter.precision(precision);
-        }
+        let formatter = FractionalFormatter::new().precision(self.width);
         wtr.write_fraction(&formatter, number)
     }
 }

--- a/src/fmt/temporal/printer.rs
+++ b/src/fmt/temporal/printer.rs
@@ -133,17 +133,12 @@ impl DateTimePrinter {
         wtr.write_str(":")?;
         wtr.write_int(&FMT_TWO, time.second())?;
         let fractional_nanosecond = time.subsec_nanosecond();
-        if let Some(precision) = self.precision {
-            if precision > 0 {
-                wtr.write_str(".")?;
-                wtr.write_fraction(
-                    &FMT_FRACTION.precision(precision),
-                    fractional_nanosecond,
-                )?;
-            }
-        } else if fractional_nanosecond != 0 {
+        if self.precision.map_or(fractional_nanosecond != 0, |p| p > 0) {
             wtr.write_str(".")?;
-            wtr.write_fraction(&FMT_FRACTION, fractional_nanosecond)?;
+            wtr.write_fraction(
+                &FMT_FRACTION.precision(self.precision),
+                fractional_nanosecond,
+            )?;
         }
         Ok(())
     }

--- a/src/fmt/util.rs
+++ b/src/fmt/util.rs
@@ -190,12 +190,14 @@ impl FractionalFormatter {
     /// based on the value.
     pub(crate) const fn precision(
         self,
-        mut precision: u8,
+        precision: Option<u8>,
     ) -> FractionalFormatter {
-        if precision > 9 {
-            precision = 9;
-        }
-        FractionalFormatter { precision: Some(precision), ..self }
+        let precision = match precision {
+            None => None,
+            Some(p) if p > 9 => Some(9),
+            Some(p) => Some(p),
+        };
+        FractionalFormatter { precision, ..self }
     }
 }
 
@@ -410,7 +412,7 @@ mod tests {
     fn fractional_precision() {
         let f = |precision, n| {
             FractionalFormatter::new()
-                .precision(precision)
+                .precision(Some(precision))
                 .format(n)
                 .as_str()
                 .to_string()


### PR DESCRIPTION
Previously, we accepted `precision: u8` and inferred "not set" as
"automatic precision." But this actually ends up making some call sites
more complicated than they need to be. It's better to just require an
`Option<u8>` since that tends to be what callers have.
