### PR TITLE
Fix `ISOWeekDate::weekday` doc and examples

### DIFF
--- a/src/civil/iso_week_date.rs
+++ b/src/civil/iso_week_date.rs
@@ -242,7 +242,7 @@ impl ISOWeekDate {
     /// Returns the day component of this ISO 8601 week date.
     ///
     /// One can use methods on `Weekday` such as
-    /// [`Weekday::to_sunday_zero_offset`] to convert the weekday to a number.
+    /// [`Weekday::to_monday_one_offset`] to convert the weekday to a number.
     ///
     /// # Example
     ///
@@ -253,6 +253,7 @@ impl ISOWeekDate {
     /// assert_eq!(weekdate.year(), 1948);
     /// assert_eq!(weekdate.week(), 53);
     /// assert_eq!(weekdate.weekday(), Weekday::Friday);
+    /// assert_eq!(weekdate.weekday().to_monday_one_offset(), 5);
     /// ```
     #[inline]
     pub fn weekday(self) -> Weekday {

--- a/src/civil/iso_week_date.rs
+++ b/src/civil/iso_week_date.rs
@@ -254,6 +254,7 @@ impl ISOWeekDate {
     /// assert_eq!(weekdate.week(), 53);
     /// assert_eq!(weekdate.weekday(), Weekday::Friday);
     /// assert_eq!(weekdate.weekday().to_monday_one_offset(), 5);
+    /// assert_eq!(weekdate.weekday().to_sunday_zero_offset(), 5);
     /// ```
     #[inline]
     pub fn weekday(self) -> Weekday {


### PR DESCRIPTION
As ISO-Week is Monday == day 1 based system, it would be nice to give correct example to readers in this context. 
So instead of `Weekday::to_sunday_zero_offset` use `Weekday::to_monday_one_offset` in doc and examples.

Add an assert test into the example code to highlight above.