### PR TITLE
Fix incorrect doc link

### DIFF
--- a/src/civil/date.rs
+++ b/src/civil/date.rs
@@ -1236,6 +1236,10 @@ impl Date {
     /// for more details. Note that ambiguous datetimes are handled in the same
     /// way as `DateTime::to_zoned`.
     ///
+    /// In the common case of a time zone being represented as a name string,
+    /// like `Australia/Tasmania`, consider using [`Date::intz`]
+    /// instead.
+    ///
     /// # Errors
     ///
     /// This returns an error if this date could not be represented as a

--- a/src/civil/datetime.rs
+++ b/src/civil/datetime.rs
@@ -1461,7 +1461,7 @@ impl DateTime {
     /// strategy, use [`TimeZone::to_ambiguous_zoned`].
     ///
     /// In the common case of a time zone being represented as a name string,
-    /// like `Australia/Tasmania`, consider using [`DateTime::to_zoned`]
+    /// like `Australia/Tasmania`, consider using [`DateTime::intz`]
     /// instead.
     ///
     /// # Errors

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -1080,6 +1080,10 @@ impl Timestamp {
     /// time (i.e., a fold, typically DST ending) or no instants in time (i.e.,
     /// a gap, typically DST starting).
     ///
+    /// In the common case of a time zone being represented as a name string,
+    /// like `Australia/Tasmania`, consider using [`Timestamp::intz`]
+    /// instead.
+    ///
     /// # Example
     ///
     /// This example shows how to create a zoned value with a fixed time zone


### PR DESCRIPTION
Current docs for `civil::DateTime::to_zoned` link to itself for the use case of parsing a string into a time zone. `civil::DateTime::intz` seems more appropriate.