### PR TITLE
Restore license files that were lost in 0.1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Bug fixes:
 
 * [#200](https://github.com/BurntSushi/jiff/issues/200):
 Fix compilation failure on Android in a Termux shell.
+* [#202](https://github.com/BurntSushi/jiff/pull/202):
+Re-add license files to crate artifact.
 
 
 0.1.22 (2025-01-12)
@@ -18,6 +20,10 @@ read the `persist.sys.timezone` property to determine the system's current
 time zone.
 
 See [PLATFORM] for more specific information about Android support.
+
+Note that this release also removed all non-essential files (including tests
+and test data) for the artifact uploaded to crates.io. If you need or want
+these files, please open a new issue.
 
 Enhancements:
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,14 @@ rust-version = "1.70"
 # We include `/tests/lib.rs` to squash a `cargo package` warning that the
 # `integration` test target is being ignored. We don't include anything else
 # so tests obviously won't work, but it makes `cargo package` quiet.
-include = ["/src/**/*.rs", "/tests/lib.rs", "/*.md"]
+include = [
+  "/src/**/*.rs",
+  "/tests/lib.rs",
+  "/*.md",
+  "COPYING",
+  "LICENSE-MIT",
+  "UNLICENSE",
+]
 
 [workspace]
 members = [

--- a/jiff-tzdb-platform/Cargo.toml
+++ b/jiff-tzdb-platform/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["date", "time", "temporal", "zone", "iana"]
 workspace = ".."
 edition = "2021"
 rust-version = "1.70"
-include = ["/*.rs"]
+include = ["/*.rs", "COPYING", "LICENSE-MIT", "UNLICENSE"]
 
 [lib]
 name = "jiff_tzdb_platform"

--- a/jiff-tzdb/Cargo.toml
+++ b/jiff-tzdb/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["date", "time", "temporal", "zone", "iana"]
 workspace = ".."
 edition = "2021"
 rust-version = "1.70"
-include = ["/*.rs", "/*.dat"]
+include = ["/*.rs", "/*.dat", "COPYING", "LICENSE-MIT", "UNLICENSE"]
 
 [lib]
 name = "jiff_tzdb"


### PR DESCRIPTION
When 6926d6d84fb685ded50816fa525ee147e43aaff4 explicitly listed files to include in published crates, the license files were lost from the crates. This PR restores them by adding them to the `include` lists.