### PR TITLE
Tweak docs to update Timestamp definition to current behaviour

### DIFF
--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -23,7 +23,7 @@ use crate::{
 /// An instant in time represented as the number of nanoseconds since the Unix
 /// epoch.
 ///
-/// A timestamp is always in the UNIX timescale.
+/// A timestamp is always in the UNIX timescale with a UTC offset of zero.
 ///
 /// To obtain civil or "local" datetime units like year, month, day or hour, a
 /// timestamp needs to be combined with a [`TimeZone`] to create a [`Zoned`].

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -23,7 +23,7 @@ use crate::{
 /// An instant in time represented as the number of nanoseconds since the Unix
 /// epoch.
 ///
-/// A timestamp is always in UTC.
+/// A timestamp is always in the UNIX timescale.
 ///
 /// To obtain civil or "local" datetime units like year, month, day or hour, a
 /// timestamp needs to be combined with a [`TimeZone`] to create a [`Zoned`].

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -23,7 +23,7 @@ use crate::{
 /// An instant in time represented as the number of nanoseconds since the Unix
 /// epoch.
 ///
-/// A timestamp is always in the UNIX timescale with a UTC offset of zero.
+/// A timestamp is always in the Unix timescale with a UTC offset of zero.
 ///
 /// To obtain civil or "local" datetime units like year, month, day or hour, a
 /// timestamp needs to be combined with a [`TimeZone`] to create a [`Zoned`].


### PR DESCRIPTION
~~The end goal with this PR is to adjust the documentation to make the semantics of the library as clear as possible.~~

~~I've started with just a tiny change to set a foundation, updating the documentation comment to define Timestamp wrt UNIX time.~~

citations, since my only msgs so far are on discord (I believe Timestamp = Unix is currently intentional, this is just a mistake in docs):

- `now` uses the value constructed by `duration_since(EPOCH)`, which is [defined as POSIX time](https://doc.rust-lang.org/stable/std/time/struct.SystemTime.html#associatedconstant.UNIX_EPOCH)
  > duration_since(UNIX_EPOCH).unwrap().as_secs() returns the number of non-leap seconds since the start of 1970 UTC. This is a POSIX time_t (as a u64), and is the same time representation as used in many Internet protocols.
  this can also be tested experimentally by printing the `Timestamp::now().as_nanos()`
- `Display for Timestamp` prints the corresponding date to an input unix time.
  this can also be tested by printing `format!("{}", Timestamp::new(24 * 60 * 60 * (365 * 30 + (30 / 4)) , 0))` to `2000-01-01T00:00:00Z`, which is 22 seconds faster than it should be
