### PR TITLE
doc: document the range of some values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+0.1.19 (TBD)
+============
+TODO
+
+Enhancements:
+
+* [#130](https://github.com/BurntSushi/jiff/issues/130):
+Document value ranges for methods like `year`, `day`, `hour` and so on.
+
+
 0.1.18 (2024-12-31)
 ===================
 This release includes a few minor enhancements. Namely, the ability to iterate
@@ -8,9 +18,9 @@ to failure modes when `Timestamp` and `Span` arithmetic fails.
 
 Enhancements:
 
-* [#144](https://github.com/BurntSushi/jiff/issues/144)
+* [#144](https://github.com/BurntSushi/jiff/issues/144):
 Add APIs for iterating over the transitions of a time zone.
-* [#145](https://github.com/BurntSushi/jiff/issues/145)
+* [#145](https://github.com/BurntSushi/jiff/issues/145):
 Improve docs and error messages around fallible `Timestamp` arithmetic.
 
 

--- a/src/civil/date.rs
+++ b/src/civil/date.rs
@@ -415,6 +415,8 @@ impl Date {
 
     /// Returns the year for this date.
     ///
+    /// The value returned is guaranteed to be in the range `-9999..=9999`.
+    ///
     /// # Example
     ///
     /// ```
@@ -444,6 +446,8 @@ impl Date {
     ///
     /// The crate is designed this way so that years in the latest era (that
     /// is, `CE`) are aligned with years in this crate.
+    ///
+    /// The year returned is guaranteed to be in the range `1..=10000`.
     ///
     /// # Example
     ///
@@ -485,6 +489,8 @@ impl Date {
 
     /// Returns the month for this date.
     ///
+    /// The value returned is guaranteed to be in the range `1..=12`.
+    ///
     /// # Example
     ///
     /// ```
@@ -499,6 +505,8 @@ impl Date {
     }
 
     /// Returns the day for this date.
+    ///
+    /// The value returned is guaranteed to be in the range `1..=31`.
     ///
     /// # Example
     ///

--- a/src/civil/datetime.rs
+++ b/src/civil/datetime.rs
@@ -440,6 +440,8 @@ impl DateTime {
 
     /// Returns the year for this datetime.
     ///
+    /// The value returned is guaranteed to be in the range `-9999..=9999`.
+    ///
     /// # Example
     ///
     /// ```
@@ -469,6 +471,8 @@ impl DateTime {
     ///
     /// The crate is designed this way so that years in the latest era (that
     /// is, `CE`) are aligned with years in this crate.
+    ///
+    /// The year returned is guaranteed to be in the range `1..=10000`.
     ///
     /// # Example
     ///
@@ -500,6 +504,8 @@ impl DateTime {
 
     /// Returns the month for this datetime.
     ///
+    /// The value returned is guaranteed to be in the range `1..=12`.
+    ///
     /// # Example
     ///
     /// ```
@@ -514,6 +520,8 @@ impl DateTime {
     }
 
     /// Returns the day for this datetime.
+    ///
+    /// The value returned is guaranteed to be in the range `1..=31`.
     ///
     /// # Example
     ///
@@ -530,6 +538,8 @@ impl DateTime {
 
     /// Returns the "hour" component of this datetime.
     ///
+    /// The value returned is guaranteed to be in the range `0..=23`.
+    ///
     /// # Example
     ///
     /// ```
@@ -544,6 +554,8 @@ impl DateTime {
     }
 
     /// Returns the "minute" component of this datetime.
+    ///
+    /// The value returned is guaranteed to be in the range `0..=59`.
     ///
     /// # Example
     ///
@@ -560,6 +572,8 @@ impl DateTime {
 
     /// Returns the "second" component of this datetime.
     ///
+    /// The value returned is guaranteed to be in the range `0..=59`.
+    ///
     /// # Example
     ///
     /// ```
@@ -574,6 +588,8 @@ impl DateTime {
     }
 
     /// Returns the "millisecond" component of this datetime.
+    ///
+    /// The value returned is guaranteed to be in the range `0..=999`.
     ///
     /// # Example
     ///
@@ -590,6 +606,8 @@ impl DateTime {
 
     /// Returns the "microsecond" component of this datetime.
     ///
+    /// The value returned is guaranteed to be in the range `0..=999`.
+    ///
     /// # Example
     ///
     /// ```
@@ -604,6 +622,8 @@ impl DateTime {
     }
 
     /// Returns the "nanosecond" component of this datetime.
+    ///
+    /// The value returned is guaranteed to be in the range `0..=999`.
     ///
     /// # Example
     ///
@@ -622,6 +642,8 @@ impl DateTime {
     ///
     /// If you want to set this value on `DateTime`, then use
     /// [`DateTimeWith::subsec_nanosecond`] via [`DateTime::with`].
+    ///
+    /// The value returned is guaranteed to be in the range `0..=999_999_999`.
     ///
     /// # Example
     ///

--- a/src/civil/time.rs
+++ b/src/civil/time.rs
@@ -402,6 +402,8 @@ impl Time {
 
     /// Returns the "hour" component of this time.
     ///
+    /// The value returned is guaranteed to be in the range `0..=23`.
+    ///
     /// # Example
     ///
     /// ```
@@ -416,6 +418,8 @@ impl Time {
     }
 
     /// Returns the "minute" component of this time.
+    ///
+    /// The value returned is guaranteed to be in the range `0..=59`.
     ///
     /// # Example
     ///
@@ -432,6 +436,8 @@ impl Time {
 
     /// Returns the "second" component of this time.
     ///
+    /// The value returned is guaranteed to be in the range `0..=59`.
+    ///
     /// # Example
     ///
     /// ```
@@ -446,6 +452,8 @@ impl Time {
     }
 
     /// Returns the "millisecond" component of this time.
+    ///
+    /// The value returned is guaranteed to be in the range `0..=999`.
     ///
     /// # Example
     ///
@@ -462,6 +470,8 @@ impl Time {
 
     /// Returns the "microsecond" component of this time.
     ///
+    /// The value returned is guaranteed to be in the range `0..=999`.
+    ///
     /// # Example
     ///
     /// ```
@@ -476,6 +486,8 @@ impl Time {
     }
 
     /// Returns the "nanosecond" component of this time.
+    ///
+    /// The value returned is guaranteed to be in the range `0..=999`.
     ///
     /// # Example
     ///
@@ -494,6 +506,8 @@ impl Time {
     ///
     /// If you want to set this value on `Time`, then use
     /// [`TimeWith::subsec_nanosecond`] via [`Time::with`].
+    ///
+    /// The value returned is guaranteed to be in the range `0..=999_999_999`.
     ///
     /// # Example
     ///

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -634,6 +634,8 @@ impl Zoned {
 
     /// Returns the year for this zoned datetime.
     ///
+    /// The value returned is guaranteed to be in the range `-9999..=9999`.
+    ///
     /// # Example
     ///
     /// ```
@@ -665,6 +667,8 @@ impl Zoned {
     ///
     /// The crate is designed this way so that years in the latest era (that
     /// is, `CE`) are aligned with years in this crate.
+    ///
+    /// The year returned is guaranteed to be in the range `1..=10000`.
     ///
     /// # Example
     ///
@@ -698,6 +702,8 @@ impl Zoned {
 
     /// Returns the month for this zoned datetime.
     ///
+    /// The value returned is guaranteed to be in the range `1..=12`.
+    ///
     /// # Example
     ///
     /// ```
@@ -715,6 +721,8 @@ impl Zoned {
 
     /// Returns the day for this zoned datetime.
     ///
+    /// The value returned is guaranteed to be in the range `1..=31`.
+    ///
     /// # Example
     ///
     /// ```
@@ -731,6 +739,8 @@ impl Zoned {
     }
 
     /// Returns the "hour" component of this zoned datetime.
+    ///
+    /// The value returned is guaranteed to be in the range `0..=23`.
     ///
     /// # Example
     ///
@@ -751,6 +761,8 @@ impl Zoned {
 
     /// Returns the "minute" component of this zoned datetime.
     ///
+    /// The value returned is guaranteed to be in the range `0..=59`.
+    ///
     /// # Example
     ///
     /// ```
@@ -769,6 +781,8 @@ impl Zoned {
     }
 
     /// Returns the "second" component of this zoned datetime.
+    ///
+    /// The value returned is guaranteed to be in the range `0..=59`.
     ///
     /// # Example
     ///
@@ -789,6 +803,8 @@ impl Zoned {
 
     /// Returns the "millisecond" component of this zoned datetime.
     ///
+    /// The value returned is guaranteed to be in the range `0..=999`.
+    ///
     /// # Example
     ///
     /// ```
@@ -808,6 +824,8 @@ impl Zoned {
 
     /// Returns the "microsecond" component of this zoned datetime.
     ///
+    /// The value returned is guaranteed to be in the range `0..=999`.
+    ///
     /// # Example
     ///
     /// ```
@@ -826,6 +844,8 @@ impl Zoned {
     }
 
     /// Returns the "nanosecond" component of this zoned datetime.
+    ///
+    /// The value returned is guaranteed to be in the range `0..=999`.
     ///
     /// # Example
     ///
@@ -848,6 +868,8 @@ impl Zoned {
     ///
     /// If you want to set this value on `Zoned`, then use
     /// [`ZonedWith::subsec_nanosecond`] via [`Zoned::with`].
+    ///
+    /// The value returned is guaranteed to be in the range `0..=999_999_999`.
     ///
     /// # Example
     ///


### PR DESCRIPTION
Specifically, this puts harder and more explicit guarantees on the range
of values returned by methods like `year`, `month`, `day`, `hour` and so
on.

Fixes #130
