### PR TITLE
reduce reliance on `alloc` crate in `src/tz/posix.rs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ icu = { version = "1.5.0", features = ["std"] }
 insta = "1.39.0"
 # We force `serde` to be enabled in dev mode so that the docs render and test
 # correctly. This is highly suspicious.
-jiff = { path = "./", features = ["serde"] }
+jiff = { path = "./", default-features = false, features = ["serde"] }
 quickcheck = { version = "1.0.3", default-features = false }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"

--- a/src/error.rs
+++ b/src/error.rs
@@ -91,6 +91,7 @@ enum ErrorKind {
     /// The cause is typically `Adhoc` or `IO`.
     ///
     /// When `std` is not enabled, this variant can never be constructed.
+    #[allow(dead_code)] // not used in some feature configs
     FilePath(FilePathError),
     /// An error that occurs when interacting with the file system.
     ///
@@ -98,6 +99,7 @@ enum ErrorKind {
     /// `std::path::PathBuf`.
     ///
     /// When `std` is not enabled, this variant can never be constructed.
+    #[allow(dead_code)] // not used in some feature configs
     IO(IOError),
 }
 
@@ -158,7 +160,7 @@ impl Error {
     /// sort of context. In Jiff, it's always a file path (at time of writing).
     ///
     /// This is only available when the `std` feature is enabled.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "tzdb-zoneinfo")]
     pub(crate) fn fs(
         path: impl Into<std::path::PathBuf>,
         err: std::io::Error,
@@ -173,7 +175,7 @@ impl Error {
     /// kind of context to this error (like a file path).
     ///
     /// This is only available when the `std` feature is enabled.
-    #[cfg(feature = "std")]
+    #[cfg(any(feature = "tz-system", feature = "tzdb-zoneinfo"))]
     pub(crate) fn io(err: std::io::Error) -> Error {
         Error::from(ErrorKind::IO(IOError { err }))
     }
@@ -184,7 +186,7 @@ impl Error {
     /// `FilePathError`.
     ///
     /// This is only available when the `std` feature is enabled.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "tzdb-zoneinfo")]
     pub(crate) fn path(self, path: impl Into<std::path::PathBuf>) -> Error {
         let err = Error::from(ErrorKind::FilePath(FilePathError {
             path: path.into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -756,6 +756,7 @@ mod tests {
         std::println!("{zdt}");
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn topscratch() {
         use crate::util::t;

--- a/src/now.rs
+++ b/src/now.rs
@@ -21,14 +21,13 @@ pub(crate) use self::sys::*;
     target_os = "unknown"
 )))]
 mod sys {
-    use std::time::{Instant, SystemTime};
-
-    pub(crate) fn system_time() -> SystemTime {
-        SystemTime::now()
+    pub(crate) fn system_time() -> std::time::SystemTime {
+        std::time::SystemTime::now()
     }
 
-    pub(crate) fn monotonic_time() -> Option<Instant> {
-        Some(Instant::now())
+    #[cfg(any(feature = "tz-system", feature = "tzdb-zoneinfo"))]
+    pub(crate) fn monotonic_time() -> Option<std::time::Instant> {
+        Some(std::time::Instant::now())
     }
 }
 
@@ -38,10 +37,8 @@ mod sys {
     target_os = "unknown"
 ))]
 mod sys {
-    use std::time::{Instant, SystemTime};
-
-    pub(crate) fn system_time() -> SystemTime {
-        use std::time::Duration;
+    pub(crate) fn system_time() -> std::time::SystemTime {
+        use std::time::{Duration, SystemTime};
 
         #[cfg(not(feature = "std"))]
         use crate::util::libm::Float;
@@ -69,7 +66,8 @@ mod sys {
         timestamp
     }
 
-    pub(crate) fn monotonic_time() -> Option<Instant> {
+    #[cfg(any(feature = "tz-system", feature = "tzdb-zoneinfo"))]
+    pub(crate) fn monotonic_time() -> Option<std::time::Instant> {
         // :-(
         None
     }

--- a/src/span.rs
+++ b/src/span.rs
@@ -2907,7 +2907,7 @@ impl Span {
     /// if this span has maximal values for all units, then rebalancing is
     /// not possible because the number of days after balancing would exceed
     /// the limit.
-    #[allow(dead_code)] // REMOVE ME
+    #[cfg(test)] // currently only used in zic parser?
     #[inline]
     pub(crate) fn rebalance(self, unit: Unit) -> Result<Span, Error> {
         Span::from_invariant_nanoseconds(unit, self.to_invariant_nanoseconds())

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -3701,7 +3701,7 @@ mod tests {
         }
     }
 
-    /// # `serde` deserializer compatibility test
+    /// A `serde` deserializer compatibility test.
     ///
     /// Serde YAML used to be unable to deserialize `jiff` types,
     /// as deserializing from bytes is not supported by the deserializer.
@@ -3711,24 +3711,24 @@ mod tests {
     #[test]
     fn timestamp_deserialize_yaml() {
         let expected = datetime(2024, 10, 31, 16, 33, 53, 123456789)
-            .intz("UTC")
+            .to_zoned(TimeZone::UTC)
             .unwrap()
             .timestamp();
 
         let deserialized: Timestamp =
-            serde_yml::from_str("2024-10-31T16:33:53.123456789+00:00[UTC]")
+            serde_yml::from_str("2024-10-31T16:33:53.123456789+00:00")
                 .unwrap();
 
         assert_eq!(deserialized, expected);
 
         let deserialized: Timestamp = serde_yml::from_slice(
-            "2024-10-31T16:33:53.123456789+00:00[UTC]".as_bytes(),
+            "2024-10-31T16:33:53.123456789+00:00".as_bytes(),
         )
         .unwrap();
 
         assert_eq!(deserialized, expected);
 
-        let cursor = Cursor::new(b"2024-10-31T16:33:53.123456789+00:00[UTC]");
+        let cursor = Cursor::new(b"2024-10-31T16:33:53.123456789+00:00");
         let deserialized: Timestamp = serde_yml::from_reader(cursor).unwrap();
 
         assert_eq!(deserialized, expected);

--- a/src/tz/db/zoneinfo/enabled.rs
+++ b/src/tz/db/zoneinfo/enabled.rs
@@ -100,6 +100,14 @@ impl ZoneInfo {
             let zones = self.zones.read().unwrap();
             if let Some(czone) = zones.get(query) {
                 if !czone.is_expired() {
+                    trace!(
+                        "for time zone query `{query}`, \
+                         found cached zone `{}` \
+                         (expiration={}, last_modified={:?})",
+                        czone.tz.diagnostic_name(),
+                        czone.expiration,
+                        czone.last_modified,
+                    );
                     return Some(czone.tz.clone());
                 }
             }
@@ -208,7 +216,7 @@ impl CachedZones {
 
     fn get_zone_index(&self, query: &str) -> Result<usize, usize> {
         self.zones.binary_search_by(|zone| {
-            cmp_ignore_ascii_case(zone.tz.diagnostic_name(), query)
+            cmp_ignore_ascii_case(zone.name.lower(), query)
         })
     }
 
@@ -220,6 +228,7 @@ impl CachedZones {
 #[derive(Clone, Debug)]
 struct CachedTimeZone {
     tz: TimeZone,
+    name: ZoneInfoName,
     expiration: Expiration,
     last_modified: Option<Timestamp>,
 }
@@ -240,9 +249,10 @@ impl CachedTimeZone {
         file.read_to_end(&mut data).map_err(|e| Error::fs(path, e))?;
         let tz = TimeZone::tzif(&info.inner.original, &data)
             .map_err(|e| e.path(path))?;
+        let name = info.clone();
         let last_modified = last_modified_from_file(path, &file);
         let expiration = Expiration::after(ttl);
-        Ok(CachedTimeZone { tz, expiration, last_modified })
+        Ok(CachedTimeZone { tz, name, expiration, last_modified })
     }
 
     /// Returns true if this time zone has gone stale and should, at minimum,
@@ -505,6 +515,11 @@ impl ZoneInfoName {
         let inner =
             ZoneInfoNameInner { full, original: original.to_string(), lower };
         Ok(ZoneInfoName { inner: Arc::new(inner) })
+    }
+
+    /// Returns the lowercase name of this time zone.
+    fn lower(&self) -> &str {
+        &self.inner.lower
     }
 }
 

--- a/src/tz/mod.rs
+++ b/src/tz/mod.rs
@@ -593,6 +593,7 @@ impl TimeZone {
     /// # Errors
     ///
     /// This returns an error if the given TZif data is invalid.
+    #[cfg(feature = "tz-system")]
     fn tzif_system(data: &[u8]) -> Result<TimeZone, Error> {
         let tzif = TimeZoneTzif::new(None, data)?;
         let kind = TimeZoneKind::Tzif(tzif);

--- a/src/tz/system/mod.rs
+++ b/src/tz/system/mod.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)] // REMOVE ME
-
 use std::{sync::RwLock, time::Duration};
 
 use alloc::{string::ToString, sync::Arc};
@@ -153,11 +151,6 @@ pub(crate) fn get_force(db: &TimeZoneDatabase) -> Result<TimeZone, Error> {
         return Ok(tz);
     }
     Err(err!("failed to find system time zone"))
-}
-
-/// Clear the system time zone cache.
-pub(crate) fn reset() {
-    *CACHE.write().unwrap() = Cache::empty();
 }
 
 /// Materializes a `TimeZone` from a `TZ` environment variable.

--- a/src/tz/tzif.rs
+++ b/src/tz/tzif.rs
@@ -437,7 +437,7 @@ impl Tzif {
                          of {}, but got {offset} according to POSIX TZ \
                          string {}",
                         typ.offset,
-                        tz.as_str(),
+                        tz,
                     ));
                 }
                 if dst != typ.is_dst {
@@ -447,7 +447,7 @@ impl Tzif {
                          string {}",
                         typ.is_dst.is_dst(),
                         dst.is_dst(),
-                        tz.as_str(),
+                        tz,
                     ));
                 }
                 if abbrev != tzif.designation(&typ) {
@@ -457,7 +457,7 @@ impl Tzif {
                          but got designation={} according to POSIX TZ \
                          string {}",
                         tzif.designation(&typ),
-                        tz.as_str(),
+                        tz,
                     ));
                 }
             }
@@ -1458,7 +1458,7 @@ mod tests {
         }
         if let Some(ref posix_tz) = tzif.posix_tz {
             writeln!(out, "POSIX TIME ZONE STRING").unwrap();
-            writeln!(out, "  {}", posix_tz.as_str()).unwrap();
+            writeln!(out, "  {}", posix_tz).unwrap();
         }
         String::from_utf8(out.into_inner().unwrap()).unwrap()
     }

--- a/src/tz/tzif.rs
+++ b/src/tz/tzif.rs
@@ -1296,6 +1296,7 @@ impl Header {
 /// format. However, it is impossible for this to return false when the given
 /// data is TZif. That is, a false positive is allowed but a false negative is
 /// not.
+#[cfg(feature = "tzdb-zoneinfo")]
 pub(crate) fn is_possibly_tzif(data: &[u8]) -> bool {
     data.starts_with(b"TZif")
 }
@@ -1512,6 +1513,7 @@ mod tests {
     /// do much with it other than to ensure we don't panic or return an error.
     /// That is, we check that we can parse each file, but not that we do so
     /// correctly.
+    #[cfg(feature = "tzdb-zoneinfo")]
     #[cfg(target_os = "linux")]
     #[test]
     fn zoneinfo() {

--- a/src/util/array_str.rs
+++ b/src/util/array_str.rs
@@ -1,0 +1,98 @@
+/// A simple and not the most-efficient fixed size string on the stack.
+///
+/// This supplanted some uses of `Box<str>` for storing tiny strings in an
+/// effort to reduce our dependence on dynamic memory allocation.
+///
+/// Also, since it isn't needed and it lets us save on storage requirements,
+/// `N` must be less than `256` (so that the length can fit in a `u8`).
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub(crate) struct ArrayStr<const N: usize> {
+    /// The UTF-8 bytes that make up the string.
+    ///
+    /// This array---the entire array---is always valid UTF-8. And
+    /// the `0..self.len` sub-slice is also always valid UTF-8.
+    bytes: [u8; N],
+    /// The number of bytes used by the string in `bytes`.
+    ///
+    /// (We could technically save this byte in some cases and use a NUL
+    /// terminator. For example, since we don't permit NUL bytes in POSIX time
+    /// zone abbreviation strings, but this is simpler and only one byte and
+    /// generalizes. And we're not really trying to micro-optimize the storage
+    /// requirements when we use these array strings. Or at least, I don't know
+    /// of a reason to.)
+    len: u8,
+}
+
+impl<const N: usize> ArrayStr<N> {
+    /// Creates a new fixed capacity string.
+    ///
+    /// If the given string exceeds `N` bytes, then this returns
+    /// `None`.
+    pub(crate) fn new(s: &str) -> Option<ArrayStr<N>> {
+        let len = s.len();
+        if len > N {
+            return None;
+        }
+        let mut bytes = [0; N];
+        bytes[..len].copy_from_slice(s.as_bytes());
+        // OK because ABBREVIATION_MAX will never exceed u8::MAX.
+        debug_assert!(
+            N <= usize::from(u8::MAX),
+            "size of ArrayStr is too big"
+        );
+        let len = u8::try_from(len).unwrap();
+        Some(ArrayStr { bytes, len })
+    }
+
+    /// Returns this array string as a string slice.
+    pub(crate) fn as_str(&self) -> &str {
+        // OK because construction guarantees valid UTF-8.
+        //
+        // This is bullet proof enough to use unchecked `str` construction
+        // here, but I can't dream up of a benchmark where it matters.
+        core::str::from_utf8(&self.bytes[..usize::from(self.len)]).unwrap()
+    }
+}
+
+/// Easy construction of `ArrayStr` from `&'static str`.
+///
+/// We specifically limit to `&'static str` to approximate string literals.
+/// This prevents most cases of accidentally creating a non-string literal
+/// that panics if the string is too big.
+///
+/// This impl primarily exists to make writing tests more convenient.
+impl<const N: usize> From<&'static str> for ArrayStr<N> {
+    fn from(s: &'static str) -> ArrayStr<N> {
+        ArrayStr::new(s).unwrap()
+    }
+}
+
+impl<const N: usize> PartialEq<str> for ArrayStr<N> {
+    fn eq(&self, rhs: &str) -> bool {
+        self.as_str() == rhs
+    }
+}
+
+impl<const N: usize> PartialEq<&str> for ArrayStr<N> {
+    fn eq(&self, rhs: &&str) -> bool {
+        self.as_str() == *rhs
+    }
+}
+
+impl<const N: usize> PartialEq<ArrayStr<N>> for str {
+    fn eq(&self, rhs: &ArrayStr<N>) -> bool {
+        self == rhs.as_str()
+    }
+}
+
+impl<const N: usize> core::fmt::Debug for ArrayStr<N> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        core::fmt::Debug::fmt(self.as_str(), f)
+    }
+}
+
+impl<const N: usize> core::fmt::Display for ArrayStr<N> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        core::fmt::Display::fmt(self.as_str(), f)
+    }
+}

--- a/src/util/cache.rs
+++ b/src/util/cache.rs
@@ -33,3 +33,18 @@ impl Expiration {
         })
     }
 }
+
+impl core::fmt::Display for Expiration {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        let Some(instant) = self.0 else {
+            return write!(f, "expired");
+        };
+        let Some(now) = crate::now::monotonic_time() else {
+            return write!(f, "expired");
+        };
+        let Some(duration) = instant.checked_duration_since(now) else {
+            return write!(f, "expired");
+        };
+        write!(f, "{duration:?}")
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,5 +1,5 @@
 pub(crate) mod array_str;
-#[cfg(feature = "std")]
+#[cfg(any(feature = "tz-system", feature = "tzdb-zoneinfo"))]
 pub(crate) mod cache;
 pub(crate) mod common;
 pub(crate) mod crc32;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod array_str;
 #[cfg(feature = "std")]
 pub(crate) mod cache;
 pub(crate) mod common;

--- a/src/util/parse.rs
+++ b/src/util/parse.rs
@@ -120,7 +120,7 @@ pub(crate) fn fraction(
 ///
 /// This is effectively `OsStr::to_str`, but with a slightly better error
 /// message.
-#[cfg(feature = "std")]
+#[cfg(feature = "tzdb-zoneinfo")]
 pub(crate) fn os_str_utf8<'o, O>(os_str: &'o O) -> Result<&'o str, Error>
 where
     O: ?Sized + AsRef<std::ffi::OsStr>,
@@ -136,7 +136,7 @@ where
 /// The main difference between this and `OsStr::to_str` is that this will
 /// be a zero-cost conversion on Unix platforms to `&[u8]`. On Windows, this
 /// will do UTF-8 validation and return an error if it's invalid UTF-8.
-#[cfg(feature = "std")]
+#[cfg(feature = "tz-system")]
 pub(crate) fn os_str_bytes<'o, O>(os_str: &'o O) -> Result<&'o [u8], Error>
 where
     O: ?Sized + AsRef<std::ffi::OsStr>,

--- a/src/util/round/increment.rs
+++ b/src/util/round/increment.rs
@@ -8,8 +8,6 @@ rounding increments up to days are supported. Similarly, rounding increments
 for time units must divide evenly into 1 unit of the next highest unit.
 */
 
-#![allow(warnings)] // REMOVE ME
-
 use crate::{
     error::{err, Error},
     util::{

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -5251,7 +5251,7 @@ mod tests {
         }
     }
 
-    /// # `serde` deserializer compatibility test
+    /// A `serde` deserializer compatibility test.
     ///
     /// Serde YAML used to be unable to deserialize `jiff` types,
     /// as deserializing from bytes is not supported by the deserializer.
@@ -5260,6 +5260,10 @@ mod tests {
     /// - <https://github.com/BurntSushi/jiff/discussions/148>
     #[test]
     fn zoned_deserialize_yaml() {
+        if crate::tz::db().is_definitively_empty() {
+            return;
+        }
+
         let expected =
             datetime(2024, 10, 31, 16, 33, 53, 123456789).intz("UTC").unwrap();
 

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -5125,8 +5125,9 @@ fn day_length(
     // FIXME: We should be doing this with a &TimeZone, but will need a
     // refactor so that we do zone-aware arithmetic using just a Timestamp and
     // a &TimeZone.
-    let tzname = alloc::string::String::from(tz.diagnostic_name());
-    let start = dt.start_of_day().to_zoned(tz).with_context(|| {
+    let tz2 = tz.clone();
+    let start = dt.start_of_day().to_zoned(tz).with_context(move || {
+        let tzname = tz2.diagnostic_name();
         err!("failed to find start of day for {dt} in time zone {tzname}")
     })?;
     let end = start.checked_add(Span::new().days_ranged(C(1))).with_context(

--- a/tests/tc39_262/span/round.rs
+++ b/tests/tc39_262/span/round.rs
@@ -1,6 +1,6 @@
 use jiff::{
     civil::date, tz::TimeZone, RoundMode, Span, SpanRelativeTo, SpanRound,
-    Timestamp, ToSpan, Unit, Zoned,
+    Timestamp, ToSpan, Unit,
 };
 
 use crate::tc39_262::Result;
@@ -105,6 +105,7 @@ fn calendar_possibly_required() -> Result {
 }
 
 /// Source: https://github.com/tc39/test262/blob/29c6f7028a683b8259140e7d6352ae0ca6448a85/test/built-ins/Temporal/Duration/prototype/round/dst-balancing-result.js
+#[cfg(feature = "std")]
 #[test]
 fn dst_balancing_result() -> Result {
     if jiff::tz::db().is_definitively_empty() {
@@ -112,7 +113,8 @@ fn dst_balancing_result() -> Result {
     }
 
     let sp = 1.year().hours(24);
-    let zdt = "1999-10-29T01-07[America/Los_Angeles]".parse::<Zoned>()?;
+    let zdt =
+        "1999-10-29T01-07[America/Los_Angeles]".parse::<jiff::Zoned>()?;
     let result =
         sp.round(SpanRound::new().largest(Unit::Year).relative(&zdt))?;
     assert_eq!(result, 1.year().hours(24));
@@ -123,20 +125,23 @@ fn dst_balancing_result() -> Result {
     // But with real TZ data, a span of 1 year will pretty much always cover
     // a DST backward transition.
     let sp = 1.month().hours(24);
-    let zdt = "2000-09-29T01-07[America/Los_Angeles]".parse::<Zoned>()?;
+    let zdt =
+        "2000-09-29T01-07[America/Los_Angeles]".parse::<jiff::Zoned>()?;
     let result =
         sp.round(SpanRound::new().largest(Unit::Year).relative(&zdt))?;
     assert_eq!(result, 1.month().hours(24));
 
     // Try one month earlier, and we balance up to 1 day.
     let sp = 1.month().hours(24);
-    let zdt = "2000-08-29T01-07[America/Los_Angeles]".parse::<Zoned>()?;
+    let zdt =
+        "2000-08-29T01-07[America/Los_Angeles]".parse::<jiff::Zoned>()?;
     let result =
         sp.round(SpanRound::new().largest(Unit::Year).relative(&zdt))?;
     assert_eq!(result, 1.month().days(1));
 
     let sp = 24.hours().nanoseconds(5);
-    let zdt = "2000-10-29T00-07[America/Los_Angeles]".parse::<Zoned>()?;
+    let zdt =
+        "2000-10-29T00-07[America/Los_Angeles]".parse::<jiff::Zoned>()?;
     let result = sp.round(
         SpanRound::new()
             .largest(Unit::Day)
@@ -151,6 +156,7 @@ fn dst_balancing_result() -> Result {
 }
 
 /// Source: https://github.com/tc39/test262/blob/29c6f7028a683b8259140e7d6352ae0ca6448a85/test/built-ins/Temporal/Duration/prototype/round/dst-rounding-result.js
+#[cfg(feature = "std")]
 #[test]
 fn dst_rounding_result() -> Result {
     if jiff::tz::db().is_definitively_empty() {
@@ -158,13 +164,15 @@ fn dst_rounding_result() -> Result {
     }
 
     let sp = 1.month().days(15).hours(11).minutes(30);
-    let zdt = "2000-02-18T02-08[America/Los_Angeles]".parse::<Zoned>()?;
+    let zdt =
+        "2000-02-18T02-08[America/Los_Angeles]".parse::<jiff::Zoned>()?;
     let result =
         sp.round(SpanRound::new().smallest(Unit::Month).relative(&zdt))?;
     assert_eq!(result, 2.months());
 
     let sp = 1.month().days(15).minutes(30);
-    let zdt = "2000-03-02T02-08[America/Los_Angeles]".parse::<Zoned>()?;
+    let zdt =
+        "2000-03-02T02-08[America/Los_Angeles]".parse::<jiff::Zoned>()?;
     let result =
         sp.round(SpanRound::new().smallest(Unit::Month).relative(&zdt))?;
     assert_eq!(result, 2.months());
@@ -177,7 +185,8 @@ fn dst_rounding_result() -> Result {
     assert_eq!(result, 1.month());
 
     let sp = 11.hours().minutes(30);
-    let zdt = "2000-04-02T00:00:00[America/Los_Angeles]".parse::<Zoned>()?;
+    let zdt =
+        "2000-04-02T00:00:00[America/Los_Angeles]".parse::<jiff::Zoned>()?;
     let result =
         sp.round(SpanRound::new().smallest(Unit::Day).relative(&zdt))?;
     assert_eq!(result, 1.day());
@@ -271,7 +280,7 @@ fn largestunit_correct_rebalancing() -> Result {
 fn largestunit_smallestunit_combinations_relative() -> Result {
     let sp = mk([5, 5, 5, 5, 5, 5, 5, 5, 5, 5]);
     let d = date(2000, 1, 1);
-    let zdt = date(1972, 1, 1).intz("UTC")?;
+    let zdt = date(1972, 1, 1).to_zoned(TimeZone::UTC)?;
     let exact: &[(Unit, &[(Unit, Span)])] = &[
         (
             Unit::Year,

--- a/tests/tc39_262/span/total.rs
+++ b/tests/tc39_262/span/total.rs
@@ -1,4 +1,4 @@
-use jiff::{civil::date, tz, Timestamp, ToSpan, Unit, Zoned};
+use jiff::{civil::date, tz, Timestamp, ToSpan, Unit};
 
 use crate::tc39_262::Result;
 
@@ -66,6 +66,7 @@ fn calendar_possibly_required() -> Result {
 }
 
 /// Source: https://github.com/tc39/test262/blob/29c6f7028a683b8259140e7d6352ae0ca6448a85/test/built-ins/Temporal/Duration/prototype/total/dst-balancing-result.js
+#[cfg(feature = "std")]
 #[test]
 fn dst_balancing_result() -> Result {
     if jiff::tz::db().is_definitively_empty() {
@@ -73,7 +74,8 @@ fn dst_balancing_result() -> Result {
     }
 
     let sp = 1.year().hours(24);
-    let zdt = "1999-10-29T01-07[America/Los_Angeles]".parse::<Zoned>()?;
+    let zdt =
+        "1999-10-29T01-07[America/Los_Angeles]".parse::<jiff::Zoned>()?;
     let result = sp.total((Unit::Day, &zdt))?;
     assert_eq!(result, 366.96);
 
@@ -83,13 +85,15 @@ fn dst_balancing_result() -> Result {
     // But with real TZ data, a span of 1 year will pretty much always cover
     // a DST backward transition.
     let sp = 1.month().hours(24);
-    let zdt = "2000-09-29T01-07[America/Los_Angeles]".parse::<Zoned>()?;
+    let zdt =
+        "2000-09-29T01-07[America/Los_Angeles]".parse::<jiff::Zoned>()?;
     let result = sp.total((Unit::Day, &zdt))?;
     assert_eq!(result, 30.96);
 
     // Try one month earlier, and we balance up to 1 day.
     let sp = 1.month().hours(24);
-    let zdt = "2000-08-29T01-07[America/Los_Angeles]".parse::<Zoned>()?;
+    let zdt =
+        "2000-08-29T01-07[America/Los_Angeles]".parse::<jiff::Zoned>()?;
     let result = sp.total((Unit::Day, &zdt))?;
     assert_eq!(result, 32.0);
 
@@ -97,6 +101,7 @@ fn dst_balancing_result() -> Result {
 }
 
 /// Source: https://github.com/tc39/test262/blob/29c6f7028a683b8259140e7d6352ae0ca6448a85/test/built-ins/Temporal/Duration/prototype/total/dst-day-length.js
+#[cfg(feature = "std")]
 #[test]
 fn dst_day_length() -> Result {
     if jiff::tz::db().is_definitively_empty() {
@@ -172,6 +177,7 @@ fn dst_day_length() -> Result {
 }
 
 /// Source: https://github.com/tc39/test262/blob/29c6f7028a683b8259140e7d6352ae0ca6448a85/test/built-ins/Temporal/Duration/prototype/total/dst-rounding-result.js
+#[cfg(feature = "std")]
 #[test]
 fn dst_rounding_result() -> Result {
     if jiff::tz::db().is_definitively_empty() {


### PR DESCRIPTION
There is still a fair bit more to do to fully address #168, but this PR gets rid of some allocations
inside of `src/tz/posix.rs`. We weren't using them by necessity per se, but
it did simplify a fair bit.