### PR TITLE
add `iso_week_date` methods, deprecate `to_iso_week_date`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 ============
 TODO
 
+Deprecations:
+
+* [#197](https://github.com/BurntSushi/jiff/discussions/197):
+`Date::to_iso_week_date` has been deprecated in favor of `Date::iso_week_date`.
+
+Enhancements:
+
+* [#197](https://github.com/BurntSushi/jiff/discussions/197):
+Add `Zoned::iso_week_date`, `DateTime::iso_week_date` and
+`Date::iso_week_date`.
+
 Bug fixes:
 
 * [#200](https://github.com/BurntSushi/jiff/issues/200):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Deprecations:
 
 Enhancements:
 
+* [#196](https://github.com/BurntSushi/jiff/discussions/196):
+Improve ISO week date documentation regarding weekday offsets.
 * [#197](https://github.com/BurntSushi/jiff/discussions/197):
 Add `Zoned::iso_week_date`, `DateTime::iso_week_date` and
 `Date::iso_week_date`.

--- a/src/civil/date.rs
+++ b/src/civil/date.rs
@@ -1079,44 +1079,44 @@ impl Date {
     ///
     /// # Example
     ///
-    /// This shows a number of examples demonstrating the conversion from an
-    /// ISO 8601 week date to a Gregorian date.
+    /// This shows a number of examples demonstrating the conversion from a
+    /// Gregorian date to an ISO 8601 week date:
     ///
     /// ```
     /// use jiff::civil::{Date, Weekday, date};
     ///
-    /// let weekdate = date(1995, 1, 1).to_iso_week_date();
+    /// let weekdate = date(1995, 1, 1).iso_week_date();
     /// assert_eq!(weekdate.year(), 1994);
     /// assert_eq!(weekdate.week(), 52);
     /// assert_eq!(weekdate.weekday(), Weekday::Sunday);
     ///
-    /// let weekdate = date(1996, 12, 31).to_iso_week_date();
+    /// let weekdate = date(1996, 12, 31).iso_week_date();
     /// assert_eq!(weekdate.year(), 1997);
     /// assert_eq!(weekdate.week(), 1);
     /// assert_eq!(weekdate.weekday(), Weekday::Tuesday);
     ///
-    /// let weekdate = date(2019, 12, 30).to_iso_week_date();
+    /// let weekdate = date(2019, 12, 30).iso_week_date();
     /// assert_eq!(weekdate.year(), 2020);
     /// assert_eq!(weekdate.week(), 1);
     /// assert_eq!(weekdate.weekday(), Weekday::Monday);
     ///
-    /// let weekdate = date(2024, 3, 9).to_iso_week_date();
+    /// let weekdate = date(2024, 3, 9).iso_week_date();
     /// assert_eq!(weekdate.year(), 2024);
     /// assert_eq!(weekdate.week(), 10);
     /// assert_eq!(weekdate.weekday(), Weekday::Saturday);
     ///
-    /// let weekdate = Date::MIN.to_iso_week_date();
+    /// let weekdate = Date::MIN.iso_week_date();
     /// assert_eq!(weekdate.year(), -9999);
     /// assert_eq!(weekdate.week(), 1);
     /// assert_eq!(weekdate.weekday(), Weekday::Monday);
     ///
-    /// let weekdate = Date::MAX.to_iso_week_date();
+    /// let weekdate = Date::MAX.iso_week_date();
     /// assert_eq!(weekdate.year(), 9999);
     /// assert_eq!(weekdate.week(), 52);
     /// assert_eq!(weekdate.weekday(), Weekday::Friday);
     /// ```
     #[inline]
-    pub fn to_iso_week_date(self) -> ISOWeekDate {
+    pub fn iso_week_date(self) -> ISOWeekDate {
         let days = t::NoUnits32::rfrom(self.to_unix_epoch_days());
         let year = t::NoUnits32::rfrom(self.year_ranged());
         let week_start = t::NoUnits32::vary([days, year], |[days, year]| {
@@ -2050,6 +2050,19 @@ impl Date {
         format: &'f F,
     ) -> fmt::strtime::Display<'f> {
         fmt::strtime::Display { fmt: format.as_ref(), tm: (*self).into() }
+    }
+}
+
+/// Deprecated APIs.
+impl Date {
+    /// A deprecated equivalent to [`Date::iso_week_date`].
+    ///
+    /// This method will be removed in `jiff 0.2`. This was done to make naming
+    /// more consistent throughout the crate.
+    #[deprecated(since = "0.1.23", note = "use Date::iso_week_date instead")]
+    #[inline]
+    pub fn to_iso_week_date(self) -> ISOWeekDate {
+        self.iso_week_date()
     }
 }
 
@@ -3741,7 +3754,7 @@ mod tests {
                 let month = Month::new(month).unwrap();
                 for day in 20..=days_in_month(year, month).get() {
                     let date = date(year.get(), month.get(), day);
-                    let wd = date.to_iso_week_date();
+                    let wd = date.iso_week_date();
                     let got = wd.to_date();
                     assert_eq!(
                         date, got,

--- a/src/civil/datetime.rs
+++ b/src/civil/datetime.rs
@@ -1,7 +1,9 @@
 use core::time::Duration as UnsignedDuration;
 
 use crate::{
-    civil::{datetime, Date, DateWith, Era, Time, TimeWith, Weekday},
+    civil::{
+        datetime, Date, DateWith, Era, ISOWeekDate, Time, TimeWith, Weekday,
+    },
     duration::{Duration, SDuration},
     error::{err, Error, ErrorContext},
     fmt::{
@@ -1250,6 +1252,66 @@ impl DateTime {
     #[inline]
     pub fn time(self) -> Time {
         self.time
+    }
+
+    /// Construct an [ISO 8601 week date] from this datetime.
+    ///
+    /// The [`ISOWeekDate`] type describes itself in more detail, but in
+    /// brief, the ISO week date calendar system eschews months in favor of
+    /// weeks.
+    ///
+    /// This routine is equivalent to
+    /// [`ISOWeekDate::from_date(dt.date())`](ISOWeekDate::from_date).
+    ///
+    /// [ISO 8601 week date]: https://en.wikipedia.org/wiki/ISO_week_date
+    ///
+    /// # Example
+    ///
+    /// This shows a number of examples demonstrating the conversion from a
+    /// Gregorian date to an ISO 8601 week date:
+    ///
+    /// ```
+    /// use jiff::civil::{Date, Time, Weekday, date};
+    ///
+    /// let dt = date(1995, 1, 1).at(18, 45, 0, 0);
+    /// let weekdate = dt.iso_week_date();
+    /// assert_eq!(weekdate.year(), 1994);
+    /// assert_eq!(weekdate.week(), 52);
+    /// assert_eq!(weekdate.weekday(), Weekday::Sunday);
+    ///
+    /// let dt = date(1996, 12, 31).at(18, 45, 0, 0);
+    /// let weekdate = dt.iso_week_date();
+    /// assert_eq!(weekdate.year(), 1997);
+    /// assert_eq!(weekdate.week(), 1);
+    /// assert_eq!(weekdate.weekday(), Weekday::Tuesday);
+    ///
+    /// let dt = date(2019, 12, 30).at(18, 45, 0, 0);
+    /// let weekdate = dt.iso_week_date();
+    /// assert_eq!(weekdate.year(), 2020);
+    /// assert_eq!(weekdate.week(), 1);
+    /// assert_eq!(weekdate.weekday(), Weekday::Monday);
+    ///
+    /// let dt = date(2024, 3, 9).at(18, 45, 0, 0);
+    /// let weekdate = dt.iso_week_date();
+    /// assert_eq!(weekdate.year(), 2024);
+    /// assert_eq!(weekdate.week(), 10);
+    /// assert_eq!(weekdate.weekday(), Weekday::Saturday);
+    ///
+    /// let dt = Date::MIN.to_datetime(Time::MIN);
+    /// let weekdate = dt.iso_week_date();
+    /// assert_eq!(weekdate.year(), -9999);
+    /// assert_eq!(weekdate.week(), 1);
+    /// assert_eq!(weekdate.weekday(), Weekday::Monday);
+    ///
+    /// let dt = Date::MAX.to_datetime(Time::MAX);
+    /// let weekdate = dt.iso_week_date();
+    /// assert_eq!(weekdate.year(), 9999);
+    /// assert_eq!(weekdate.week(), 52);
+    /// assert_eq!(weekdate.weekday(), Weekday::Friday);
+    /// ```
+    #[inline]
+    pub fn iso_week_date(self) -> ISOWeekDate {
+        self.date().iso_week_date()
     }
 
     /// Converts a civil datetime to a [`Zoned`] datetime by adding the given

--- a/src/civil/iso_week_date.rs
+++ b/src/civil/iso_week_date.rs
@@ -243,7 +243,10 @@ impl ISOWeekDate {
     /// Returns the day component of this ISO 8601 week date.
     ///
     /// One can use methods on `Weekday` such as
-    /// [`Weekday::to_sunday_zero_offset`] to convert the weekday to a number.
+    /// [`Weekday::to_monday_one_offset`]
+    /// and
+    /// [`Weekday::to_sunday_zero_offset`]
+    /// to convert the weekday to a number.
     ///
     /// # Example
     ///
@@ -254,6 +257,10 @@ impl ISOWeekDate {
     /// assert_eq!(weekdate.year(), 1948);
     /// assert_eq!(weekdate.week(), 53);
     /// assert_eq!(weekdate.weekday(), Weekday::Friday);
+    /// assert_eq!(weekdate.weekday().to_monday_zero_offset(), 4);
+    /// assert_eq!(weekdate.weekday().to_monday_one_offset(), 5);
+    /// assert_eq!(weekdate.weekday().to_sunday_zero_offset(), 5);
+    /// assert_eq!(weekdate.weekday().to_sunday_one_offset(), 6);
     /// ```
     #[inline]
     pub fn weekday(self) -> Weekday {

--- a/src/civil/iso_week_date.rs
+++ b/src/civil/iso_week_date.rs
@@ -1,10 +1,11 @@
 use crate::{
-    civil::{Date, Weekday},
+    civil::{Date, DateTime, Weekday},
     error::{err, Error},
     util::{
         rangeint::RInto,
         t::{self, ISOWeek, ISOYear, C},
     },
+    Zoned,
 };
 
 /// A type representing an [ISO 8601 week date].
@@ -190,7 +191,7 @@ impl ISOWeekDate {
     /// ```
     #[inline]
     pub fn from_date(date: Date) -> ISOWeekDate {
-        date.to_iso_week_date()
+        date.iso_week_date()
     }
 
     // N.B. I tried defining a `ISOWeekDate::constant` for defining ISO week
@@ -448,6 +449,27 @@ impl From<Date> for ISOWeekDate {
     #[inline]
     fn from(date: Date) -> ISOWeekDate {
         ISOWeekDate::from_date(date)
+    }
+}
+
+impl From<DateTime> for ISOWeekDate {
+    #[inline]
+    fn from(dt: DateTime) -> ISOWeekDate {
+        ISOWeekDate::from(dt.date())
+    }
+}
+
+impl From<Zoned> for ISOWeekDate {
+    #[inline]
+    fn from(zdt: Zoned) -> ISOWeekDate {
+        ISOWeekDate::from(zdt.date())
+    }
+}
+
+impl<'a> From<&'a Zoned> for ISOWeekDate {
+    #[inline]
+    fn from(zdt: &'a Zoned) -> ISOWeekDate {
+        ISOWeekDate::from(zdt.date())
     }
 }
 

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -1,7 +1,10 @@
 use core::time::Duration as UnsignedDuration;
 
 use crate::{
-    civil::{Date, DateTime, DateTimeRound, DateTimeWith, Era, Time, Weekday},
+    civil::{
+        Date, DateTime, DateTimeRound, DateTimeWith, Era, ISOWeekDate, Time,
+        Weekday,
+    },
     duration::{Duration, SDuration},
     error::{err, Error, ErrorContext},
     fmt::{
@@ -1852,6 +1855,56 @@ impl Zoned {
     #[inline]
     pub fn time(&self) -> Time {
         self.datetime().time()
+    }
+
+    /// Construct a civil [ISO 8601 week date] from this zoned datetime.
+    ///
+    /// The [`ISOWeekDate`] type describes itself in more detail, but in
+    /// brief, the ISO week date calendar system eschews months in favor of
+    /// weeks.
+    ///
+    /// This routine is equivalent to
+    /// [`ISOWeekDate::from_date(zdt.date())`](ISOWeekDate::from_date).
+    ///
+    /// [ISO 8601 week date]: https://en.wikipedia.org/wiki/ISO_week_date
+    ///
+    /// # Example
+    ///
+    /// This shows a number of examples demonstrating the conversion from a
+    /// Gregorian date to an ISO 8601 week date:
+    ///
+    /// ```
+    /// use jiff::civil::{Date, Time, Weekday, date};
+    ///
+    /// let zdt = date(1995, 1, 1).at(18, 45, 0, 0).intz("US/Eastern")?;
+    /// let weekdate = zdt.iso_week_date();
+    /// assert_eq!(weekdate.year(), 1994);
+    /// assert_eq!(weekdate.week(), 52);
+    /// assert_eq!(weekdate.weekday(), Weekday::Sunday);
+    ///
+    /// let zdt = date(1996, 12, 31).at(18, 45, 0, 0).intz("US/Eastern")?;
+    /// let weekdate = zdt.iso_week_date();
+    /// assert_eq!(weekdate.year(), 1997);
+    /// assert_eq!(weekdate.week(), 1);
+    /// assert_eq!(weekdate.weekday(), Weekday::Tuesday);
+    ///
+    /// let zdt = date(2019, 12, 30).at(18, 45, 0, 0).intz("US/Eastern")?;
+    /// let weekdate = zdt.iso_week_date();
+    /// assert_eq!(weekdate.year(), 2020);
+    /// assert_eq!(weekdate.week(), 1);
+    /// assert_eq!(weekdate.weekday(), Weekday::Monday);
+    ///
+    /// let zdt = date(2024, 3, 9).at(18, 45, 0, 0).intz("US/Eastern")?;
+    /// let weekdate = zdt.iso_week_date();
+    /// assert_eq!(weekdate.year(), 2024);
+    /// assert_eq!(weekdate.week(), 10);
+    /// assert_eq!(weekdate.weekday(), Weekday::Saturday);
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[inline]
+    pub fn iso_week_date(self) -> ISOWeekDate {
+        self.date().iso_week_date()
     }
 
     /// Returns the time zone offset of this zoned datetime.


### PR DESCRIPTION
This PR rolls up #196 and adds some convenience `iso_week_date` methods
to `Zoned` and `DateTime`. These forward to the corresponding method on
`Date`.

Also, to make naming more consistent, we deprecate
`Date::to_iso_week_date` and add `Date::iso_week_date`. The `to_`
prefix is somewhat inconsistently used in Jiff. According to Rust API
guidelines, it should probably be used a lot more, since some APIs
that look like getters are actually doing a little bit of work. But I
think the API reads overall better by just dropping the `to_` prefix.
Using the `to_` prefix also has the problem of exposing aspects of the
implementation which could change over time.

Finally, we add corresponding `From` impls for converting `DateTime`
and `Zoned` values into a `ISOWeekDate`.

Closes #196, Closes #197
