### PR TITLE
feat: impl TryFrom str for Timestamp

### DIFF
--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -2428,6 +2428,15 @@ impl core::str::FromStr for Timestamp {
     }
 }
 
+impl<'a> core::convert::TryFrom<&'a str> for Timestamp {
+    type Error = Error;
+
+    #[inline]
+    fn try_from(string: &str) -> Result<Timestamp, Error> {
+        DEFAULT_DATETIME_PARSER.parse_timestamp(string)
+    }
+}
+
 impl Eq for Timestamp {}
 
 impl PartialEq for Timestamp {


### PR DESCRIPTION
Not quite sure if this falls into our API philosophy.

My use case is such a method ([full code](https://github.com/tisonkun/cronexpr/pull/7/files#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R281)):

```rust
    pub fn find_next<T>(&self, timestamp: T) -> Result<Zoned, Error>
    where
        T: TryInto<Timestamp>,
        T::Error: std::error::Error,
    {
        let zoned = timestamp
            .try_into()
            .map(|ts| ts.to_zoned(self.timezone.clone()))
            .map_err(error_with_context("failed to parse timestamp"))?;
        // ...
    }
```

... and I want `foo.find_next("2024-01-01T00:00:00+08:00")` compile.

The reason for such a method is:

1. Accept both Timestamp and things that can convert to Timestamp.
2. Why not directly Timestamp? Because I don't want users to that crate have to explicit add a dependency to jiff (not only the extra typing and concept, but also version resolution puzzle like https://github.com/GreptimeTeam/greptimedb/issues/3610).

Alternatives. I can switch to:

1. Directly depend on jiff anyway.
2. Expose different methods to accept common inputs (Timestamp, String, and even millis)
3. Accept a closure that construct Timestamp fallibly. So `|| "...".parse()` and `|| Ok(ts)` are accepted.

