### PR TITLE
tz: fix termux compilation on Android

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,7 @@ jobs:
         - powerpc64-unknown-linux-gnu
         - s390x-unknown-linux-gnu
         - x86_64-linux-android
+        - aarch64-linux-android
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+0.1.23 (TBD)
+============
+TODO
+
+Bug fixes:
+
+* [#200](https://github.com/BurntSushi/jiff/issues/200):
+Fix compilation failure on Android in a Termux shell.
+
+
 0.1.22 (2025-01-12)
 ===================
 This release adds support for Android. This support means that Jiff will
@@ -8,6 +18,8 @@ read the `persist.sys.timezone` property to determine the system's current
 time zone.
 
 See [PLATFORM] for more specific information about Android support.
+
+Enhancements:
 
 * [#140](https://github.com/BurntSushi/jiff/issues/140):
 Add support for the Android platform.


### PR DESCRIPTION
I guess some platforms use `*const u8` for C strings while most
seemingly use `*const i8`. So insert a bunch of `.cast()` calls where
appropriate.

Ref #140

Fixes #200
