### PR TITLE
tz: add `TimeZone::preceding` and `TimeZone::following` for iterating over time zone transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ TODO
 
 Enhancements:
 
+* [#144](https://github.com/BurntSushi/jiff/issues/144)
+Add APIs for iterating over the transitions of a time zone.
 * [#145](https://github.com/BurntSushi/jiff/issues/145)
 Improve docs and error messages around fallible `Timestamp` arithmetic.
 

--- a/src/fmt/strtime/mod.rs
+++ b/src/fmt/strtime/mod.rs
@@ -249,7 +249,9 @@ use crate::{
     },
     tz::{Offset, OffsetConflict, TimeZone, TimeZoneDatabase},
     util::{
-        self, escape,
+        self,
+        array_str::Abbreviation,
+        escape,
         t::{self, C},
     },
     Error, Timestamp, Zoned,
@@ -257,9 +259,6 @@ use crate::{
 
 mod format;
 mod parse;
-
-/// Matches the abbreviation defined in `jiff::tz::posix`.
-type Abbreviation = crate::util::array_str::ArrayStr<30>;
 
 /// Parse the given `input` according to the given `format` string.
 ///

--- a/src/tz/tzif.rs
+++ b/src/tz/tzif.rs
@@ -18,7 +18,7 @@ use crate::{
     timestamp::Timestamp,
     tz::{
         posix::{IanaTz, ReasonablePosixTimeZone},
-        AmbiguousOffset, Dst, Offset,
+        AmbiguousOffset, Dst, Offset, TimeZoneTransition,
     },
     util::{
         crc32,
@@ -260,41 +260,48 @@ impl Tzif {
     pub(crate) fn previous_transition(
         &self,
         ts: Timestamp,
-    ) -> Option<Timestamp> {
+    ) -> Option<TimeZoneTransition> {
         assert!(!self.transitions.is_empty(), "transitions is non-empty");
         let search =
             self.transitions.binary_search_by_key(&ts, |t| t.timestamp);
         let index = match search {
             Ok(i) | Err(i) => i.checked_sub(1)?,
         };
-        if index == 0 {
+        let trans = if index == 0 {
             // The first transition is a dummy that we insert, so if we land on
             // it here, treat it as if it doesn't exist.
-            None
+            return None;
         } else if index == self.transitions.len() - 1 {
-            let tzif_prev_trans = self.transitions[index].timestamp;
-            let Some(posix_tz) = self.posix_tz.as_ref() else {
-                // No POSIX TZ means the last transition is our only possible
-                // answer.
-                return Some(tzif_prev_trans);
-            };
-            // Since the POSIX TZ must be consistent with the last transition,
-            // it must be the case that tzif_prev_trans <= posix_prev_tans in
-            // all cases. So the transition according to the POSIX TZ is
-            // always correct here.
-            //
-            // What if this returns `None` though? I'm not sure in which cases
-            // that could matter, and I think it might be a violation of the
-            // TZif format if it does.
-            posix_tz.previous_transition(ts)
+            if let Some(ref posix_tz) = self.posix_tz {
+                // Since the POSIX TZ must be consistent with the last
+                // transition, it must be the case that tzif_last <=
+                // posix_prev_trans in all cases. So the transition according
+                // to the POSIX TZ is always correct here.
+                //
+                // What if this returns `None` though? I'm not sure in which
+                // cases that could matter, and I think it might be a violation
+                // of the TZif format if it does.
+                return posix_tz.previous_transition(ts);
+            }
+            &self.transitions[index]
         } else {
-            Some(self.transitions[index].timestamp)
-        }
+            &self.transitions[index]
+        };
+        let typ = &self.types[usize::from(trans.type_index)];
+        Some(TimeZoneTransition {
+            timestamp: trans.timestamp,
+            offset: typ.offset,
+            abbrev: self.designation(typ),
+            dst: typ.is_dst,
+        })
     }
 
     /// Returns the timestamp of the soonest time zone transition after the
     /// timestamp given. If one doesn't exist, `None` is returned.
-    pub(crate) fn next_transition(&self, ts: Timestamp) -> Option<Timestamp> {
+    pub(crate) fn next_transition(
+        &self,
+        ts: Timestamp,
+    ) -> Option<TimeZoneTransition> {
         assert!(!self.transitions.is_empty(), "transitions is non-empty");
         let search =
             self.transitions.binary_search_by_key(&ts, |t| t.timestamp);
@@ -302,30 +309,33 @@ impl Tzif {
             Ok(i) => i.checked_add(1)?,
             Err(i) => i,
         };
-        if index == 0 {
+        let trans = if index == 0 {
             // The first transition is a dummy that we insert, so if we land on
             // it here, treat it as if it doesn't exist.
-            None
+            return None;
         } else if index >= self.transitions.len() - 1 {
-            let tzif_next_trans =
-                self.transitions.last().expect("last transition").timestamp;
-            let Some(posix_tz) = self.posix_tz.as_ref() else {
-                // No POSIX TZ means the last transition is our only possible
-                // answer.
-                return Some(tzif_next_trans);
-            };
-            // Since the POSIX TZ must be consistent with the last transition,
-            // it must be the case that tzif_next_trans <= posix_next_tans in
-            // all cases. So the transition according to the POSIX TZ is
-            // always correct here.
-            //
-            // What if this returns `None` though? I'm not sure in which cases
-            // that could matter, and I think it might be a violation of the
-            // TZif format if it does.
-            posix_tz.next_transition(ts)
+            if let Some(ref posix_tz) = self.posix_tz {
+                // Since the POSIX TZ must be consistent with the last
+                // transition, it must be the case that next.timestamp <=
+                // posix_next_tans in all cases. So the transition according to
+                // the POSIX TZ is always correct here.
+                //
+                // What if this returns `None` though? I'm not sure in which
+                // cases that could matter, and I think it might be a violation
+                // of the TZif format if it does.
+                return posix_tz.next_transition(ts);
+            }
+            self.transitions.last().expect("last transition")
         } else {
-            Some(self.transitions[index].timestamp)
-        }
+            &self.transitions[index]
+        };
+        let typ = &self.types[usize::from(trans.type_index)];
+        Some(TimeZoneTransition {
+            timestamp: trans.timestamp,
+            offset: typ.offset,
+            abbrev: self.designation(typ),
+            dst: typ.is_dst,
+        })
     }
 
     fn local_time_type_to_offset(

--- a/test
+++ b/test
@@ -12,6 +12,16 @@ cd "$(dirname "$0")"
 echo "===== DEFAULT FEATURES ====="
 cargo test
 
+# This one is useful because sometimes the bundled time zone database can
+# behave differently than the system time zone database depending on the
+# inputs. For example, the bundled database uses as few transitions as possible
+# (this is tzdb's "slim" data model) and thus relies more heavily on POSIX
+# time zone strings. So if there's a bug in POSIX time zone handling, you're
+# likely to see it with the bundled database while missing it completely with
+# the system database.
+echo "===== WITH ONLY THE BUNDLED TIME ZONE DATABASE ====="
+cargo test --no-default-features --features std,tz-system,tzdb-bundle-always
+
 # We test core-only mode specially. Sadly, in core-only mode, error messages
 # are quite a bit worse. And this wreaks havoc with Jiff's snapshot tests on
 # error messages. We could `cfg` all of them, but that's a huge pain and it's


### PR DESCRIPTION
This adds new APIs for iterating over the preceding and following time
zone transitions from a particular point in time.

The hard work was something I actually did a bit ago, but I never
exposed, since I didn't want to figure out the API details. There's
actually a fair bit of information we can expose (timestamp, offset,
abbreviation and whether DST is active), so we introduce a new type,
`jiff::tz::TimeZoneTransition`, that wraps this all up.

Closes #144
