### PR TITLE
feat: implement Hash trait for structs that has implemented PartialEq/Eq

### DIFF
--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -2457,6 +2457,14 @@ impl PartialOrd for Timestamp {
     }
 }
 
+impl core::hash::Hash for Timestamp {
+    #[inline]
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.as_second_ranged().get().hash(state);
+        self.subsec_nanosecond_ranged().get().hash(state);
+    }
+}
+
 /// Adds a span of time to a timestamp.
 ///
 /// This uses checked arithmetic and panics on overflow. To handle overflow

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -3123,6 +3123,13 @@ impl<'a> PartialOrd<Zoned> for &'a Zoned {
     }
 }
 
+impl core::hash::Hash for Zoned {
+    #[inline]
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.timestamp().hash(state);
+    }
+}
+
 #[cfg(feature = "std")]
 impl TryFrom<std::time::SystemTime> for Zoned {
     type Error = Error;


### PR DESCRIPTION
Some of the core structs(e.g. `Duration`, `Time`) has implemented `Hash` trait while some of them hasn't.

This pull request implements `Hash` trait for the rest of the structs that should have implemented it(which are `PartialEq` and `Eq`).