### PR TITLE
docs: fix a typo

### DIFF
--- a/src/civil/date.rs
+++ b/src/civil/date.rs
@@ -1236,7 +1236,7 @@ impl Date {
     ///
     /// # Example
     ///
-    /// This example shows how to created a zoned value with a fixed time zone
+    /// This example shows how to create a zoned value with a fixed time zone
     /// offset:
     ///
     /// ```

--- a/src/civil/datetime.rs
+++ b/src/civil/datetime.rs
@@ -1388,7 +1388,7 @@ impl DateTime {
     ///
     /// # Example
     ///
-    /// This example shows how to created a zoned value with a fixed time zone
+    /// This example shows how to create a zoned value with a fixed time zone
     /// offset:
     ///
     /// ```

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -1082,7 +1082,7 @@ impl Timestamp {
     ///
     /// # Example
     ///
-    /// This example shows how to created a zoned value with a fixed time zone
+    /// This example shows how to create a zoned value with a fixed time zone
     /// offset:
     ///
     /// ```


### PR DESCRIPTION
This PR (replacing #146) merely fixes a humble typo that has been repeated a few times.

---

The wasm failure appears unrelated.

It seems to occur in various branches (at least the last four PRs are red due to the same wasm CI failure). All scheduled builds [are affected, too](https://github.com/BurntSushi/jiff/actions).

The CI failure is thus unrelated to the changeset.