### PR TITLE
doc: correct function reference in Timestamp

### DIFF
--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -2132,7 +2132,7 @@ impl Timestamp {
     /// ```
     #[deprecated(
         since = "0.1.5",
-        note = "use Timestamp::as_signed_duration instead"
+        note = "use Timestamp::as_jiff_duration instead"
     )]
     #[inline]
     pub fn as_duration(self) -> (i8, core::time::Duration) {


### PR DESCRIPTION
The documentation for the deprecated `as_duration` function in `Timestamp` referenced a non-existent function `as_signed_duration`. It should point to `as_jiff_duration` instead.