### PR TITLE
Update chrono-tz dev-dependency from 0.9 to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ wasm-bindgen = { version = "0.2.70", optional = true }
 [dev-dependencies]
 anyhow = "1.0.81"
 chrono = { version = "0.4.38", features = ["serde"] }
-chrono-tz = "0.9.0"
+chrono-tz = "0.10.0"
 # This adds approximately 50 new compilation units when running `cargo test`
 # locally on Unix. Blech.
 icu = { version = "1.5.0", features = ["std"] }


### PR DESCRIPTION
I confirmed that `cargo test --workspace` still passes.

From the [release notes](https://github.com/chronotope/chrono-tz/releases/tag/v0.10.0):

```
### Changes

- Make `OffsetName::abbreviation` return an `Option`. This reflects that numeric values such as `+11` are no longer encoded in the upstream TZDB as abbreviations (https://github.com/chronotope/chrono-tz/pull/185).
```

Since jiff and its tests don’t use this type, there is no impact and no code changes are required.