### PR TITLE
fmt/strtime: support non-ASCII in `strftime` format strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Enhancements:
 * [#130](https://github.com/BurntSushi/jiff/issues/130):
 Document value ranges for methods like `year`, `day`, `hour` and so on.
 
+Bug fixes:
+
+* [#155](https://github.com/BurntSushi/jiff/issues/155):
+Relax `strftime` format strings from ASCII-only to all of UTF-8.
+
 
 0.1.18 (2024-12-31)
 ===================

--- a/src/fmt/strtime/mod.rs
+++ b/src/fmt/strtime/mod.rs
@@ -2168,4 +2168,26 @@ mod tests {
             @"2024-07-30T00:56:25+04:00[+04:00]",
         );
     }
+
+    // Regression test for format strings with non-ASCII in them.
+    //
+    // We initially didn't support non-ASCII because I had thought it wouldn't
+    // be used. i.e., If someone wanted to do something with non-ASCII, then
+    // I thought they'd want to be using something more sophisticated that took
+    // locale into account. But apparently not.
+    //
+    // See: https://github.com/BurntSushi/jiff/issues/155
+    #[test]
+    fn ok_non_ascii() {
+        let fmt = "%Y年%m月%d日，%H时%M分%S秒";
+        let dt = crate::civil::date(2022, 2, 4).at(3, 58, 59, 0);
+        insta::assert_snapshot!(
+            dt.strftime(fmt),
+            @"2022年02月04日，03时58分59秒",
+        );
+        insta::assert_debug_snapshot!(
+            DateTime::strptime(fmt, "2022年02月04日，03时58分59秒").unwrap(),
+            @"2022-02-04T03:58:59",
+        );
+    }
 }


### PR DESCRIPTION
I'm not sure why I didn't do this initially. I think I thought there
wasn't a use case. But it's easy enough to support.

This would have probably been easier if we accepted a `&str` for the
format string, especially since we require valid UTF-8 (which is a
strict relaxation from requiring valid ASCII). In that case, we would
just iterate over `chars()`. But, that would require the caller to
create the `&str` (thus paying for UTF-8 validation) and would require
`strftime` to do UTF-8 decoding. This way, we don't require any of that
up-front UTF-8 validation, and in the vast majority of cases
(ASCII-only), we just handle things one-byte-at-a-time without caring
about UTF-8.

Fixes #155
