### PR TITLE
add core-only (no-std and no-alloc) support to Jiff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 # https://docs.rs/jiff/*/#crate-features
 [features]
 default = ["std", "tz-system", "tzdb-bundle-platform", "tzdb-zoneinfo"]
-std = ["alloc", "serde?/std"]
+std = ["alloc", "log?/std", "serde?/std"]
 alloc = ["serde?/alloc", "portable-atomic-util/alloc"]
 serde = ["dep:serde"]
 logging = ["dep:log"]
@@ -76,7 +76,7 @@ js = ["dep:wasm-bindgen", "dep:js-sys"]
 
 [dependencies]
 jiff-tzdb = { version = "0.1.1", path = "jiff-tzdb", optional = true }
-log = { version = "0.4.21", optional = true }
+log = { version = "0.4.21", optional = true, default-features = false }
 serde = { version = "1.0.203", optional = true, default-features = false }
 
 # Note that the `cfg` gate for the `tzdb-bundle-platform` must repeat the

--- a/src/civil/date.rs
+++ b/src/civil/date.rs
@@ -857,7 +857,7 @@ impl Date {
 
         let nth = Nth::try_new("nth", nth)?;
         if nth == 0 {
-            Err(Error::specific("nth weekday", 0))
+            Err(err!("nth weekday of month cannot be `0`"))
         } else if nth > 0 {
             let nth = nth.max(C(1));
             let first_weekday = self.first_of_month().weekday();
@@ -1037,7 +1037,7 @@ impl Date {
 
         let nth = t::SpanWeeks::try_new("nth weekday", nth)?;
         if nth == 0 {
-            Err(Error::specific("nth weekday", 0))
+            Err(err!("nth weekday cannot be `0`"))
         } else if nth > 0 {
             let nth = nth.max(C(1));
             let weekday_diff = weekday.since_ranged(self.weekday().next());
@@ -3644,7 +3644,7 @@ fn day_of_year(year: Year, day: i16) -> Result<Date, Error> {
         // Can only happen given day=366 and this is a leap year.
         debug_assert_eq!(day, 366);
         debug_assert!(!start.in_leap_year());
-        return Err(Error::signed("day-of-year", day, 1, 365));
+        return Err(Error::range("day-of-year", day, 1, 365));
     }
     Ok(end)
 }

--- a/src/civil/iso_week_date.rs
+++ b/src/civil/iso_week_date.rs
@@ -1,6 +1,6 @@
 use crate::{
     civil::{Date, Weekday},
-    error::Error,
+    error::{err, Error},
     util::{
         rangeint::RInto,
         t::{self, ISOWeek, ISOYear, C},
@@ -329,7 +329,9 @@ impl ISOWeekDate {
         debug_assert_eq!(t::Year::MIN, ISOYear::MIN);
         debug_assert_eq!(t::Year::MAX, ISOYear::MAX);
         if week == 53 && !is_long_year(year) {
-            return Err(Error::specific("ISO week number", week));
+            return Err(err!(
+                "ISO week number `{week}` is invalid for year `{year}`"
+            ));
         }
         // And also, the maximum Date constrains what we can utter with
         // ISOWeekDate so that we can preserve infallible conversions between
@@ -344,7 +346,7 @@ impl ISOWeekDate {
             && weekday.to_monday_zero_offset()
                 > Weekday::Friday.to_monday_zero_offset()
         {
-            return Err(Error::signed(
+            return Err(Error::range(
                 "weekday",
                 weekday.to_monday_zero_offset(),
                 Weekday::Monday.to_monday_one_offset(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,4 @@
-use alloc::{boxed::Box, string::String};
-
-use crate::sync::Arc;
+use crate::util::sync::Arc;
 
 /// Creates a new ad hoc error with no causal chain.
 ///
@@ -8,7 +6,7 @@ use crate::sync::Arc;
 /// creates is just a wrapper around the string created by `format!`.
 macro_rules! err {
     ($($tt:tt)*) => {{
-        crate::error::Error::adhoc(alloc::format!($($tt)*))
+        crate::error::Error::adhoc_from_args(format_args!($($tt)*))
     }}
 }
 
@@ -54,18 +52,22 @@ pub struct Error {
     /// `std` feature is enabled, which isn't cloneable.
     ///
     /// This also makes clones cheap. And it also make the size of error equal
-    /// to one word (although a `Box` would achieve that last goal).
+    /// to one word (although a `Box` would achieve that last goal). This is
+    /// why we put the `Arc` here instead of on `std::io::Error` directly.
     inner: Arc<ErrorInner>,
 }
 
 #[derive(Debug)]
+#[cfg_attr(not(feature = "alloc"), derive(Clone))]
 struct ErrorInner {
     kind: ErrorKind,
+    #[cfg(feature = "alloc")]
     cause: Option<Error>,
 }
 
 /// The underlying kind of a [`Error`].
 #[derive(Debug)]
+#[cfg_attr(not(feature = "alloc"), derive(Clone))]
 enum ErrorKind {
     /// An ad hoc error that is constructed from anything that implements
     /// the `core::fmt::Display` trait.
@@ -81,9 +83,6 @@ enum ErrorKind {
     /// of a public API, or as a result of an operation on a number that
     /// results in it being out of range.
     Range(RangeError),
-    /// An error that occurs when a lookup of a time zone, by name, fails
-    /// because that time zone does not exist.
-    TimeZoneLookup(TimeZoneLookupError),
     /// An error associated with a file path.
     ///
     /// This is generally expected to always have a cause attached to it
@@ -113,61 +112,43 @@ impl Error {
     /// convenient. And the alternative is quite brutal given the varied ways
     /// in which things in a datetime library can fail. (Especially parsing
     /// errors.)
-    pub(crate) fn adhoc(
-        err: impl core::fmt::Display + Send + Sync + 'static,
-    ) -> Error {
-        Error::from(ErrorKind::Adhoc(AdhocError(Box::new(err))))
+    #[cfg(feature = "alloc")]
+    pub(crate) fn adhoc<'a>(message: impl core::fmt::Display + 'a) -> Error {
+        Error::from(ErrorKind::Adhoc(AdhocError::from_display(message)))
     }
 
-    pub(crate) fn unsigned(
-        what: &'static str,
-        given: impl Into<u128>,
-        min: impl Into<i128>,
-        max: impl Into<i128>,
+    /// Like `Error::adhoc`, but accepts a `core::fmt::Arguments`.
+    ///
+    /// This is used with the `err!` macro so that we can thread a
+    /// `core::fmt::Arguments` down. This lets us extract a `&'static str`
+    /// from some messages in core-only mode and provide somewhat decent error
+    /// messages in some cases.
+    pub(crate) fn adhoc_from_args<'a>(
+        message: core::fmt::Arguments<'a>,
     ) -> Error {
-        Error::from(ErrorKind::Range(RangeError::unsigned(
-            what, given, min, max,
-        )))
+        Error::from(ErrorKind::Adhoc(AdhocError::from_args(message)))
     }
 
-    pub(crate) fn signed(
+    /// Like `Error::adhoc`, but creates an error from a `&'static str`
+    /// directly.
+    ///
+    /// This is useful in contexts where you know you have a `&'static str`,
+    /// and avoids relying on `alloc`-only routines like `Error::adhoc`.
+    pub(crate) fn adhoc_from_static_str(message: &'static str) -> Error {
+        Error::from(ErrorKind::Adhoc(AdhocError::from_static_str(message)))
+    }
+
+    /// Creates a new error indicating that a `given` value is out of the
+    /// specified `min..=max` range. The given `what` label is used in the
+    /// error message as a human readable description of what exactly is out
+    /// of range. (e.g., "seconds")
+    pub(crate) fn range(
         what: &'static str,
         given: impl Into<i128>,
         min: impl Into<i128>,
         max: impl Into<i128>,
     ) -> Error {
-        Error::from(ErrorKind::Range(RangeError::signed(
-            what, given, min, max,
-        )))
-    }
-
-    pub(crate) fn specific(
-        what: &'static str,
-        given: impl Into<i128>,
-    ) -> Error {
-        Error::from(ErrorKind::Range(RangeError::specific(what, given)))
-    }
-
-    pub(crate) fn time_zone_lookup(name: impl Into<String>) -> Error {
-        let inner = TimeZoneLookupErrorInner { name: name.into() };
-        Error::from(ErrorKind::TimeZoneLookup(TimeZoneLookupError(Box::new(
-            inner,
-        ))))
-    }
-
-    /// A convenience constructor for building an I/O error associated with
-    /// a file path.
-    ///
-    /// Generallly speaking, an I/O error should always be associated with some
-    /// sort of context. In Jiff, it's always a file path (at time of writing).
-    ///
-    /// This is only available when the `std` feature is enabled.
-    #[cfg(feature = "tzdb-zoneinfo")]
-    pub(crate) fn fs(
-        path: impl Into<std::path::PathBuf>,
-        err: std::io::Error,
-    ) -> Error {
-        Error::io(err).path(path)
+        Error::from(ErrorKind::Range(RangeError::new(what, given, min, max)))
     }
 
     /// A convenience constructor for building an I/O error.
@@ -202,16 +183,23 @@ impl std::error::Error for Error {}
 
 impl core::fmt::Display for Error {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        let mut err = self;
-        loop {
-            write!(f, "{}", err.inner.kind)?;
-            err = match err.inner.cause.as_ref() {
-                None => break,
-                Some(err) => err,
-            };
-            write!(f, ": ")?;
+        #[cfg(feature = "alloc")]
+        {
+            let mut err = self;
+            loop {
+                write!(f, "{}", err.inner.kind)?;
+                err = match err.inner.cause.as_ref() {
+                    None => break,
+                    Some(err) => err,
+                };
+                write!(f, ": ")?;
+            }
+            Ok(())
         }
-        Ok(())
+        #[cfg(not(feature = "alloc"))]
+        {
+            write!(f, "{}", self.inner.kind)
+        }
     }
 }
 
@@ -220,7 +208,6 @@ impl core::fmt::Display for ErrorKind {
         match *self {
             ErrorKind::Adhoc(ref msg) => msg.fmt(f),
             ErrorKind::Range(ref err) => err.fmt(f),
-            ErrorKind::TimeZoneLookup(ref err) => err.fmt(f),
             ErrorKind::FilePath(ref err) => err.fmt(f),
             ErrorKind::IO(ref err) => err.fmt(f),
         }
@@ -229,24 +216,79 @@ impl core::fmt::Display for ErrorKind {
 
 impl From<ErrorKind> for Error {
     fn from(kind: ErrorKind) -> Error {
-        Error { inner: Arc::new(ErrorInner { kind, cause: None }) }
+        #[cfg(feature = "alloc")]
+        {
+            Error { inner: Arc::new(ErrorInner { kind, cause: None }) }
+        }
+        #[cfg(not(feature = "alloc"))]
+        {
+            Error { inner: Arc::new(ErrorInner { kind }) }
+        }
     }
 }
 
-struct AdhocError(Box<dyn core::fmt::Display + Send + Sync + 'static>);
+/// A generic error message.
+///
+/// This somewhat unfortunately represents most of the errors in Jiff. When I
+/// first started building Jiff, I had a goal of making every error structured.
+/// But this ended up being a ton of work, and I find it much easier and nicer
+/// for error messages to be embedded where they occur.
+#[cfg_attr(not(feature = "alloc"), derive(Clone))]
+struct AdhocError {
+    #[cfg(feature = "alloc")]
+    message: alloc::boxed::Box<str>,
+    #[cfg(not(feature = "alloc"))]
+    message: &'static str,
+}
+
+impl AdhocError {
+    #[cfg(feature = "alloc")]
+    fn from_display<'a>(message: impl core::fmt::Display + 'a) -> AdhocError {
+        use alloc::string::ToString;
+
+        let message = message.to_string().into_boxed_str();
+        AdhocError { message }
+    }
+
+    fn from_args<'a>(message: core::fmt::Arguments<'a>) -> AdhocError {
+        #[cfg(feature = "alloc")]
+        {
+            AdhocError::from_display(message)
+        }
+        #[cfg(not(feature = "alloc"))]
+        {
+            let message = message.as_str().unwrap_or(
+                "unknown Jiff error (better error messages require \
+                 enabling the `alloc` feature for the `jiff` crate)",
+            );
+            AdhocError::from_static_str(message)
+        }
+    }
+
+    fn from_static_str(message: &'static str) -> AdhocError {
+        #[cfg(feature = "alloc")]
+        {
+            AdhocError::from_display(message)
+        }
+        #[cfg(not(feature = "alloc"))]
+        {
+            AdhocError { message }
+        }
+    }
+}
 
 #[cfg(feature = "std")]
 impl std::error::Error for AdhocError {}
 
 impl core::fmt::Display for AdhocError {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        self.0.fmt(f)
+        core::fmt::Display::fmt(&self.message, f)
     }
 }
 
 impl core::fmt::Debug for AdhocError {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        self.0.fmt(f)
+        core::fmt::Debug::fmt(&self.message, f)
     }
 }
 
@@ -256,49 +298,33 @@ impl core::fmt::Debug for AdhocError {
 /// which input was out of bounds, the value given and its minimum and maximum
 /// allowed values.
 #[derive(Debug)]
-struct RangeError(Box<RangeErrorKind>);
-
-#[derive(Debug)]
-enum RangeErrorKind {
-    Positive { what: &'static str, given: u128, min: i128, max: i128 },
-    Negative { what: &'static str, given: i128, min: i128, max: i128 },
-    Specific { what: &'static str, given: i128 },
+#[cfg_attr(not(feature = "alloc"), derive(Clone))]
+struct RangeError {
+    what: &'static str,
+    #[cfg(feature = "alloc")]
+    given: i128,
+    #[cfg(feature = "alloc")]
+    min: i128,
+    #[cfg(feature = "alloc")]
+    max: i128,
 }
 
 impl RangeError {
-    fn unsigned(
+    fn new(
         what: &'static str,
-        given: impl Into<u128>,
-        min: impl Into<i128>,
-        max: impl Into<i128>,
+        _given: impl Into<i128>,
+        _min: impl Into<i128>,
+        _max: impl Into<i128>,
     ) -> RangeError {
-        RangeError(Box::new(RangeErrorKind::Positive {
+        RangeError {
             what,
-            given: given.into(),
-            min: min.into(),
-            max: max.into(),
-        }))
-    }
-
-    fn signed(
-        what: &'static str,
-        given: impl Into<i128>,
-        min: impl Into<i128>,
-        max: impl Into<i128>,
-    ) -> RangeError {
-        RangeError(Box::new(RangeErrorKind::Negative {
-            what,
-            given: given.into(),
-            min: min.into(),
-            max: max.into(),
-        }))
-    }
-
-    fn specific(what: &'static str, given: impl Into<i128>) -> RangeError {
-        RangeError(Box::new(RangeErrorKind::Specific {
-            what,
-            given: given.into(),
-        }))
+            #[cfg(feature = "alloc")]
+            given: _given.into(),
+            #[cfg(feature = "alloc")]
+            min: _min.into(),
+            #[cfg(feature = "alloc")]
+            max: _max.into(),
+        }
     }
 }
 
@@ -307,46 +333,20 @@ impl std::error::Error for RangeError {}
 
 impl core::fmt::Display for RangeError {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        match *self.0 {
-            RangeErrorKind::Positive { what, given, min, max } => {
-                write!(
-                    f,
-                    "parameter '{what}' with value {given} \
-                     is not in the required range of {min}..={max}",
-                )
-            }
-            RangeErrorKind::Negative { what, given, min, max } => {
-                write!(
-                    f,
-                    "parameter '{what}' with value {given} \
-                     is not in the required range of {min}..={max}",
-                )
-            }
-            RangeErrorKind::Specific { what, given } => {
-                write!(f, "parameter '{what}' with value {given} is illegal",)
-            }
+        #[cfg(feature = "alloc")]
+        {
+            let RangeError { what, given, min, max } = *self;
+            write!(
+                f,
+                "parameter '{what}' with value {given} \
+                 is not in the required range of {min}..={max}",
+            )
         }
-    }
-}
-
-#[derive(Debug)]
-struct TimeZoneLookupError(Box<TimeZoneLookupErrorInner>);
-
-#[derive(Debug)]
-struct TimeZoneLookupErrorInner {
-    name: String,
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for TimeZoneLookupError {}
-
-impl core::fmt::Display for TimeZoneLookupError {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(
-            f,
-            "failed to find timezone '{}' in time zone database",
-            self.0.name
-        )
+        #[cfg(not(feature = "alloc"))]
+        {
+            let RangeError { what } = *self;
+            write!(f, "parameter '{what}' is not in the required range")
+        }
     }
 }
 
@@ -359,6 +359,7 @@ impl core::fmt::Display for TimeZoneLookupError {
 /// Otherwise, this type is a simple wrapper around `std::io::Error`. Its
 /// purpose is to encapsulate the conditional compilation based on the `std`
 /// feature.
+#[cfg_attr(not(feature = "alloc"), derive(Clone))]
 struct IOError {
     #[cfg(feature = "std")]
     err: std::io::Error,
@@ -400,6 +401,7 @@ impl From<std::io::Error> for IOError {
     }
 }
 
+#[cfg_attr(not(feature = "alloc"), derive(Clone))]
 struct FilePathError {
     #[cfg(feature = "std")]
     path: std::path::PathBuf,
@@ -454,11 +456,12 @@ impl IntoError for Error {
 
 impl IntoError for &'static str {
     fn into_error(self) -> Error {
-        Error::adhoc(self)
+        Error::adhoc_from_static_str(self)
     }
 }
 
-impl IntoError for String {
+#[cfg(feature = "alloc")]
+impl IntoError for alloc::string::String {
     fn into_error(self) -> Error {
         Error::adhoc(self)
     }
@@ -499,28 +502,46 @@ pub(crate) trait ErrorContext {
 
 impl ErrorContext for Error {
     fn context(self, consequent: impl IntoError) -> Error {
-        let mut err = consequent.into_error();
-        assert!(
-            err.inner.cause.is_none(),
-            "cause of consequence must be `None`"
-        );
-        // OK because we just created this error so the Arc has one reference.
-        Arc::get_mut(&mut err.inner).unwrap().cause = Some(self);
-        err
+        #[cfg(feature = "alloc")]
+        {
+            let mut err = consequent.into_error();
+            assert!(
+                err.inner.cause.is_none(),
+                "cause of consequence must be `None`"
+            );
+            // OK because we just created this error so the Arc
+            // has one reference.
+            Arc::get_mut(&mut err.inner).unwrap().cause = Some(self);
+            err
+        }
+        #[cfg(not(feature = "alloc"))]
+        {
+            // We just completely drop `self`. :-(
+            consequent.into_error()
+        }
     }
 
     fn with_context<E: IntoError>(
         self,
         consequent: impl FnOnce() -> E,
     ) -> Error {
-        let mut err = consequent().into_error();
-        assert!(
-            err.inner.cause.is_none(),
-            "cause of consequence must be `None`"
-        );
-        // OK because we just created this error so the Arc has one reference.
-        Arc::get_mut(&mut err.inner).unwrap().cause = Some(self);
-        err
+        #[cfg(feature = "alloc")]
+        {
+            let mut err = consequent().into_error();
+            assert!(
+                err.inner.cause.is_none(),
+                "cause of consequence must be `None`"
+            );
+            // OK because we just created this error so the Arc
+            // has one reference.
+            Arc::get_mut(&mut err.inner).unwrap().cause = Some(self);
+            err
+        }
+        #[cfg(not(feature = "alloc"))]
+        {
+            // We just completely drop `self`. :-(
+            consequent().into_error()
+        }
     }
 }
 
@@ -547,7 +568,29 @@ mod tests {
     // general, we should not increase the size without a very good reason.
     #[test]
     fn error_size() {
-        let expected_size = core::mem::size_of::<usize>();
+        let mut expected_size = core::mem::size_of::<usize>();
+        if !cfg!(feature = "alloc") {
+            // oooowwwwwwwwwwwch.
+            //
+            // Like, this is horrible, right? core-only environments are
+            // precisely the place where one want to keep things slim. But
+            // in core-only, I don't know of a way to introduce any sort of
+            // indirection in the library level without using a completely
+            // different API.
+            //
+            // This is what makes me doubt that core-only Jiff is actually
+            // useful. In what context are people using a huge library like
+            // Jiff but can't define a small little heap allocator?
+            //
+            // OK, this used to be `expected_size *= 10`, but I slimmed it down
+            // to x3. Still kinda sucks right? If we tried harder, I think we
+            // could probably slim this down more. And if we were willing to
+            // sacrifice error message quality even more (like, all the way),
+            // then we could make `Error` a zero sized type. Which might
+            // actually be the right trade-off for core-only, but I'll hold off
+            // until we have some real world use cases.
+            expected_size *= 3;
+        }
         assert_eq!(expected_size, core::mem::size_of::<Error>());
     }
 }

--- a/src/fmt/friendly/printer.rs
+++ b/src/fmt/friendly/printer.rs
@@ -922,6 +922,7 @@ impl SpanPrinter {
     /// let span = 3.years().months(5);
     /// assert_eq!(PRINTER.span_to_string(&span), "3y 5mo");
     /// ```
+    #[cfg(any(test, feature = "alloc"))]
     pub fn span_to_string(&self, span: &Span) -> alloc::string::String {
         let mut buf = alloc::string::String::with_capacity(4);
         // OK because writing to `String` never fails.
@@ -962,6 +963,7 @@ impl SpanPrinter {
     ///     "24h 2m 5.123000789s ago",
     /// );
     /// ```
+    #[cfg(any(test, feature = "alloc"))]
     pub fn duration_to_string(
         &self,
         duration: &SignedDuration,

--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -110,6 +110,7 @@ pub trait Write {
     }
 }
 
+#[cfg(any(test, feature = "alloc"))]
 impl Write for alloc::string::String {
     #[inline]
     fn write_str(&mut self, string: &str) -> Result<(), Error> {
@@ -118,6 +119,7 @@ impl Write for alloc::string::String {
     }
 }
 
+#[cfg(any(test, feature = "alloc"))]
 impl Write for alloc::vec::Vec<u8> {
     #[inline]
     fn write_str(&mut self, string: &str) -> Result<(), Error> {
@@ -181,6 +183,9 @@ impl<W: std::io::Write> Write for StdIoWrite<W> {
 /// to something with a `std::fmt::Write` trait implementation but not a
 /// `fmt::Write` implementation.
 ///
+/// (Despite using `Std` in this name, this type is available in `core`-only
+/// configurations.)
+///
 /// # Example
 ///
 /// This example shows the `std::fmt::Display` trait implementation for
@@ -209,7 +214,9 @@ pub struct StdFmtWrite<W>(pub W);
 impl<W: core::fmt::Write> Write for StdFmtWrite<W> {
     #[inline]
     fn write_str(&mut self, string: &str) -> Result<(), Error> {
-        self.0.write_str(string).map_err(Error::adhoc)
+        self.0
+            .write_str(string)
+            .map_err(|_| err!("an error occurred when formatting an argument"))
     }
 }
 

--- a/src/fmt/rfc2822.rs
+++ b/src/fmt/rfc2822.rs
@@ -102,6 +102,7 @@ pub(crate) static DEFAULT_DATETIME_PRINTER: DateTimePrinter =
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
+#[cfg(feature = "alloc")]
 #[inline]
 pub fn to_string(zdt: &Zoned) -> Result<alloc::string::String, Error> {
     let mut buf = alloc::string::String::new();
@@ -1144,6 +1145,7 @@ impl DateTimePrinter {
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    #[cfg(feature = "alloc")]
     pub fn zoned_to_string(
         &self,
         zdt: &Zoned,
@@ -1185,6 +1187,7 @@ impl DateTimePrinter {
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    #[cfg(feature = "alloc")]
     pub fn timestamp_to_string(
         &self,
         timestamp: &Timestamp,
@@ -1230,6 +1233,7 @@ impl DateTimePrinter {
     /// ```
     ///
     /// [RFC 9110]: https://datatracker.ietf.org/doc/html/rfc9110#section-5.6.7-15
+    #[cfg(feature = "alloc")]
     pub fn timestamp_to_rfc9110_string(
         &self,
         timestamp: &Timestamp,

--- a/src/fmt/rfc9557.rs
+++ b/src/fmt/rfc9557.rs
@@ -378,7 +378,9 @@ impl Parser {
     }
 
     // N.B. If we ever actually need the values, this should probably return a
-    // `Vec<&'i [u8]>`.
+    // `Vec<&'i [u8]>`. (Well, no, because that wouldn't be good for core-only
+    // configurations. So it will probably need to be something else. But,
+    // probably Jiff will never care about other values.)
     fn parse_annotation_values<'i>(
         &self,
         input: &'i [u8],
@@ -1034,7 +1036,7 @@ mod tests {
 
         insta::assert_snapshot!(
             p(b"[Foo]"),
-            @"failed to find timezone 'Foo' in time zone database",
+            @"failed to find time zone `Foo` in time zone database",
         );
     }
 

--- a/src/fmt/temporal/mod.rs
+++ b/src/fmt/temporal/mod.rs
@@ -975,6 +975,7 @@ impl DateTimePrinter {
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    #[cfg(feature = "alloc")]
     pub fn zoned_to_string(&self, zdt: &Zoned) -> alloc::string::String {
         let mut buf = alloc::string::String::with_capacity(4);
         // OK because writing to `String` never fails.
@@ -1018,6 +1019,7 @@ impl DateTimePrinter {
     ///     "1970-01-01T00:00:00.000000001Z",
     /// );
     /// ```
+    #[cfg(feature = "alloc")]
     pub fn timestamp_to_string(
         &self,
         timestamp: &Timestamp,
@@ -1073,6 +1075,7 @@ impl DateTimePrinter {
     ///     "1970-01-01T00:00:00.000000001+00:00",
     /// );
     /// ```
+    #[cfg(feature = "alloc")]
     pub fn timestamp_with_offset_to_string(
         &self,
         timestamp: &Timestamp,
@@ -1099,6 +1102,7 @@ impl DateTimePrinter {
     /// let dt = date(2024, 6, 15).at(7, 0, 0, 0);
     /// assert_eq!(PRINTER.datetime_to_string(&dt), "2024-06-15T07:00:00");
     /// ```
+    #[cfg(feature = "alloc")]
     pub fn datetime_to_string(
         &self,
         dt: &civil::DateTime,
@@ -1124,6 +1128,7 @@ impl DateTimePrinter {
     /// let d = date(2024, 6, 15);
     /// assert_eq!(PRINTER.date_to_string(&d), "2024-06-15");
     /// ```
+    #[cfg(feature = "alloc")]
     pub fn date_to_string(&self, date: &civil::Date) -> alloc::string::String {
         let mut buf = alloc::string::String::with_capacity(4);
         // OK because writing to `String` never fails.
@@ -1146,6 +1151,7 @@ impl DateTimePrinter {
     /// let t = time(7, 0, 0, 0);
     /// assert_eq!(PRINTER.time_to_string(&t), "07:00:00");
     /// ```
+    #[cfg(feature = "alloc")]
     pub fn time_to_string(&self, time: &civil::Time) -> alloc::string::String {
         let mut buf = alloc::string::String::with_capacity(4);
         // OK because writing to `String` never fails.
@@ -1616,6 +1622,7 @@ impl SpanPrinter {
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    #[cfg(feature = "alloc")]
     pub fn span_to_string(&self, span: &Span) -> alloc::string::String {
         let mut buf = alloc::string::String::with_capacity(4);
         // OK because writing to `String` never fails.
@@ -1644,6 +1651,7 @@ impl SpanPrinter {
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    #[cfg(feature = "alloc")]
     pub fn duration_to_string(
         &self,
         duration: &SignedDuration,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -594,8 +594,16 @@ For more, see the [`fmt::serde`] sub-module. (This requires enabling Jiff's
   finding your system's default time zone. But if you don't need that (or can
   bundle the Time Zone Database), then Jiff has nearly full functionality
   without `std` enabled, excepting things like `std::error::Error` trait
-  implementations. Jiff does require dynamic memory allocation. That is,
-  there is no way to use Jiff in `core`-only contexts.
+  implementations and a global time zone database (which is required for
+  things like [`Timestamp::intz`] to work).
+* **alloc** (enabled by default) -
+  When enabled, Jiff will depend on the `alloc` crate. In particular, this
+  enables functionality that requires or greatly benefits from dynamic memory
+  allocation. If you can enable this, it is strongly encouraged that you do so.
+  Without it, only fixed time zones are supported and error messages are
+  significantly degraded. Also, the sizes of some types get bigger. If you
+  have use cases for Jiff in a no-std and no-alloc context, I would love
+  feedback on the issue tracker about your use cases.
 * **logging** -
   When enabled, the `log` crate is used to emit messages where appropriate.
   Generally speaking, this is reserved for system interaction points, such as
@@ -675,29 +683,10 @@ For more, see the [`fmt::serde`] sub-module. (This requires enabling Jiff's
 #[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
 compile_error!("jiff currently not supported on non-{32,64}");
 
-#[cfg(not(feature = "alloc"))]
-compile_error!("jiff currently requires dynamic memory allocation");
-
 #[cfg(any(test, feature = "std"))]
 extern crate std;
 
-// We don't currently support a non-alloc mode for Jiff. I'm not opposed to
-// doing it, but dynamic memory allocation is pretty heavily weaved into some
-// core parts of Jiff. In particular, its error types.
-//
-// When I originally started writing Jiff, my goal was to support a core-only
-// mode. But it became too painful to make every use of the heap conditional.
-//
-// With that said, I believe errors are the only thing that is "pervasive"
-// that allocates. That, and time zones. So if core-only was deeply desired,
-// we could probably pull the "much worse user experience" level and make it
-// happen. Alternatively, we could carve out a "jiff core" crate, although I
-// don't really know what that would look like.
-//
-// If you have a use case for a core-only Jiff, please file an issue. And
-// please don't just say, "I want Jiff without heap allocation." Please give a
-// detailed accounting of 1) why you can't use dynamic memory allocation and 2)
-// what specific functionality from Jiff you actually need.
+#[cfg(any(test, feature = "alloc"))]
 extern crate alloc;
 
 pub use crate::{
@@ -741,18 +730,6 @@ pub mod _documentation {
     pub mod platform {}
     #[doc = include_str!("../CHANGELOG.md")]
     pub mod changelog {}
-}
-
-/// This module re-exports `Arc`.
-///
-/// That is, it provides some indirection for the case when `alloc::sync::Arc`
-/// is unavailable.
-mod sync {
-    #[cfg(not(target_has_atomic = "ptr"))]
-    pub use portable_atomic_util::Arc;
-
-    #[cfg(target_has_atomic = "ptr")]
-    pub use alloc::sync::Arc;
 }
 
 #[cfg(test)]

--- a/src/span.rs
+++ b/src/span.rs
@@ -1,7 +1,5 @@
 use core::{cmp::Ordering, time::Duration as UnsignedDuration};
 
-use alloc::borrow::Cow;
-
 use crate::{
     civil::{Date, DateTime, Time},
     duration::{Duration, SDuration},
@@ -9,6 +7,7 @@ use crate::{
     fmt::{friendly, temporal},
     tz::TimeZone,
     util::{
+        borrow::DumbCow,
         escape,
         rangeint::{ri64, ri8, RFrom, RInto, TryRFrom, TryRInto},
         round::increment,
@@ -3103,7 +3102,8 @@ impl Span {
     ///
     /// This is useful for debugging. Normally, this would be the "alternate"
     /// debug impl (perhaps), but that's what insta uses and I preferred having
-    /// the standard serialization used there.
+    /// the friendly format used there since is much more terse.
+    #[cfg(feature = "alloc")]
     #[allow(dead_code)]
     fn debug(&self) -> alloc::string::String {
         use core::fmt::Write;
@@ -5158,7 +5158,7 @@ impl<'a> SpanRelativeTo<'a> {
             }
             SpanRelativeToKind::Zoned(zdt) => {
                 Ok(Relative::Zoned(RelativeZoned {
-                    zoned: Cow::Borrowed(zdt),
+                    zoned: DumbCow::Borrowed(zdt),
                 }))
             }
         }
@@ -5641,7 +5641,7 @@ impl RelativeCivil {
 /// A simple wrapper around a possibly borrowed `Zoned`.
 #[derive(Clone, Debug)]
 struct RelativeZoned<'a> {
-    zoned: Cow<'a, Zoned>,
+    zoned: DumbCow<'a, Zoned>,
 }
 
 impl<'a> RelativeZoned<'a> {
@@ -5658,7 +5658,7 @@ impl<'a> RelativeZoned<'a> {
         let zoned = self.zoned.checked_add(span).with_context(|| {
             err!("failed to add {span} to {zoned}", zoned = self.zoned)
         })?;
-        Ok(RelativeZoned { zoned: Cow::Owned(zoned) })
+        Ok(RelativeZoned { zoned: DumbCow::Owned(zoned) })
     }
 
     /// Returns the result of [`Zoned::checked_add`] with an absolute duration.
@@ -5674,7 +5674,7 @@ impl<'a> RelativeZoned<'a> {
         let zoned = self.zoned.checked_add(duration).with_context(|| {
             err!("failed to add {duration:?} to {zoned}", zoned = self.zoned)
         })?;
-        Ok(RelativeZoned { zoned: Cow::Owned(zoned) })
+        Ok(RelativeZoned { zoned: DumbCow::Owned(zoned) })
     }
 
     /// Returns the result of [`Zoned::until`].

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -2084,11 +2084,10 @@ impl Timestamp {
     ) -> Result<Timestamp, Error> {
         let sign = sign.signum();
         let seconds = i64::try_from(duration.as_secs()).map_err(|_| {
-            Error::unsigned(
-                "duration seconds",
+            err!(
+                "could not convert unsigned `Duration` of `{} seconds` \
+                 to signed 64-bit integer",
                 duration.as_secs(),
-                UnixSeconds::MIN_REPR,
-                UnixSeconds::MAX_REPR,
             )
         })?;
         let nanos = i32::try_from(duration.subsec_nanos())
@@ -2153,7 +2152,7 @@ impl Timestamp {
     ) -> Result<Timestamp, Error> {
         let (second, nanosecond) = (second.rinto(), nanosecond.rinto());
         if second == UnixSeconds::MIN_REPR && nanosecond < 0 {
-            return Err(Error::signed(
+            return Err(Error::range(
                 "seconds and nanoseconds",
                 nanosecond,
                 0,

--- a/src/tz/db/bundled/disabled.rs
+++ b/src/tz/db/bundled/disabled.rs
@@ -1,8 +1,6 @@
-use alloc::{string::String, vec::Vec};
-
 use crate::tz::TimeZone;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct BundledZoneInfo;
 
 impl BundledZoneInfo {
@@ -16,8 +14,9 @@ impl BundledZoneInfo {
         None
     }
 
-    pub(crate) fn available(&self) -> Vec<String> {
-        Vec::new()
+    #[cfg(feature = "alloc")]
+    pub(crate) fn available(&self) -> alloc::vec::Vec<alloc::string::String> {
+        alloc::vec::Vec::new()
     }
 
     pub(crate) fn is_definitively_empty(&self) -> bool {

--- a/src/tz/db/mod.rs
+++ b/src/tz/db/mod.rs
@@ -1,6 +1,8 @@
-use alloc::{string::String, vec::Vec};
-
-use crate::{error::Error, sync::Arc, tz::TimeZone};
+use crate::{
+    error::{err, Error},
+    tz::TimeZone,
+    util::sync::Arc,
+};
 
 use self::{bundled::BundledZoneInfo, zoneinfo::ZoneInfo};
 
@@ -184,6 +186,8 @@ pub struct TimeZoneDatabase {
 }
 
 #[derive(Debug)]
+// Needed for core-only "dumb" `Arc`.
+#[cfg_attr(not(feature = "alloc"), derive(Clone))]
 struct TimeZoneDatabaseInner {
     zoneinfo: ZoneInfo,
     bundled: BundledZoneInfo,
@@ -213,6 +217,11 @@ impl TimeZoneDatabase {
     ///
     /// Typically, one does not need to call this routine directly. Instead,
     /// it's done for you as part of [`jiff::tz::db`](crate::tz::db()).
+    /// This does require Jiff's `std` feature to be enabled though. So for
+    /// example, you might use this constructor when the features `alloc`
+    /// and `tzdb-bundle-always` are enabled to get access to a bundled
+    /// copy of the IANA time zone database. (Accessing the system copy at
+    /// `/usr/share/zoneinfo` requires `std`.)
     ///
     /// Beware that calling this constructor will create a new _distinct_
     /// handle from the one returned by `jiff::tz::db` with its own cache.
@@ -282,10 +291,22 @@ impl TimeZoneDatabase {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn get(&self, name: &str) -> Result<TimeZone, Error> {
-        let inner = self
-            .inner
-            .as_deref()
-            .ok_or_else(|| Error::time_zone_lookup(name))?;
+        let inner = self.inner.as_deref().ok_or_else(|| {
+            if cfg!(feature = "std") {
+                err!(
+                    "failed to find time zone `{name}` since there is no \
+                     time zone database configured",
+                )
+            } else {
+                err!(
+                    "failed to find time zone `{name}`, there is no \
+                     global time zone database configured (and is currently \
+                     impossible to do so without Jiff's `std` feature \
+                     enabled, if you need this functionality, please file \
+                     an issue on Jiff's tracker with your use case)",
+                )
+            }
+        })?;
         if let Some(tz) = inner.zoneinfo.get(name) {
             trace!(
                 "found time zone {name} in system zoneinfo ({:?}) database",
@@ -297,7 +318,7 @@ impl TimeZoneDatabase {
             trace!("found time zone {name} in bundled zoneinfo database");
             return Ok(tz);
         }
-        Err(Error::time_zone_lookup(name))
+        Err(err!("failed to find time zone `{name}` in time zone database"))
     }
 
     /// Returns a list of all available time zone identifiers from this
@@ -318,9 +339,12 @@ impl TimeZoneDatabase {
     ///     println!("{tzid}");
     /// }
     /// ```
+    #[cfg(feature = "alloc")]
     pub fn available(&self) -> TimeZoneNameIter {
         let Some(ref inner) = self.inner else {
-            return TimeZoneNameIter { it: Vec::new().into_iter() };
+            return TimeZoneNameIter {
+                it: alloc::vec::Vec::new().into_iter(),
+            };
         };
         let mut all = inner.zoneinfo.available();
         all.extend(inner.bundled.available());
@@ -389,15 +413,17 @@ impl core::fmt::Debug for TimeZoneDatabase {
 ///
 /// There are no guarantees about the order in which this iterator yields
 /// time zone identifiers.
+#[cfg(feature = "alloc")]
 #[derive(Clone, Debug)]
 pub struct TimeZoneNameIter {
-    it: alloc::vec::IntoIter<String>,
+    it: alloc::vec::IntoIter<alloc::string::String>,
 }
 
+#[cfg(feature = "alloc")]
 impl Iterator for TimeZoneNameIter {
-    type Item = String;
+    type Item = alloc::string::String;
 
-    fn next(&mut self) -> Option<String> {
+    fn next(&mut self) -> Option<alloc::string::String> {
         self.it.next()
     }
 }
@@ -414,7 +440,15 @@ mod tests {
     /// accidentally increasing its size.
     #[test]
     fn time_zone_database_size() {
-        let word = core::mem::size_of::<usize>();
-        assert_eq!(word, core::mem::size_of::<TimeZoneDatabase>());
+        #[cfg(feature = "alloc")]
+        {
+            let word = core::mem::size_of::<usize>();
+            assert_eq!(word, core::mem::size_of::<TimeZoneDatabase>());
+        }
+        // A `TimeZoneDatabase` in core-only is vapid.
+        #[cfg(not(feature = "alloc"))]
+        {
+            assert_eq!(1, core::mem::size_of::<TimeZoneDatabase>());
+        }
     }
 }

--- a/src/tz/db/zoneinfo/disabled.rs
+++ b/src/tz/db/zoneinfo/disabled.rs
@@ -1,7 +1,6 @@
-use alloc::{string::String, vec::Vec};
-
 use crate::tz::TimeZone;
 
+#[derive(Clone)]
 pub(crate) struct ZoneInfo;
 
 impl ZoneInfo {
@@ -27,8 +26,9 @@ impl ZoneInfo {
         None
     }
 
-    pub(crate) fn available(&self) -> Vec<String> {
-        Vec::new()
+    #[cfg(feature = "alloc")]
+    pub(crate) fn available(&self) -> alloc::vec::Vec<alloc::string::String> {
+        alloc::vec::Vec::new()
     }
 
     pub(crate) fn is_definitively_empty(&self) -> bool {

--- a/src/tz/db/zoneinfo/enabled.rs
+++ b/src/tz/db/zoneinfo/enabled.rs
@@ -244,9 +244,10 @@ impl CachedTimeZone {
         ttl: Duration,
     ) -> Result<CachedTimeZone, Error> {
         let path = &info.inner.full;
-        let mut file = File::open(path).map_err(|e| Error::fs(path, e))?;
+        let mut file =
+            File::open(path).map_err(|e| Error::io(e).path(path))?;
         let mut data = vec![];
-        file.read_to_end(&mut data).map_err(|e| Error::fs(path, e))?;
+        file.read_to_end(&mut data).map_err(|e| Error::io(e).path(path))?;
         let tz = TimeZone::tzif(&info.inner.original, &data)
             .map_err(|e| e.path(path))?;
         let name = info.clone();

--- a/src/tz/system/mod.rs
+++ b/src/tz/system/mod.rs
@@ -4,9 +4,8 @@ use alloc::string::ToString;
 
 use crate::{
     error::{err, Error, ErrorContext},
-    sync::Arc,
     tz::{posix::PosixTz, TimeZone, TimeZoneDatabase},
-    util::cache::Expiration,
+    util::{cache::Expiration, sync::Arc},
 };
 
 #[cfg(unix)]

--- a/src/tz/testdata.rs
+++ b/src/tz/testdata.rs
@@ -1,6 +1,6 @@
 use alloc::string::ToString;
 
-use crate::tz::Tzif;
+use crate::tz::tzif::Tzif;
 
 /// A list of all TZif files in our testdata directory.
 ///

--- a/src/tz/zic.rs
+++ b/src/tz/zic.rs
@@ -113,12 +113,12 @@ use crate::{
     civil::{Date, DateTime, Time, Weekday},
     error::{err, Error, ErrorContext},
     span::{Span, ToSpan},
-    sync::Arc,
     timestamp::Timestamp,
     tz::{Dst, Offset},
     util::{
         parse,
         rangeint::RInto,
+        sync::Arc,
         t::{self, C},
     },
     Unit,
@@ -841,7 +841,7 @@ impl RuleSaveP {
         )?
         .get_seconds();
         let seconds = i32::try_from(seconds).map_err(|_| {
-            Error::signed("SAVE seconds", seconds, i32::MIN, i32::MAX)
+            Error::range("SAVE seconds", seconds, i32::MIN, i32::MAX)
         })?;
         Offset::from_seconds(seconds)
     }

--- a/src/util/borrow.rs
+++ b/src/util/borrow.rs
@@ -1,0 +1,31 @@
+/*!
+This module re-exports a "dumb" version of `std::borrow::Cow`.
+
+It doesn't have any of the generic goodness and doesn't support dynamically
+sized types. It's just either a `T` or a `&T`.
+
+We have pretty simplistic needs, and we use this simpler type that works
+in core-only mode.
+*/
+
+#[derive(Clone, Debug)]
+pub(crate) enum DumbCow<'a, T> {
+    Owned(T),
+    Borrowed(&'a T),
+}
+
+impl<'a, T> core::ops::Deref for DumbCow<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        match *self {
+            DumbCow::Owned(ref t) => t,
+            DumbCow::Borrowed(t) => t,
+        }
+    }
+}
+
+impl<'a, T: core::fmt::Display> core::fmt::Display for DumbCow<'a, T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        core::fmt::Display::fmt(core::ops::Deref::deref(self), f)
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod array_str;
+pub(crate) mod borrow;
 #[cfg(any(feature = "tz-system", feature = "tzdb-zoneinfo"))]
 pub(crate) mod cache;
 pub(crate) mod common;
@@ -9,5 +10,6 @@ pub(crate) mod libm;
 pub(crate) mod parse;
 pub(crate) mod rangeint;
 pub(crate) mod round;
+pub(crate) mod sync;
 pub(crate) mod t;
 pub(crate) mod utf8;

--- a/src/util/rangeint.rs
+++ b/src/util/rangeint.rs
@@ -84,7 +84,7 @@ macro_rules! define_ranged {
                 what: &'static str,
                 given: $repr,
             ) -> Error {
-                Error::signed(what, given, Self::MIN_REPR, Self::MAX_REPR)
+                Error::range(what, given, Self::MIN_REPR, Self::MAX_REPR)
             }
 
             #[inline]
@@ -115,7 +115,7 @@ macro_rules! define_ranged {
                 let val = val.into();
                 #[allow(irrefutable_let_patterns)]
                 let Ok(val) = <$repr>::try_from(val) else {
-                    return Err(Error::signed(
+                    return Err(Error::range(
                         what,
                         val,
                         Self::MIN_REPR,
@@ -133,7 +133,7 @@ macro_rules! define_ranged {
                 let val = val.into();
                 #[allow(irrefutable_let_patterns)]
                 let Ok(val) = <$repr>::try_from(val) else {
-                    return Err(Error::signed(
+                    return Err(Error::range(
                         what,
                         val,
                         Self::MIN_REPR,
@@ -335,7 +335,7 @@ macro_rules! define_ranged {
                 min: impl Into<i128>,
                 max: impl Into<i128>,
             ) -> Error {
-                Error::signed(
+                Error::range(
                     what,
                     self.get_unchecked(),
                     min.into(),
@@ -1363,7 +1363,7 @@ macro_rules! define_ranged {
                     #[cfg(not(debug_assertions))]
                     {
                         let val = <$repr>::try_from(r.val).map_err(|_| {
-                            Error::signed(what, r.val, MIN2, MAX2)
+                            Error::range(what, r.val, MIN2, MAX2)
                         })?;
                         if !Self::contains(val) {
                             return Err(Self::error(what, val));
@@ -1373,7 +1373,7 @@ macro_rules! define_ranged {
                     #[cfg(debug_assertions)]
                     {
                         let val = <$repr>::try_from(r.val).map_err(|_| {
-                            Error::signed(what, r.val, MIN2, MAX2)
+                            Error::range(what, r.val, MIN2, MAX2)
                         })?;
                         if !Self::contains(val) {
                             return Err(Self::error(what, val));

--- a/src/util/sync.rs
+++ b/src/util/sync.rs
@@ -1,0 +1,48 @@
+/*!
+This module re-exports `Arc`.
+
+That is, it provides some indirection for the case when `alloc::sync::Arc` is
+unavailable.
+
+It also defines a "dumb" `Arc` in core-only mode that doesn't actually do
+anything (no indirection, no reference counting).
+*/
+
+#[cfg(all(feature = "alloc", not(target_has_atomic = "ptr")))]
+pub(crate) use portable_atomic_util::Arc;
+
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+pub(crate) use alloc::sync::Arc;
+
+/// A "fake" `Arc`.
+///
+/// Basically, it exposes the `Arc` APIs we use in Jiff, but doesn't
+/// actually introduce indirection or reference counting. It's only used
+/// in core-only mode and in effect results in inlining all data into its
+/// container.
+///
+/// Not ideal, but we use `Arc` in very few places. One is `TimeZone`,
+/// which ends up being pretty small in core-only mode since it doesn't
+/// support carrying TZif data.
+#[cfg(not(feature = "alloc"))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct Arc<T>(T);
+
+#[cfg(not(feature = "alloc"))]
+impl<T> Arc<T> {
+    pub(crate) fn new(t: T) -> Arc<T> {
+        Arc(t)
+    }
+
+    pub(crate) fn get_mut(this: &mut Arc<T>) -> Option<&mut T> {
+        Some(&mut this.0)
+    }
+}
+
+#[cfg(not(feature = "alloc"))]
+impl<T> core::ops::Deref for Arc<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -604,7 +604,6 @@ impl Zoned {
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    #[cfg(feature = "std")]
     #[inline]
     pub fn intz(&self, name: &str) -> Result<Zoned, Error> {
         let tz = crate::tz::db().get(name)?;
@@ -3077,7 +3076,6 @@ impl core::fmt::Display for Zoned {
 /// Note that this is only enabled when the `std` feature
 /// is enabled because it requires access to a global
 /// [`TimeZoneDatabase`](crate::tz::TimeZoneDatabase).
-#[cfg(feature = "std")]
 impl core::str::FromStr for Zoned {
     type Err = Error;
 
@@ -5244,11 +5242,25 @@ mod tests {
     fn zoned_size() {
         #[cfg(debug_assertions)]
         {
-            assert_eq!(96, core::mem::size_of::<Zoned>());
+            #[cfg(feature = "alloc")]
+            {
+                assert_eq!(96, core::mem::size_of::<Zoned>());
+            }
+            #[cfg(all(target_pointer_width = "64", not(feature = "alloc")))]
+            {
+                assert_eq!(120, core::mem::size_of::<Zoned>());
+            }
         }
         #[cfg(not(debug_assertions))]
         {
-            assert_eq!(40, core::mem::size_of::<Zoned>());
+            #[cfg(feature = "alloc")]
+            {
+                assert_eq!(40, core::mem::size_of::<Zoned>());
+            }
+            #[cfg(all(target_pointer_width = "64", not(feature = "alloc")))]
+            {
+                assert_eq!(56, core::mem::size_of::<Zoned>());
+            }
         }
     }
 

--- a/test
+++ b/test
@@ -12,10 +12,38 @@ cd "$(dirname "$0")"
 echo "===== DEFAULT FEATURES ====="
 cargo test
 
+# We test core-only mode specially. Sadly, in core-only mode, error messages
+# are quite a bit worse. And this wreaks havoc with Jiff's snapshot tests on
+# error messages. We could `cfg` all of them, but that's a huge pain and it's
+# not clear that it's worth it.
+#
+# Since we use snapshot tests for more than error messages, this technique also
+# risks accidentally passing a test that doesn't involve error messages. Sigh.
+# We accept this risk because this still runs a lot of tests, and the tests
+# that aren't covered are run in other configurations. Still, it's not ideal.
+echo "===== CORE ONLY ====="
+cargo build --no-default-features
+INSTA_FORCE_PASS=1 INSTA_UPDATE=no cargo test --lib --no-default-features
+INSTA_FORCE_PASS=1 INSTA_UPDATE=no cargo test --test integration --no-default-features
+
+# More core-only tests, when combined with compatible features.
 features=(
-    "std"
+    "serde"
+    "logging"
+    "serde logging"
+)
+for f in "${features[@]}"; do
+    echo "===== COREONLY PLUS '$f' ====="
+    cargo build --no-default-features --features "$f"
+    INSTA_FORCE_PASS=1 INSTA_UPDATE=no cargo test --lib --no-default-features --features "$f"
+    INSTA_FORCE_PASS=1 INSTA_UPDATE=no cargo test --test integration --no-default-features --features "$f"
+done
+
+features=(
     "alloc"
     "alloc tzdb-bundle-always"
+    "alloc serde"
+    "std"
     "std tzdb-bundle-platform tzdb-bundle-always"
     "std tzdb-bundle-platform tzdb-bundle-always tzdb-zoneinfo"
     "std tzdb-bundle-platform tzdb-zoneinfo"
@@ -24,7 +52,7 @@ features=(
     "std tzdb-bundle-always serde"
 )
 for f in "${features[@]}"; do
-    echo "===== FEATURE: $f ====="
+    echo "===== FEATURES: '$f' ====="
     cargo build --no-default-features --features "$f"
     cargo test --lib --no-default-features --features "$f"
     cargo test --test integration --no-default-features --features "$f"


### PR DESCRIPTION
There are a few main downsides to core-only support:

1. The error messages produced by Jiff are now awful.
2. Time zone integration is basically gone. All you get are fixed offset
   time zones. Neither POSIX time zones nor IANA time zones are
   supported.
3. The sizes of some types (e.g., `TimeZone` and `Zoned`) are now bigger
   than they are when `alloc` is enabled.

It is possible (1) could be mitigated somewhat, but not entirely. One
way they could be improved is by using more structured error types
instead of strings at the point where the error occurs. When using
strings, some kind of interpolation is needed to convert it to a heap
allocated `String`. But if we used structured error types, we wouldn't
need this heap allocation in the vast majority of cases. However,
doing this is a major pain. Additionally, a significant component
of Jiff's error messages is its chaining, which enables the easy
contextualization of errors. I don't see how to do this in core-only
contexts. In any case, I could maybe be convinced to switch to more
structured errors, but I would need real users of Jiff in core-only mode
to convince me to spend that effort and maintenance headache.

As for (2), time zone integration could be improved. But again, I'd like
to see use cases before digging into this in order to avoid exposing the
wrong API. In particular, POSIX time zones do actually work fine in
core-only contexts, but I've disabled them for now because they greatly
increase the size of a `TimeZone`. There are, I think, ways of shrinking
it without changing the API, but it would be a lot of effort. However,
IANA time zone support is a somewhat different beast, and that requires
some careful thought and real use cases to guide its development.

And for (3), I'm not really sure how to get around inflating the size of
types. My suspicion is that this is really unavoidable, and that it
probably makes using things like `Zoned` in a core-only context
untenable. For core-only, my guess is that they will want an `Unzoned`
type that is like `Zoned`, but doesn't carry a time zone and instead
requires callers to pass in a `&TimeZone` for every API that needs it.
But again, this is a lot of effort to build and I don't want to do it
unless there are compelling use cases for it.

Otherwise, here are some additional small changes that fell out of this
work:

* `Zoned`'s API now includes `FromStr` and `intz` in no-std mode.
This makes it more consistent with other APIs that offer `intz`. I
believe this was a holdover from when `jiff::tz::db()` was itself only
available when `std` was enabled. But I had changed to a model where it
was always available, but, e.g., the time zone database was empty. I
updated routines like `Timestamp::intz` to always be available, but
apparently didn't do it for `Zoned`.
* The docs now make it clear that you need `std` to use the global time
zone database. And explicitly mention that even without `std`, but so
long as `alloc` is enabled, you can still use a `TimeZoneDatabase` with
a bundled copy of the IANA time zone database.

I originally tried to do this work in a commit-by-commit manner, but it
got way too messy. So I just piled everything into one commit.

Closes #168