### PR TITLE
allocate exact capacity for RFC 9110 strings

### DIFF
--- a/src/fmt/rfc2822.rs
+++ b/src/fmt/rfc2822.rs
@@ -1238,7 +1238,7 @@ impl DateTimePrinter {
         &self,
         timestamp: &Timestamp,
     ) -> Result<alloc::string::String, Error> {
-        let mut buf = alloc::string::String::with_capacity(4);
+        let mut buf = alloc::string::String::with_capacity(29);
         self.print_timestamp_rfc9110(timestamp, &mut buf)?;
         Ok(buf)
     }


### PR DESCRIPTION
`fmt::rfc2822::DateTimePrinter::timestamp_to_rfc9110_string` allocates a `String` with capacity of `4`; however RFC 9110-preferred-format strings are guaranteed to have an exact length of 29. I realize this crate doesn't prioritize performance; however the fact that `String::with_capacity` was already used as opposed to `String::new` suggests this isn't an entirely inappropriate diff.