### PR TITLE
implement a few deprecations and expand the strtime conversion specifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Deprecations:
 * [#28](https://github.com/BurntSushi/jiff/issues/28):
 The `intz` methods on `Zoned`, `Timestamp`, `civil::DateTime` and `civil::Date`
 have been deprecated in favor of `in_tz`.
+* [#32](https://github.com/BurntSushi/jiff/issues/32):
+The `Eq` and `PartialEq` trait implementations on `Span` have been deprecated
+in favor of using the new `SpanFieldwise` type.
 
 
 0.1.24 (2025-01-16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ deprecated. This will become an error in `jiff 0.2`. To continue assuming
 days are 24 hours without a relative reference date, you can use the new
 `SpanRelativeTo::days_are_24_hours` API. In `jiff 0.1`, you'll seen a
 WARN-level log message emitted if you're code will be broken by `jiff 0.2`.
+* [#147](https://github.com/BurntSushi/jiff/issues/147):
+Both `%V` and `%:V` have been deprecated in favor of `%Q` and `%:Q`. In
+`jiff 0.2`, `%V` will correspond to the ISO 8601 week number and `%:V` will
+result in an error. This change was made to improve compatibility with other
+`strtime` implementations. `%V` and `%:V` continue to correspond to IANA
+time zone identifiers in `jiff 0.1`, but using them for parsing or formatting
+will result in a WARN-level deprecation message.
 
 
 0.1.24 (2025-01-16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ have been deprecated in favor of `in_tz`.
 * [#32](https://github.com/BurntSushi/jiff/issues/32):
 The `Eq` and `PartialEq` trait implementations on `Span` have been deprecated
 in favor of using the new `SpanFieldwise` type.
+* [#48](https://github.com/BurntSushi/jiff/issues/48):
+Silently assuming days are always 24 hours in some `Span` APIs has now been
+deprecated. This will become an error in `jiff 0.2`. To continue assuming
+days are 24 hours without a relative reference date, you can use the new
+`SpanRelativeTo::days_are_24_hours` API. In `jiff 0.1`, you'll seen a
+WARN-level log message emitted if you're code will be broken by `jiff 0.2`.
 
 
 0.1.24 (2025-01-16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+0.1.25 (TBD)
+============
+TODO
+
+Deprecations:
+
+* [#28](https://github.com/BurntSushi/jiff/issues/28):
+The `intz` methods on `Zoned`, `Timestamp`, `civil::DateTime` and `civil::Date`
+have been deprecated in favor of `in_tz`.
+
+
 0.1.24 (2025-01-16)
 ===================
 This release updates Jiff's bundled copy of the [IANA Time Zone Database] to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ result in an error. This change was made to improve compatibility with other
 time zone identifiers in `jiff 0.1`, but using them for parsing or formatting
 will result in a WARN-level deprecation message.
 
+Enhancements:
+
+* [#147](https://github.com/BurntSushi/jiff/issues/147):
+Adds a number of new conversion specifiers to Jiff's `strftime` and
+`strptime` APIs. Specifically, `%C`, `%G`, `%g`, `%j`, `%k`, `%l`, `%n`, `%R`,
+`%s`, `%t`, `%U`, `%u`, `%W`, `%w`. Their behavior should match the
+corresponding specifiers in GNU libc.
+
 
 0.1.24 (2025-01-16)
 ===================

--- a/COMPARE.md
+++ b/COMPARE.md
@@ -260,9 +260,9 @@ fn main() -> anyhow::Result<()> {
     // returns the same civil time the next day.
     assert_eq!(zdt2.to_string(), "2024-03-10T21:00:00-04:00[America/New_York]");
     // The span of time is 23 hours:
-    assert_eq!(&zdt2 - &zdt1, 23.hours());
+    assert_eq!(&zdt2 - &zdt1, 23.hours().fieldwise());
     // But if you ask for the span in units of days, you get exactly 1:
-    assert_eq!(zdt1.until((Unit::Day, &zdt2))?, 1.day());
+    assert_eq!(zdt1.until((Unit::Day, &zdt2))?, 1.day().fieldwise());
 
     Ok(())
 }
@@ -331,7 +331,7 @@ fn main() -> anyhow::Result<()> {
     assert_eq!(json, "\"P5Y2M1DT20H\"");
 
     let got: Span = serde_json::from_str(&json)?;
-    assert_eq!(got, span);
+    assert_eq!(got, span.fieldwise());
 
     Ok(())
 }
@@ -419,7 +419,7 @@ fn main() -> anyhow::Result<()> {
         .smallest(Unit::Day)
         .mode(RoundMode::HalfExpand);
     let span = zdt1.until(round_options)?;
-    assert_eq!(span, 22.years().months(7).days(24));
+    assert_eq!(span.fieldwise(), 22.years().months(7).days(24));
 
     Ok(())
 }
@@ -452,14 +452,14 @@ fn main() -> anyhow::Result<()> {
         SpanRound::new().smallest(Unit::Day).relative(&gapday),
     )?;
     // rounds up, even though on a normal day 11.5 hours would round down.
-    assert_eq!(span2, 1.day());
+    assert_eq!(span2, 1.day().fieldwise());
 
     let span1 = 12.hours();
     let span2 = span1.round(
         SpanRound::new().smallest(Unit::Day).relative(&foldday),
     )?;
     // rounds down, even though on a normal day 12 hours would round up.
-    assert_eq!(span2, 0.days());
+    assert_eq!(span2, 0.days().fieldwise());
 
     Ok(())
 }
@@ -484,7 +484,7 @@ fn main() -> anyhow::Result<()> {
         .smallest(Unit::Day)
         .mode(RoundMode::HalfExpand);
     let span = zdt1.until(round_options)?;
-    assert_eq!(span, 271.months().days(24));
+    assert_eq!(span, 271.months().days(24).fieldwise());
 
     Ok(())
 }
@@ -591,7 +591,7 @@ fn main() -> anyhow::Result<()> {
     let span1 = 2.years().months(4).days(25).hours(23);
     let span2 = 3.hours();
     let span3 = span1.checked_add((span2, date(2024, 1, 1)))?;
-    assert_eq!(span3, 2.years().months(4).days(26).hours(2));
+    assert_eq!(span3.fieldwise(), 2.years().months(4).days(26).hours(2));
 
     Ok(())
 }
@@ -612,7 +612,7 @@ use jiff::{SpanRound, ToSpan, Unit};
 fn main() -> anyhow::Result<()> {
     let span1 = 1.day();
     let span2 = span1.round(SpanRound::new().largest(Unit::Hour))?;
-    assert_eq!(span2, 24.hours());
+    assert_eq!(span2, 24.hours().fieldwise());
 
     Ok(())
 }
@@ -631,7 +631,7 @@ fn main() -> anyhow::Result<()> {
     let span2 = span1.round(
         SpanRound::new().largest(Unit::Hour).relative(&zdt)
     )?;
-    assert_eq!(span2, 23.hours());
+    assert_eq!(span2, 23.hours().fieldwise());
 
     // In the case of a fold (typically transitioning out of DST):
     let zdt = date(2024, 11, 2).at(21, 0, 0, 0).in_tz("America/New_York")?;
@@ -639,7 +639,7 @@ fn main() -> anyhow::Result<()> {
     let span2 = span1.round(
         SpanRound::new().largest(Unit::Hour).relative(&zdt)
     )?;
-    assert_eq!(span2, 25.hours());
+    assert_eq!(span2, 25.hours().fieldwise());
 
     Ok(())
 }
@@ -892,7 +892,7 @@ fn main() -> anyhow::Result<()> {
         .smallest(Unit::Day)
         .mode(RoundMode::HalfExpand);
     let span = zdt1.until(round_options)?;
-    assert_eq!(span, 22.years().months(7).days(24));
+    assert_eq!(span, 22.years().months(7).days(24).fieldwise());
 
     Ok(())
 }
@@ -932,12 +932,12 @@ fn main() -> anyhow::Result<()> {
     // Balance down to seconds.
     let span1 = 4.hours().minutes(36).seconds(59);
     let span2 = span1.round(SpanRound::new().largest(Unit::Second))?;
-    assert_eq!(span2, 16_619.seconds());
+    assert_eq!(span2, 16_619.seconds().fieldwise());
 
     // Now go back by balancing up to hours.
     let span1 = 16_619.seconds();
     let span2 = span1.round(SpanRound::new().largest(Unit::Hour))?;
-    assert_eq!(span2, 4.hours().minutes(36).seconds(59));
+    assert_eq!(span2, 4.hours().minutes(36).seconds(59).fieldwise());
 
     Ok(())
 }
@@ -1071,7 +1071,7 @@ fn main() -> anyhow::Result<()> {
     let ts1: Timestamp = "2015-06-30T23:00:00Z".parse()?;
     let ts2: Timestamp = "2015-07-01T00:00:00Z".parse()?;
     let span = ts2 - ts1;
-    assert_eq!(span, 3_600.seconds());
+    assert_eq!(span, 3_600.seconds().fieldwise());
 
     Ok(())
 }

--- a/COMPARE.md
+++ b/COMPARE.md
@@ -61,7 +61,7 @@ time zone:
 use jiff::civil::date;
 
 fn main() -> anyhow::Result<()> {
-    let zdt = date(2024, 6, 30).at(9, 46, 0, 0).intz("America/New_York")?;
+    let zdt = date(2024, 6, 30).at(9, 46, 0, 0).in_tz("America/New_York")?;
     assert_eq!(zdt.to_string(), "2024-06-30T09:46:00-04:00[America/New_York]");
     Ok(())
 }
@@ -137,7 +137,7 @@ expect it to still perform DST arithmetic:
 use jiff::{civil::date, ToSpan, Zoned};
 
 fn main() -> anyhow::Result<()> {
-    let zdt = date(2024, 3, 10).at(1, 59, 59, 0).intz("America/New_York")?;
+    let zdt = date(2024, 3, 10).at(1, 59, 59, 0).in_tz("America/New_York")?;
 
     let json = serde_json::to_string_pretty(&zdt)?;
     assert_eq!(json, "\"2024-03-10T01:59:59-05:00[America/New_York]\"");
@@ -253,7 +253,7 @@ datetimes. And they agree on the results.
 use jiff::{civil::date, ToSpan, Unit};
 
 fn main() -> anyhow::Result<()> {
-    let zdt1 = date(2024, 3, 9).at(21, 0, 0, 0).intz("America/New_York")?;
+    let zdt1 = date(2024, 3, 9).at(21, 0, 0, 0).in_tz("America/New_York")?;
     let zdt2 = zdt1.checked_add(1.day())?;
 
     // Even though 2 o'clock didn't occur on 2024-03-10, adding 1 day
@@ -411,8 +411,8 @@ In Jiff, one can round the duration computed between two datetimes:
 use jiff::{civil::date, RoundMode, ToSpan, Unit, ZonedDifference};
 
 fn main() -> anyhow::Result<()> {
-    let zdt1 = date(2001, 11, 18).at(8, 30, 0, 0).intz("America/New_York")?;
-    let zdt2 = date(2024, 7, 11).at(22, 38, 0, 0).intz("America/New_York")?;
+    let zdt1 = date(2001, 11, 18).at(8, 30, 0, 0).in_tz("America/New_York")?;
+    let zdt2 = date(2024, 7, 11).at(22, 38, 0, 0).in_tz("America/New_York")?;
 
     let round_options = ZonedDifference::new(&zdt2)
         .largest(Unit::Year)
@@ -444,8 +444,8 @@ is that we provide a reference datetime with which to interpret the span.
 use jiff::{civil::date, SpanRound, ToSpan, Unit};
 
 fn main() -> anyhow::Result<()> {
-    let gapday = date(2024, 3, 10).intz("America/New_York")?;
-    let foldday = date(2024, 11, 3).intz("America/New_York")?;
+    let gapday = date(2024, 3, 10).in_tz("America/New_York")?;
+    let foldday = date(2024, 11, 3).in_tz("America/New_York")?;
 
     let span1 = 11.hours().minutes(30);
     let span2 = span1.round(
@@ -476,8 +476,8 @@ This example is like the one above, except we choose a smaller "largest" unit:
 use jiff::{civil::date, RoundMode, ToSpan, Unit, ZonedDifference};
 
 fn main() -> anyhow::Result<()> {
-    let zdt1 = date(2001, 11, 18).at(8, 30, 0, 0).intz("America/New_York")?;
-    let zdt2 = date(2024, 7, 11).at(22, 38, 0, 0).intz("America/New_York")?;
+    let zdt1 = date(2001, 11, 18).at(8, 30, 0, 0).in_tz("America/New_York")?;
+    let zdt2 = date(2024, 7, 11).at(22, 38, 0, 0).in_tz("America/New_York")?;
 
     let round_options = ZonedDifference::new(&zdt2)
         .largest(Unit::Month)
@@ -496,7 +496,7 @@ fn main() -> anyhow::Result<()> {
 use jiff::civil::{date, Weekday};
 
 fn main() -> anyhow::Result<()> {
-    let zdt = date(2024, 7, 11).at(22, 59, 0, 0).intz("America/New_York")?;
+    let zdt = date(2024, 7, 11).at(22, 59, 0, 0).in_tz("America/New_York")?;
     assert_eq!(zdt.weekday(), Weekday::Thursday);
 
     let next_tuesday = zdt.nth_weekday(1, Weekday::Tuesday)?;
@@ -626,7 +626,7 @@ use jiff::{civil::date, SpanRound, ToSpan, Unit};
 
 fn main() -> anyhow::Result<()> {
     // In the case of a gap (typically transitioning in DST):
-    let zdt = date(2024, 3, 9).at(21, 0, 0, 0).intz("America/New_York")?;
+    let zdt = date(2024, 3, 9).at(21, 0, 0, 0).in_tz("America/New_York")?;
     let span1 = 1.day();
     let span2 = span1.round(
         SpanRound::new().largest(Unit::Hour).relative(&zdt)
@@ -634,7 +634,7 @@ fn main() -> anyhow::Result<()> {
     assert_eq!(span2, 23.hours());
 
     // In the case of a fold (typically transitioning out of DST):
-    let zdt = date(2024, 11, 2).at(21, 0, 0, 0).intz("America/New_York")?;
+    let zdt = date(2024, 11, 2).at(21, 0, 0, 0).in_tz("America/New_York")?;
     let span1 = 1.day();
     let span2 = span1.round(
         SpanRound::new().largest(Unit::Hour).relative(&zdt)
@@ -731,7 +731,7 @@ only create a datetime with an offset, but with a _time zone_:
 use jiff::{civil::date, ToSpan};
 
 fn main() -> anyhow::Result<()> {
-    let zdt1 = date(2024, 3, 10).at(1, 30, 0, 0).intz("America/New_York")?;
+    let zdt1 = date(2024, 3, 10).at(1, 30, 0, 0).in_tz("America/New_York")?;
     let zdt2 = zdt1.checked_add(1.hour())?;
     assert_eq!(zdt2.to_string(), "2024-03-10T03:30:00-04:00[America/New_York]");
 
@@ -863,7 +863,7 @@ use jiff::{civil::date, Unit, Zoned};
 fn main() -> anyhow::Result<()> {
     // Can also use `.to_zoned(TimeZone::system())` to use your system's
     // default time zone.
-    let zdt1 = date(2024, 7, 11).at(16, 46, 0, 0).intz("America/New_York")?;
+    let zdt1 = date(2024, 7, 11).at(16, 46, 0, 0).in_tz("America/New_York")?;
     let zdt2 = zdt1.round(Unit::Hour)?;
     assert_eq!(zdt2.to_string(), "2024-07-11T17:00:00-04:00[America/New_York]");
 
@@ -884,8 +884,8 @@ In Jiff, one can round the duration computed between two datetimes
 use jiff::{civil::date, RoundMode, ToSpan, Unit, ZonedDifference};
 
 fn main() -> anyhow::Result<()> {
-    let zdt1 = date(2001, 11, 18).at(8, 30, 0, 0).intz("America/New_York")?;
-    let zdt2 = date(2024, 7, 11).at(22, 38, 0, 0).intz("America/New_York")?;
+    let zdt1 = date(2001, 11, 18).at(8, 30, 0, 0).in_tz("America/New_York")?;
+    let zdt2 = date(2024, 7, 11).at(22, 38, 0, 0).in_tz("America/New_York")?;
 
     let round_options = ZonedDifference::new(&zdt2)
         .largest(Unit::Year)
@@ -908,7 +908,7 @@ With Jiff, you can add durations with calendar units:
 use jiff::{civil::date, ToSpan, Unit};
 
 fn main() -> anyhow::Result<()> {
-    let zdt1 = date(2024, 7, 11).at(21, 0, 0, 0).intz("America/New_York")?;
+    let zdt1 = date(2024, 7, 11).at(21, 0, 0, 0).in_tz("America/New_York")?;
     let zdt2 = zdt1.checked_add(2.years().months(6).days(1))?;
     assert_eq!(zdt2.to_string(), "2027-01-12T21:00:00-05:00[America/New_York]");
 
@@ -1139,7 +1139,7 @@ use jiff::Timestamp;
 
 fn main() -> anyhow::Result<()> {
     let ts: Timestamp = "2024-09-10T23:37:20Z".parse()?;
-    let zoned = ts.intz("Asia/Tokyo")?;
+    let zoned = ts.in_tz("Asia/Tokyo")?;
 
     // Create ICU datetime.
     let datetime = DateTime::try_new_iso_datetime(

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -504,8 +504,8 @@ respectively. For example, this:
 ```rust
 use jiff::{civil::date, ToSpan};
 
-let zdt1 = date(2024, 7, 16).at(22, 3, 23, 0).intz("America/New_York")?;
-let zdt2 = date(2024, 8, 16).at(22, 3, 59, 0).intz("America/New_York")?;
+let zdt1 = date(2024, 7, 16).at(22, 3, 23, 0).in_tz("America/New_York")?;
+let zdt2 = date(2024, 8, 16).at(22, 3, 59, 0).in_tz("America/New_York")?;
 assert_eq!(zdt1.until(&zdt2)?, 744.hours().seconds(36));
 
 # Ok::<(), Box<dyn std::error::Error>>(())
@@ -516,8 +516,8 @@ Is equivalent to:
 ```rust
 use jiff::{civil::date, ToSpan, ZonedDifference};
 
-let zdt1 = date(2024, 7, 16).at(22, 3, 23, 0).intz("America/New_York")?;
-let zdt2 = date(2024, 8, 16).at(22, 3, 59, 0).intz("America/New_York")?;
+let zdt1 = date(2024, 7, 16).at(22, 3, 23, 0).in_tz("America/New_York")?;
+let zdt2 = date(2024, 8, 16).at(22, 3, 59, 0).in_tz("America/New_York")?;
 assert_eq!(zdt1.until(ZonedDifference::new(&zdt2))?, 744.hours().seconds(36));
 
 # Ok::<(), Box<dyn std::error::Error>>(())
@@ -529,8 +529,8 @@ configuration. For example, rounding the span returned:
 ```rust
 use jiff::{civil::date, ToSpan, Unit, ZonedDifference};
 
-let zdt1 = date(2024, 7, 16).at(22, 3, 23, 0).intz("America/New_York")?;
-let zdt2 = date(2024, 8, 16).at(22, 3, 59, 0).intz("America/New_York")?;
+let zdt1 = date(2024, 7, 16).at(22, 3, 23, 0).in_tz("America/New_York")?;
+let zdt2 = date(2024, 8, 16).at(22, 3, 59, 0).in_tz("America/New_York")?;
 assert_eq!(
     zdt1.until(ZonedDifference::new(&zdt2).smallest(Unit::Minute))?,
     744.hours(),
@@ -553,8 +553,8 @@ instead of this:
 ```rust
 use jiff::{civil::date, ToSpan, Unit, ZonedDifference};
 
-let zdt1 = date(2024, 7, 16).at(22, 3, 23, 0).intz("America/New_York")?;
-let zdt2 = date(2024, 8, 16).at(22, 3, 59, 0).intz("America/New_York")?;
+let zdt1 = date(2024, 7, 16).at(22, 3, 23, 0).in_tz("America/New_York")?;
+let zdt2 = date(2024, 8, 16).at(22, 3, 59, 0).in_tz("America/New_York")?;
 let diff = ZonedDifference::new(&zdt2)
     .largest(Unit::Month)
     .smallest(Unit::Minute);
@@ -568,8 +568,8 @@ One would need to do this:
 ```rust
 use jiff::{civil::date, RoundMode, SpanRound, ToSpan, Unit};
 
-let zdt1 = date(2024, 7, 16).at(22, 3, 23, 0).intz("America/New_York")?;
-let zdt2 = date(2024, 8, 16).at(22, 3, 59, 0).intz("America/New_York")?;
+let zdt1 = date(2024, 7, 16).at(22, 3, 23, 0).in_tz("America/New_York")?;
+let zdt2 = date(2024, 8, 16).at(22, 3, 59, 0).in_tz("America/New_York")?;
 let span = zdt1.until(&zdt2)?;
 let rounded = span.round(
     SpanRound::new()

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -297,12 +297,12 @@ fn main() -> anyhow::Result<()> {
 
     // When computing durations between `Date` values,
     // the spans default to days.
-    assert_eq!(date1.until(date2)?, 31.days());
-    assert_eq!(date2.until(date3)?, 30.days());
+    assert_eq!(date1.until(date2)?, 31.days().fieldwise());
+    assert_eq!(date2.until(date3)?, 30.days().fieldwise());
 
     // But we can request bigger units!
-    assert_eq!(date1.until((Unit::Month, date2))?, 1.month());
-    assert_eq!(date2.until((Unit::Month, date3))?, 1.month());
+    assert_eq!(date1.until((Unit::Month, date2))?, 1.month().fieldwise());
+    assert_eq!(date2.until((Unit::Month, date3))?, 1.month().fieldwise());
 
     Ok(())
 }
@@ -506,7 +506,7 @@ use jiff::{civil::date, ToSpan};
 
 let zdt1 = date(2024, 7, 16).at(22, 3, 23, 0).in_tz("America/New_York")?;
 let zdt2 = date(2024, 8, 16).at(22, 3, 59, 0).in_tz("America/New_York")?;
-assert_eq!(zdt1.until(&zdt2)?, 744.hours().seconds(36));
+assert_eq!(zdt1.until(&zdt2)?, 744.hours().seconds(36).fieldwise());
 
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
@@ -518,7 +518,10 @@ use jiff::{civil::date, ToSpan, ZonedDifference};
 
 let zdt1 = date(2024, 7, 16).at(22, 3, 23, 0).in_tz("America/New_York")?;
 let zdt2 = date(2024, 8, 16).at(22, 3, 59, 0).in_tz("America/New_York")?;
-assert_eq!(zdt1.until(ZonedDifference::new(&zdt2))?, 744.hours().seconds(36));
+assert_eq!(
+  zdt1.until(ZonedDifference::new(&zdt2))?,
+  744.hours().seconds(36).fieldwise(),
+);
 
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
@@ -533,7 +536,7 @@ let zdt1 = date(2024, 7, 16).at(22, 3, 23, 0).in_tz("America/New_York")?;
 let zdt2 = date(2024, 8, 16).at(22, 3, 59, 0).in_tz("America/New_York")?;
 assert_eq!(
     zdt1.until(ZonedDifference::new(&zdt2).smallest(Unit::Minute))?,
-    744.hours(),
+    744.hours().fieldwise(),
 );
 
 # Ok::<(), Box<dyn std::error::Error>>(())
@@ -558,7 +561,7 @@ let zdt2 = date(2024, 8, 16).at(22, 3, 59, 0).in_tz("America/New_York")?;
 let diff = ZonedDifference::new(&zdt2)
     .largest(Unit::Month)
     .smallest(Unit::Minute);
-assert_eq!(zdt1.until(diff)?, 1.month());
+assert_eq!(zdt1.until(diff)?, 1.month().fieldwise());
 
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
@@ -578,7 +581,7 @@ let rounded = span.round(
         .relative(&zdt1)
         .mode(RoundMode::Trunc),
 )?;
-assert_eq!(rounded, 1.month());
+assert_eq!(rounded, 1.month().fieldwise());
 
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```

--- a/PLATFORM.md
+++ b/PLATFORM.md
@@ -246,7 +246,7 @@ database to be compiled into your binary. Nothing else needs to be done. Jiff
 will automatically use the bundled copy.
 * Manually create `TimeZone` values via `TimeZone::tzif` from TZif formatted
 data. With this approach, you may need to change how you use Jiff in some
-cases. For example, any `intz` method will need to be changed to use the
+cases. For example, any `in_tz` method will need to be changed to use the
 `to_zoned` equivalent.
 
 #### System time zone

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ use jiff::{Timestamp, ToSpan};
 
 fn main() -> Result<(), jiff::Error> {
     let time: Timestamp = "2024-07-11T01:14:00Z".parse()?;
-    let zoned = time.intz("America/New_York")?.checked_add(1.month().hours(2))?;
+    let zoned = time.in_tz("America/New_York")?.checked_add(1.month().hours(2))?;
     assert_eq!(zoned.to_string(), "2024-08-10T23:14:00-04:00[America/New_York]");
     // Or, if you want an RFC3339 formatted string:
     assert_eq!(zoned.timestamp().to_string(), "2024-08-11T03:14:00Z");

--- a/bench/src/bench.rs
+++ b/bench/src/bench.rs
@@ -21,7 +21,7 @@ fn civil_datetime_to_instant_with_tzdb_lookup(c: &mut Criterion) {
         let dt = jiff::civil::date(2024, 6, 30).at(9, 46, 0, 0);
         c.bench_function(&format!("jiff/{NAME}"), |b| {
             b.iter(|| {
-                let zdt = bb(dt).intz(bb(TZNAME)).unwrap();
+                let zdt = bb(dt).in_tz(bb(TZNAME)).unwrap();
                 assert_eq!(zdt.timestamp().as_second(), STAMP)
             })
         });

--- a/src/civil/date.rs
+++ b/src/civil/date.rs
@@ -1152,7 +1152,7 @@ impl Date {
     /// time zone and setting the clock time to midnight.
     ///
     /// This is a convenience function for
-    /// `date.to_datetime(midnight).intz(name)`. See [`DateTime::to_zoned`]
+    /// `date.to_datetime(midnight).in_tz(name)`. See [`DateTime::to_zoned`]
     /// for more details. Note that ambiguous datetimes are handled in the
     /// same way as `DateTime::to_zoned`.
     ///
@@ -1174,7 +1174,7 @@ impl Date {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt = date(2024, 6, 20).intz("America/New_York")?;
+    /// let zdt = date(2024, 6, 20).in_tz("America/New_York")?;
     /// assert_eq!(zdt.to_string(), "2024-06-20T00:00:00-04:00[America/New_York]");
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1195,7 +1195,7 @@ impl Date {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt = date(2024, 3, 10).intz("Cuba")?;
+    /// let zdt = date(2024, 3, 10).in_tz("Cuba")?;
     /// assert_eq!(zdt.to_string(), "2024-03-10T01:00:00-04:00[Cuba]");
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1223,7 +1223,7 @@ impl Date {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[inline]
-    pub fn intz(self, time_zone_name: &str) -> Result<Zoned, Error> {
+    pub fn in_tz(self, time_zone_name: &str) -> Result<Zoned, Error> {
         let tz = crate::tz::db().get(time_zone_name)?;
         self.to_zoned(tz)
     }
@@ -1237,7 +1237,7 @@ impl Date {
     /// way as `DateTime::to_zoned`.
     ///
     /// In the common case of a time zone being represented as a name string,
-    /// like `Australia/Tasmania`, consider using [`Date::intz`]
+    /// like `Australia/Tasmania`, consider using [`Date::in_tz`]
     /// instead.
     ///
     /// # Errors
@@ -2067,6 +2067,17 @@ impl Date {
     #[inline]
     pub fn to_iso_week_date(self) -> ISOWeekDate {
         self.iso_week_date()
+    }
+
+    /// A deprecated equivalent to [`Date::in_tz`].
+    ///
+    /// This will be removed in `jiff 0.2`. The method was renamed to make
+    /// it clearer that the name stood for "in time zone."
+    #[deprecated(since = "0.1.25", note = "use Date::in_tz instead")]
+    #[inline]
+    pub fn intz(self, time_zone_name: &str) -> Result<Zoned, Error> {
+        let tz = crate::tz::db().get(time_zone_name)?;
+        self.to_zoned(tz)
     }
 }
 

--- a/src/civil/date.rs
+++ b/src/civil/date.rs
@@ -563,10 +563,8 @@ impl Date {
     /// ```
     #[inline]
     pub fn day_of_year(self) -> i16 {
-        type DayOfYear = ri16<1, 366>;
-
         let days = C(1) + self.since_days_ranged(self.first_of_year());
-        DayOfYear::rfrom(days).get()
+        t::DayOfYear::rfrom(days).get()
     }
 
     /// Returns the ordinal day of the year that this date resides in, but
@@ -3669,9 +3667,7 @@ fn month_add_overflowing(
 }
 
 fn day_of_year(year: Year, day: i16) -> Result<Date, Error> {
-    type DayOfYear = ri16<1, 366>;
-
-    let day = DayOfYear::try_new("day-of-year", day)?;
+    let day = t::DayOfYear::try_new("day-of-year", day)?;
     let span = Span::new().days_ranged(day - C(1));
     let start = Date::new_ranged(year, C(1), C(1))?;
     let end = start.checked_add(span)?;

--- a/src/civil/date.rs
+++ b/src/civil/date.rs
@@ -115,7 +115,7 @@ use crate::{
 ///
 /// let date1 = date(2024, 3, 3);
 /// let date2 = date(2024, 2, 25);
-/// assert_eq!(date1 - date2, 7.days());
+/// assert_eq!(date1 - date2, 7.days().fieldwise());
 /// ```
 ///
 /// The `until` and `since` APIs are polymorphic and allow re-balancing and
@@ -129,7 +129,7 @@ use crate::{
 /// let date2 = date(2024, 2, 25);
 /// assert_eq!(
 ///     date1.since((Unit::Year, date2))?,
-///     2.months().days(7),
+///     2.months().days(7).fieldwise(),
 /// );
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -148,7 +148,7 @@ use crate::{
 ///             .smallest(Unit::Month)
 ///             .largest(Unit::Year),
 ///     )?,
-///     2.months(),
+///     2.months().fieldwise(),
 /// );
 /// // `DateDifference` uses truncation as a rounding mode by default,
 /// // but you can set the rounding mode to break ties away from zero:
@@ -160,7 +160,7 @@ use crate::{
 ///             .mode(RoundMode::HalfExpand),
 ///     )?,
 ///     // Rounds up to 8 days.
-///     3.months(),
+///     3.months().fieldwise(),
 /// );
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1615,12 +1615,12 @@ impl Date {
     ///
     /// let earlier = date(2006, 8, 24);
     /// let later = date(2019, 1, 31);
-    /// assert_eq!(earlier.until(later)?, 4543.days());
+    /// assert_eq!(earlier.until(later)?, 4543.days().fieldwise());
     ///
     /// // Flipping the dates is fine, but you'll get a negative span.
     /// let earlier = date(2006, 8, 24);
     /// let later = date(2019, 1, 31);
-    /// assert_eq!(later.until(earlier)?, -4543.days());
+    /// assert_eq!(later.until(earlier)?, -4543.days().fieldwise());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -1663,7 +1663,7 @@ impl Date {
     /// let d2 = date(2019, 02, 06);
     ///
     /// let span = d1.until(DateDifference::from(d2).smallest(Unit::Month))?;
-    /// assert_eq!(span, 277.months());
+    /// assert_eq!(span, 277.months().fieldwise());
     ///
     /// // Or even include years to make the span a bit more comprehensible.
     /// let span = d1.until(
@@ -1673,7 +1673,7 @@ impl Date {
     /// )?;
     /// // Notice that we are one day shy of 23y2m. Rounding spans computed
     /// // between dates uses truncation by default.
-    /// assert_eq!(span, 23.years().months(1));
+    /// assert_eq!(span, 23.years().months(1).fieldwise());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -1691,7 +1691,7 @@ impl Date {
     /// let d2 = date(2024, 5, 1);
     ///
     /// let span = d1.until((Unit::Month, d2))?;
-    /// assert_eq!(span, 1.month().days(29));
+    /// assert_eq!(span, 1.month().days(29).fieldwise());
     /// let maybe_original = d2.checked_sub(span)?;
     /// // Not the same as the original datetime!
     /// assert_eq!(maybe_original, date(2024, 3, 3));
@@ -1699,7 +1699,7 @@ impl Date {
     /// // But in the default configuration, days are always the biggest unit
     /// // and reversibility is guaranteed.
     /// let span = d1.until(d2)?;
-    /// assert_eq!(span, 60.days());
+    /// assert_eq!(span, 60.days().fieldwise());
     /// let is_original = d2.checked_sub(span)?;
     /// assert_eq!(is_original, d1);
     ///
@@ -1743,9 +1743,9 @@ impl Date {
     ///
     /// let earlier = date(2006, 8, 24);
     /// let later = date(2019, 1, 31);
-    /// assert_eq!(later - earlier, 4543.days());
+    /// assert_eq!(later - earlier, 4543.days().fieldwise());
     /// // Equivalent to:
-    /// assert_eq!(later.since(earlier).unwrap(), 4543.days());
+    /// assert_eq!(later.since(earlier).unwrap(), 4543.days().fieldwise());
     /// ```
     #[inline]
     pub fn since<A: Into<DateDifference>>(
@@ -1819,7 +1819,7 @@ impl Date {
     /// let d2 = date(2025, 4, 1);
     ///
     /// let span = d1.until((Unit::Year, d2))?;
-    /// assert_eq!(span, 1.year().months(3));
+    /// assert_eq!(span, 1.year().months(3).fieldwise());
     ///
     /// let duration = d1.duration_until(d2);
     /// assert_eq!(duration, SignedDuration::from_hours(456 * 24));
@@ -1829,7 +1829,7 @@ impl Date {
     /// // it to a span and then balance it by providing a relative date!
     /// let options = SpanRound::new().largest(Unit::Year).relative(d1);
     /// let span = Span::try_from(duration)?.round(options)?;
-    /// assert_eq!(span, 1.year().months(3));
+    /// assert_eq!(span, 1.year().months(3).fieldwise());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -2715,7 +2715,7 @@ impl<'a> From<&'a UnsignedDuration> for DateArithmetic {
 ///         .smallest(Unit::Year)
 ///         .mode(RoundMode::HalfExpand),
 /// )?;
-/// assert_eq!(span, 6.years());
+/// assert_eq!(span, 6.years().fieldwise());
 ///
 /// // If the span were one day longer, it would round up to 7 years.
 /// let d2 = "2030-09-14".parse::<Date>()?;
@@ -2724,7 +2724,7 @@ impl<'a> From<&'a UnsignedDuration> for DateArithmetic {
 ///         .smallest(Unit::Year)
 ///         .mode(RoundMode::HalfExpand),
 /// )?;
-/// assert_eq!(span, 7.years());
+/// assert_eq!(span, 7.years().fieldwise());
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
@@ -2776,7 +2776,7 @@ impl DateDifference {
     ///         .largest(Unit::Week)
     ///         .mode(RoundMode::HalfExpand),
     /// )?;
-    /// assert_eq!(span, 349.weeks());
+    /// assert_eq!(span, 349.weeks().fieldwise());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -2814,7 +2814,7 @@ impl DateDifference {
     /// let span = d1.until(
     ///     DateDifference::new(d2).largest(Unit::Month),
     /// )?;
-    /// assert_eq!(span, 80.months().days(7));
+    /// assert_eq!(span, 80.months().days(7).fieldwise());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -2846,7 +2846,7 @@ impl DateDifference {
     ///         .mode(RoundMode::Ceil),
     /// )?;
     /// // Only 7 months and 1 day elapsed, but we asked to always round up!
-    /// assert_eq!(span, 8.months());
+    /// assert_eq!(span, 8.months().fieldwise());
     ///
     /// // Since `Ceil` always rounds toward positive infinity, the behavior
     /// // flips for a negative span.
@@ -2855,7 +2855,7 @@ impl DateDifference {
     ///         .smallest(Unit::Month)
     ///         .mode(RoundMode::Ceil),
     /// )?;
-    /// assert_eq!(span, -7.months());
+    /// assert_eq!(span, -7.months().fieldwise());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -2887,7 +2887,7 @@ impl DateDifference {
     ///         .increment(2)
     ///         .mode(RoundMode::HalfExpand),
     /// )?;
-    /// assert_eq!(span, 8.months());
+    /// assert_eq!(span, 8.months().fieldwise());
     ///
     /// // If our second date was just one day less, rounding would truncate
     /// // down to 6 months!
@@ -2898,7 +2898,7 @@ impl DateDifference {
     ///         .increment(2)
     ///         .mode(RoundMode::HalfExpand),
     /// )?;
-    /// assert_eq!(span, 6.months());
+    /// assert_eq!(span, 6.months().fieldwise());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -3689,7 +3689,7 @@ fn day_of_year(year: Year, day: i16) -> Result<Date, Error> {
 mod tests {
     use std::io::Cursor;
 
-    use crate::{civil::date, tz::TimeZone, Timestamp, ToSpan};
+    use crate::{civil::date, span::span_eq, tz::TimeZone, Timestamp, ToSpan};
 
     use super::*;
 
@@ -3794,23 +3794,23 @@ mod tests {
         let d1 = date(2023, 4, 15);
         let d2 = date(2019, 2, 22);
         let span = d1.since((Unit::Year, d2)).unwrap();
-        assert_eq!(span, 4.years().months(1).days(21));
+        span_eq!(span, 4.years().months(1).days(21));
         let span = d2.since((Unit::Year, d1)).unwrap();
-        assert_eq!(span, -4.years().months(1).days(24));
+        span_eq!(span, -4.years().months(1).days(24));
 
         let d1 = date(2023, 2, 22);
         let d2 = date(2019, 4, 15);
         let span = d1.since((Unit::Year, d2)).unwrap();
-        assert_eq!(span, 3.years().months(10).days(7));
+        span_eq!(span, 3.years().months(10).days(7));
         let span = d2.since((Unit::Year, d1)).unwrap();
-        assert_eq!(span, -3.years().months(10).days(7));
+        span_eq!(span, -3.years().months(10).days(7));
 
         let d1 = date(9999, 12, 31);
         let d2 = date(-9999, 1, 1);
         let span = d1.since((Unit::Year, d2)).unwrap();
-        assert_eq!(span, 19998.years().months(11).days(30));
+        span_eq!(span, 19998.years().months(11).days(30));
         let span = d2.since((Unit::Year, d1)).unwrap();
-        assert_eq!(span, -19998.years().months(11).days(30));
+        span_eq!(span, -19998.years().months(11).days(30));
     }
 
     #[test]
@@ -3818,36 +3818,36 @@ mod tests {
         let d1 = date(2024, 7, 24);
         let d2 = date(2024, 2, 22);
         let span = d1.since((Unit::Month, d2)).unwrap();
-        assert_eq!(span, 5.months().days(2));
+        span_eq!(span, 5.months().days(2));
         let span = d2.since((Unit::Month, d1)).unwrap();
-        assert_eq!(span, -5.months().days(2));
+        span_eq!(span, -5.months().days(2));
         assert_eq!(d2, d1.checked_sub(5.months().days(2)).unwrap());
         assert_eq!(d1, d2.checked_sub(-5.months().days(2)).unwrap());
 
         let d1 = date(2024, 7, 15);
         let d2 = date(2024, 2, 22);
         let span = d1.since((Unit::Month, d2)).unwrap();
-        assert_eq!(span, 4.months().days(22));
+        span_eq!(span, 4.months().days(22));
         let span = d2.since((Unit::Month, d1)).unwrap();
-        assert_eq!(span, -4.months().days(23));
+        span_eq!(span, -4.months().days(23));
         assert_eq!(d2, d1.checked_sub(4.months().days(22)).unwrap());
         assert_eq!(d1, d2.checked_sub(-4.months().days(23)).unwrap());
 
         let d1 = date(2023, 4, 15);
         let d2 = date(2023, 2, 22);
         let span = d1.since((Unit::Month, d2)).unwrap();
-        assert_eq!(span, 1.month().days(21));
+        span_eq!(span, 1.month().days(21));
         let span = d2.since((Unit::Month, d1)).unwrap();
-        assert_eq!(span, -1.month().days(24));
+        span_eq!(span, -1.month().days(24));
         assert_eq!(d2, d1.checked_sub(1.month().days(21)).unwrap());
         assert_eq!(d1, d2.checked_sub(-1.month().days(24)).unwrap());
 
         let d1 = date(2023, 4, 15);
         let d2 = date(2019, 2, 22);
         let span = d1.since((Unit::Month, d2)).unwrap();
-        assert_eq!(span, 49.months().days(21));
+        span_eq!(span, 49.months().days(21));
         let span = d2.since((Unit::Month, d1)).unwrap();
-        assert_eq!(span, -49.months().days(24));
+        span_eq!(span, -49.months().days(24));
     }
 
     #[test]
@@ -3855,9 +3855,9 @@ mod tests {
         let d1 = date(2024, 7, 15);
         let d2 = date(2024, 6, 22);
         let span = d1.since((Unit::Week, d2)).unwrap();
-        assert_eq!(span, 3.weeks().days(2));
+        span_eq!(span, 3.weeks().days(2));
         let span = d2.since((Unit::Week, d1)).unwrap();
-        assert_eq!(span, -3.weeks().days(2));
+        span_eq!(span, -3.weeks().days(2));
     }
 
     #[test]
@@ -3865,9 +3865,9 @@ mod tests {
         let d1 = date(2024, 7, 15);
         let d2 = date(2024, 2, 22);
         let span = d1.since((Unit::Day, d2)).unwrap();
-        assert_eq!(span, 144.days());
+        span_eq!(span, 144.days());
         let span = d2.since((Unit::Day, d1)).unwrap();
-        assert_eq!(span, -144.days());
+        span_eq!(span, -144.days());
     }
 
     #[test]
@@ -3876,12 +3876,12 @@ mod tests {
         let feb1 = date(2020, 2, 1);
         let mar1 = date(2020, 3, 1);
 
-        assert_eq!(jan1.until(feb1).unwrap(), 31.days());
-        assert_eq!(jan1.until((Unit::Month, feb1)).unwrap(), 1.month());
-        assert_eq!(feb1.until(mar1).unwrap(), 29.days());
-        assert_eq!(feb1.until((Unit::Month, mar1)).unwrap(), 1.month());
-        assert_eq!(jan1.until(mar1).unwrap(), 60.days());
-        assert_eq!(jan1.until((Unit::Month, mar1)).unwrap(), 2.months());
+        span_eq!(jan1.until(feb1).unwrap(), 31.days());
+        span_eq!(jan1.until((Unit::Month, feb1)).unwrap(), 1.month());
+        span_eq!(feb1.until(mar1).unwrap(), 29.days());
+        span_eq!(feb1.until((Unit::Month, mar1)).unwrap(), 1.month());
+        span_eq!(jan1.until(mar1).unwrap(), 60.days());
+        span_eq!(jan1.until((Unit::Month, mar1)).unwrap(), 2.months());
     }
 
     // Ref: https://github.com/tc39/proposal-temporal/issues/2845#issuecomment-2121057896
@@ -3895,10 +3895,10 @@ mod tests {
         let d2 = date(2020, 2, 29);
 
         let since = d1.since((Unit::Month, d2)).unwrap();
-        assert_eq!(since, 2.months());
+        span_eq!(since, 2.months());
 
         let until = d2.until((Unit::Month, d1)).unwrap();
-        assert_eq!(until, 2.months().days(1));
+        span_eq!(until, 2.months().days(1));
     }
 
     // Ref: https://github.com/tc39/proposal-temporal/issues/2893
@@ -3909,14 +3909,14 @@ mod tests {
         let earlier = date(2019, 1, 8);
         let later = date(2021, 9, 7);
         let span = earlier.until((Unit::Week, later)).unwrap();
-        assert_eq!(span, 139.weeks());
+        span_eq!(span, 139.weeks());
 
         let options = SpanRound::new()
             .smallest(Unit::Week)
             .mode(RoundMode::HalfExpand)
             .relative(earlier.to_datetime(Time::midnight()));
         let rounded = span.round(options).unwrap();
-        assert_eq!(rounded, 139.weeks());
+        span_eq!(rounded, 139.weeks());
     }
 
     // This test checks current behavior, but I think it's wrong. I think the
@@ -3927,11 +3927,11 @@ mod tests {
     fn until_months_no_balance() {
         let sp =
             date(2023, 5, 31).until((Unit::Month, date(2024, 4, 30))).unwrap();
-        assert_eq!(sp, 10.months().days(30));
+        span_eq!(sp, 10.months().days(30));
 
         let sp =
             date(2023, 5, 31).until((Unit::Month, date(2023, 6, 30))).unwrap();
-        assert_eq!(sp, 30.days());
+        span_eq!(sp, 30.days());
     }
 
     #[test]

--- a/src/civil/datetime.rs
+++ b/src/civil/datetime.rs
@@ -673,12 +673,12 @@ impl DateTime {
     /// use jiff::{civil, Timestamp};
     ///
     /// // 1,234 nanoseconds after the Unix epoch.
-    /// let zdt = Timestamp::new(0, 1_234)?.intz("UTC")?;
+    /// let zdt = Timestamp::new(0, 1_234)?.in_tz("UTC")?;
     /// let dt = zdt.datetime();
     /// assert_eq!(dt.subsec_nanosecond(), 1_234);
     ///
     /// // 1,234 nanoseconds before the Unix epoch.
-    /// let zdt = Timestamp::new(0, -1_234)?.intz("UTC")?;
+    /// let zdt = Timestamp::new(0, -1_234)?.in_tz("UTC")?;
     /// let dt = zdt.datetime();
     /// // The nanosecond is equal to `1_000_000_000 - 1_234`.
     /// assert_eq!(dt.subsec_nanosecond(), 999998766);
@@ -1353,7 +1353,7 @@ impl DateTime {
     /// use jiff::civil::DateTime;
     ///
     /// let dt: DateTime = "2024-06-20 15:06".parse()?;
-    /// let zdt = dt.intz("America/New_York")?;
+    /// let zdt = dt.in_tz("America/New_York")?;
     /// assert_eq!(zdt.to_string(), "2024-06-20T15:06:00-04:00[America/New_York]");
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1378,12 +1378,12 @@ impl DateTime {
     ///
     /// // This is the gap, where by default we select the later time.
     /// let dt: DateTime = "2024-03-10 02:30".parse()?;
-    /// let zdt = dt.intz("America/New_York")?;
+    /// let zdt = dt.in_tz("America/New_York")?;
     /// assert_eq!(zdt.to_string(), "2024-03-10T03:30:00-04:00[America/New_York]");
     ///
     /// // This is the fold, where by default we select the earlier time.
     /// let dt: DateTime = "2024-11-03 01:30".parse()?;
-    /// let zdt = dt.intz("America/New_York")?;
+    /// let zdt = dt.in_tz("America/New_York")?;
     /// // Since this is a fold, the wall clock time is repeated. It might be
     /// // hard to see that this is the earlier time, but notice the offset:
     /// // it is the offset for DST time in New York. The later time, or the
@@ -1402,7 +1402,7 @@ impl DateTime {
     /// use jiff::civil::date;
     ///
     /// let dt = date(2024, 6, 20).at(15, 6, 0, 0);
-    /// assert!(dt.intz("does not exist").is_err());
+    /// assert!(dt.in_tz("does not exist").is_err());
     /// ```
     ///
     /// Note that even if a time zone exists in, say, the IANA database, there
@@ -1420,9 +1420,9 @@ impl DateTime {
     /// let dt = DateTime::MAX;
     /// // All errors because the combination of the offset and the datetime
     /// // isn't enough to fit into timestamp limits.
-    /// assert!(dt.intz("UTC").is_err());
-    /// assert!(dt.intz("America/New_York").is_err());
-    /// assert!(dt.intz("Australia/Tasmania").is_err());
+    /// assert!(dt.in_tz("UTC").is_err());
+    /// assert!(dt.in_tz("America/New_York").is_err());
+    /// assert!(dt.in_tz("Australia/Tasmania").is_err());
     /// // In fact, the only valid offset one can use to turn the maximum civil
     /// // datetime into a Zoned value is the maximum offset:
     /// let tz = Offset::from_seconds(93_599).unwrap().to_time_zone();
@@ -1441,7 +1441,7 @@ impl DateTime {
     /// always a way to convert a `Zoned` instant to a human readable wall
     /// clock time.
     #[inline]
-    pub fn intz(self, time_zone_name: &str) -> Result<Zoned, Error> {
+    pub fn in_tz(self, time_zone_name: &str) -> Result<Zoned, Error> {
         let tz = crate::tz::db().get(time_zone_name)?;
         self.to_zoned(tz)
     }
@@ -1461,7 +1461,7 @@ impl DateTime {
     /// strategy, use [`TimeZone::to_ambiguous_zoned`].
     ///
     /// In the common case of a time zone being represented as a name string,
-    /// like `Australia/Tasmania`, consider using [`DateTime::intz`]
+    /// like `Australia/Tasmania`, consider using [`DateTime::in_tz`]
     /// instead.
     ///
     /// # Errors
@@ -2356,6 +2356,20 @@ impl DateTime {
         format: &'f F,
     ) -> fmt::strtime::Display<'f> {
         fmt::strtime::Display { fmt: format.as_ref(), tm: (*self).into() }
+    }
+}
+
+/// Deprecated APIs.
+impl DateTime {
+    /// A deprecated equivalent to [`DateTime::in_tz`].
+    ///
+    /// This will be removed in `jiff 0.2`. The method was renamed to make
+    /// it clearer that the name stood for "in time zone."
+    #[deprecated(since = "0.1.25", note = "use DateTime::in_tz instead")]
+    #[inline]
+    pub fn intz(self, time_zone_name: &str) -> Result<Zoned, Error> {
+        let tz = crate::tz::db().get(time_zone_name)?;
+        self.to_zoned(tz)
     }
 }
 

--- a/src/civil/time.rs
+++ b/src/civil/time.rs
@@ -144,7 +144,10 @@ use crate::{
 ///
 /// let time1 = time(22, 0, 0, 0);
 /// let time2 = time(20, 10, 1, 0);
-/// assert_eq!(time1 - time2, 1.hours().minutes(49).seconds(59));
+/// assert_eq!(
+///     time1 - time2,
+///     1.hours().minutes(49).seconds(59).fieldwise(),
+/// );
 /// ```
 ///
 /// The `until` and `since` APIs are polymorphic and allow re-balancing and
@@ -158,7 +161,7 @@ use crate::{
 /// let time2 = time(7, 0, 0, 0);
 /// assert_eq!(
 ///     time1.since((Unit::Minute, time2))?,
-///     990.minutes(),
+///     990.minutes().fieldwise(),
 /// );
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -175,7 +178,7 @@ use crate::{
 ///     time1.until(
 ///         TimeDifference::new(time2).smallest(Unit::Minute),
 ///     )?,
-///     5.minutes(),
+///     5.minutes().fieldwise(),
 /// );
 /// // `TimeDifference` uses truncation as a rounding mode by default,
 /// // but you can set the rounding mode to break ties away from zero:
@@ -186,7 +189,7 @@ use crate::{
 ///             .mode(RoundMode::HalfExpand),
 ///     )?,
 ///     // Rounds up to 6 minutes.
-///     6.minutes(),
+///     6.minutes().fieldwise(),
 /// );
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1177,9 +1180,9 @@ impl Time {
     ///
     /// let t1 = time(22, 35, 1, 0);
     /// let t2 = time(22, 35, 3, 500_000_000);
-    /// assert_eq!(t1.until(t2)?, 2.seconds().milliseconds(500));
+    /// assert_eq!(t1.until(t2)?, 2.seconds().milliseconds(500).fieldwise());
     /// // Flipping the dates is fine, but you'll get a negative span.
-    /// assert_eq!(t2.until(t1)?, -2.seconds().milliseconds(500));
+    /// assert_eq!(t2.until(t1)?, -2.seconds().milliseconds(500).fieldwise());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -1239,7 +1242,7 @@ impl Time {
     ///
     /// let earlier = time(1, 0, 0, 0);
     /// let later = time(22, 30, 0, 0);
-    /// assert_eq!(later - earlier, 21.hours().minutes(30));
+    /// assert_eq!(later - earlier, 21.hours().minutes(30).fieldwise());
     /// ```
     #[inline]
     pub fn since<A: Into<TimeDifference>>(
@@ -1315,7 +1318,7 @@ impl Time {
     /// // between two civil times never exceeds the limits
     /// // of a `Span`.
     /// let span = Span::try_from(dur).unwrap();
-    /// assert_eq!(span, Span::new().seconds(2).milliseconds(500));
+    /// assert_eq!(span, Span::new().seconds(2).milliseconds(500).fieldwise());
     /// // Guaranteed to succeed and always return the original
     /// // duration because the units are always hours or smaller,
     /// // and thus uniform. This means a relative datetime is
@@ -2299,7 +2302,7 @@ impl<'a> From<&'a UnsignedDuration> for TimeArithmetic {
 ///         .mode(RoundMode::HalfExpand)
 ///         .increment(30),
 /// )?;
-/// assert_eq!(span, 7.hours());
+/// assert_eq!(span, 7.hours().fieldwise());
 ///
 /// // One less minute, and because of the HalfExpand mode, the span would
 /// // get rounded down.
@@ -2310,7 +2313,7 @@ impl<'a> From<&'a UnsignedDuration> for TimeArithmetic {
 ///         .mode(RoundMode::HalfExpand)
 ///         .increment(30),
 /// )?;
-/// assert_eq!(span, 6.hours().minutes(30));
+/// assert_eq!(span, 6.hours().minutes(30).fieldwise());
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
@@ -2358,7 +2361,7 @@ impl TimeDifference {
     ///         .smallest(Unit::Second)
     ///         .mode(RoundMode::HalfExpand),
     /// )?;
-    /// assert_eq!(span, 16.minutes().seconds(1));
+    /// assert_eq!(span, 16.minutes().seconds(1).fieldwise());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -2389,7 +2392,7 @@ impl TimeDifference {
     /// let t1 = "08:14".parse::<Time>()?;
     /// let t2 = "08:30".parse::<Time>()?;
     /// let span = t1.until(TimeDifference::new(t2).largest(Unit::Second))?;
-    /// assert_eq!(span, 960.seconds());
+    /// assert_eq!(span, 960.seconds().fieldwise());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -2421,7 +2424,7 @@ impl TimeDifference {
     ///         .mode(RoundMode::Ceil),
     /// )?;
     /// // Only one minute elapsed, but we asked to always round up!
-    /// assert_eq!(span, 1.hour());
+    /// assert_eq!(span, 1.hour().fieldwise());
     ///
     /// // Since `Ceil` always rounds toward positive infinity, the behavior
     /// // flips for a negative span.
@@ -2430,7 +2433,7 @@ impl TimeDifference {
     ///         .smallest(Unit::Hour)
     ///         .mode(RoundMode::Ceil),
     /// )?;
-    /// assert_eq!(span, 0.hour());
+    /// assert_eq!(span, 0.hour().fieldwise());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -2476,7 +2479,7 @@ impl TimeDifference {
     ///         .increment(5)
     ///         .mode(RoundMode::HalfExpand),
     /// )?;
-    /// assert_eq!(span, 4.hour().minutes(35));
+    /// assert_eq!(span, 4.hour().minutes(35).fieldwise());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -3160,7 +3163,7 @@ impl TimeWith {
 mod tests {
     use std::io::Cursor;
 
-    use crate::{civil::time, ToSpan};
+    use crate::{civil::time, span::span_eq, ToSpan};
 
     use super::*;
 
@@ -3318,7 +3321,7 @@ mod tests {
         let t1 = time(23, 30, 0, 0);
         let (t2, span) = t1.overflowing_add(5.hours()).unwrap();
         assert_eq!(t2, time(4, 30, 0, 0));
-        assert_eq!(span, 1.days());
+        span_eq!(span, 1.days());
     }
 
     #[test]

--- a/src/civil/time.rs
+++ b/src/civil/time.rs
@@ -533,12 +533,12 @@ impl Time {
     /// use jiff::{civil, Timestamp};
     ///
     /// // 1,234 nanoseconds after the Unix epoch.
-    /// let zdt = Timestamp::new(0, 1_234)?.intz("UTC")?;
+    /// let zdt = Timestamp::new(0, 1_234)?.in_tz("UTC")?;
     /// let time = zdt.datetime().time();
     /// assert_eq!(time.subsec_nanosecond(), 1_234);
     ///
     /// // 1,234 nanoseconds before the Unix epoch.
-    /// let zdt = Timestamp::new(0, -1_234)?.intz("UTC")?;
+    /// let zdt = Timestamp::new(0, -1_234)?.in_tz("UTC")?;
     /// let time = zdt.datetime().time();
     /// // The nanosecond is equal to `1_000_000_000 - 1_234`.
     /// assert_eq!(time.subsec_nanosecond(), 999998766);

--- a/src/fmt/friendly/mod.rs
+++ b/src/fmt/friendly/mod.rs
@@ -53,7 +53,11 @@ let spans = [
 ];
 for (string, span) in spans {
     let parsed: Span = string.parse()?;
-    assert_eq!(span, parsed, "result of parsing {string:?}");
+    assert_eq!(
+        span.fieldwise(),
+        parsed.fieldwise(),
+        "result of parsing {string:?}",
+    );
 }
 
 # Ok::<(), Box<dyn std::error::Error>>(())
@@ -106,9 +110,9 @@ use jiff::{SignedDuration, Span, ToSpan};
 
 let expected = 2.months().days(35).hours(2).minutes(30);
 let span: Span = "2 months, 35 days, 02:30:00".parse()?;
-assert_eq!(span, expected);
+assert_eq!(span, expected.fieldwise());
 let span: Span = "P2M35DT2H30M".parse()?;
-assert_eq!(span, expected);
+assert_eq!(span, expected.fieldwise());
 
 let expected = SignedDuration::new(2 * 60 * 60 + 30 * 60, 123_456_789);
 let sdur: SignedDuration = "2h 30m 0,123456789s".parse()?;
@@ -142,7 +146,10 @@ struct Record {
 
 let json = r#"{"span":"1 year 2 months 36 hours 1100ms"}"#;
 let got: Record = serde_json::from_str(&json)?;
-assert_eq!(got.span, 1.year().months(2).hours(36).milliseconds(1100));
+assert_eq!(
+    got.span.fieldwise(),
+    1.year().months(2).hours(36).milliseconds(1100),
+);
 
 let expected = r#"{"span":"1y 2mo 36h 1100ms"}"#;
 assert_eq!(serde_json::to_string(&got).unwrap(), expected);
@@ -228,7 +235,7 @@ let expected =
         .milliseconds(123)
         .microseconds(456)
         .nanoseconds(789);
-assert_eq!(span, expected);
+assert_eq!(span, expected.fieldwise());
 
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
@@ -337,7 +344,7 @@ As the error message suggests, parsing into a [`Span`](crate::Span) works fine:
 ```
 use jiff::Span;
 
-assert_eq!("1 day".parse::<Span>().unwrap(), Span::new().days(1));
+assert_eq!("1 day".parse::<Span>().unwrap(), Span::new().days(1).fieldwise());
 ```
 
 Jiff has this behavior because it's not possible to determine, in general,

--- a/src/fmt/friendly/mod.rs
+++ b/src/fmt/friendly/mod.rs
@@ -172,8 +172,8 @@ hour before printing:
 ```
 use jiff::{civil, RoundMode, ToSpan, Unit, ZonedDifference};
 
-let commented_at = civil::date(2024, 8, 1).at(19, 29, 13, 123_456_789).intz("US/Eastern")?;
-let now = civil::date(2024, 12, 26).at(12, 49, 0, 0).intz("US/Eastern")?;
+let commented_at = civil::date(2024, 8, 1).at(19, 29, 13, 123_456_789).in_tz("US/Eastern")?;
+let now = civil::date(2024, 12, 26).at(12, 49, 0, 0).in_tz("US/Eastern")?;
 
 // The default, with units permitted up to years.
 let span = now.since((Unit::Year, &commented_at))?;
@@ -378,22 +378,22 @@ use jiff::{civil, Span};
 let span: Span = "1 day".parse()?;
 let dur = humantime::parse_duration("1 day")?;
 
-let zdt = civil::date(2024, 3, 9).at(17, 0, 0, 0).intz("US/Eastern")?;
+let zdt = civil::date(2024, 3, 9).at(17, 0, 0, 0).in_tz("US/Eastern")?;
 
 // Adding 1 day gives the generally expected result of the same clock
 // time on the following day when adding a `Span`.
-assert_eq!(&zdt + span, civil::date(2024, 3, 10).at(17, 0, 0, 0).intz("US/Eastern")?);
+assert_eq!(&zdt + span, civil::date(2024, 3, 10).at(17, 0, 0, 0).in_tz("US/Eastern")?);
 // But with humantime, all days are assumed to be exactly 24 hours. So
 // you get an instant in time that is 24 hours later, even when some
 // days are shorter and some are longer.
-assert_eq!(&zdt + dur, civil::date(2024, 3, 10).at(18, 0, 0, 0).intz("US/Eastern")?);
+assert_eq!(&zdt + dur, civil::date(2024, 3, 10).at(18, 0, 0, 0).in_tz("US/Eastern")?);
 
 // Notice also that this inaccuracy can occur merely by a duration that
 // _crosses_ a time zone transition boundary (like DST) at any point. It
 // doesn't require your datetimes to be "close" to when DST occurred.
 let dur = humantime::parse_duration("20 day")?;
-let zdt = civil::date(2024, 3, 1).at(17, 0, 0, 0).intz("US/Eastern")?;
-assert_eq!(&zdt + dur, civil::date(2024, 3, 21).at(18, 0, 0, 0).intz("US/Eastern")?);
+let zdt = civil::date(2024, 3, 1).at(17, 0, 0, 0).in_tz("US/Eastern")?;
+assert_eq!(&zdt + dur, civil::date(2024, 3, 21).at(18, 0, 0, 0).in_tz("US/Eastern")?);
 
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```

--- a/src/fmt/friendly/parser.rs
+++ b/src/fmt/friendly/parser.rs
@@ -42,7 +42,7 @@ use crate::{
 /// use jiff::{SignedDuration, Span, ToSpan};
 ///
 /// let span: Span = "5 years, 2 months".parse()?;
-/// assert_eq!(span, 5.years().months(2));
+/// assert_eq!(span, 5.years().months(2).fieldwise());
 ///
 /// let sdur: SignedDuration = "5 hours, 2 minutes".parse()?;
 /// assert_eq!(sdur, SignedDuration::new(5 * 60 * 60 + 2 * 60, 0));
@@ -61,12 +61,18 @@ use crate::{
 ///
 /// let string = "1 year, 3 months, 15:00:01.3";
 /// let span = PARSER.parse_span(string)?;
-/// assert_eq!(span, 1.year().months(3).hours(15).seconds(1).milliseconds(300));
+/// assert_eq!(
+///     span,
+///     1.year().months(3).hours(15).seconds(1).milliseconds(300).fieldwise(),
+/// );
 ///
 /// // Negative durations are supported too!
 /// let string = "1 year, 3 months, 15:00:01.3 ago";
 /// let span = PARSER.parse_span(string)?;
-/// assert_eq!(span, -1.year().months(3).hours(15).seconds(1).milliseconds(300));
+/// assert_eq!(
+///     span,
+///     -1.year().months(3).hours(15).seconds(1).milliseconds(300).fieldwise(),
+/// );
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
@@ -94,7 +100,10 @@ impl SpanParser {
     ///
     /// let bytes = b"1 year 3 months 15 hours 1300ms";
     /// let span = PARSER.parse_span(bytes)?;
-    /// assert_eq!(span, 1.year().months(3).hours(15).milliseconds(1300));
+    /// assert_eq!(
+    ///     span,
+    ///     1.year().months(3).hours(15).milliseconds(1300).fieldwise(),
+    /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -162,7 +171,11 @@ impl SpanParser {
     /// static PARSER: SpanParser = SpanParser::new();
     /// for (string, span) in spans {
     ///     let parsed = PARSER.parse_span(string)?;
-    ///     assert_eq!(span, parsed, "result of parsing {string:?}");
+    ///     assert_eq!(
+    ///         span.fieldwise(),
+    ///         parsed.fieldwise(),
+    ///         "result of parsing {string:?}",
+    ///     );
     /// }
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())

--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -152,7 +152,7 @@ impl<W: Write> Write for &mut W {
 ///
 /// use jiff::{civil::date, fmt::{StdIoWrite, temporal::DateTimePrinter}};
 ///
-/// let zdt = date(2024, 6, 15).at(7, 0, 0, 0).intz("America/New_York")?;
+/// let zdt = date(2024, 6, 15).at(7, 0, 0, 0).in_tz("America/New_York")?;
 ///
 /// let path = Path::new("/tmp/output");
 /// let mut file = BufWriter::new(File::create(path)?);

--- a/src/fmt/rfc2822.rs
+++ b/src/fmt/rfc2822.rs
@@ -97,7 +97,7 @@ pub(crate) static DEFAULT_DATETIME_PRINTER: DateTimePrinter =
 /// ```
 /// use jiff::{civil::date, fmt::rfc2822};
 ///
-/// let zdt = date(2024, 6, 15).at(7, 0, 0, 0).intz("Australia/Tasmania")?;
+/// let zdt = date(2024, 6, 15).at(7, 0, 0, 0).in_tz("Australia/Tasmania")?;
 /// assert_eq!(rfc2822::to_string(&zdt)?, "Sat, 15 Jun 2024 07:00:00 +1000");
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -152,7 +152,7 @@ pub fn to_string(zdt: &Zoned) -> Result<alloc::string::String, Error> {
 ///
 /// let zdt = date(2024, 7, 13)
 ///     .at(15, 9, 59, 789_000_000)
-///     .intz("America/New_York")?;
+///     .in_tz("America/New_York")?;
 /// // The default format (i.e., Temporal) guarantees lossless
 /// // serialization.
 /// assert_eq!(zdt.to_string(), "2024-07-13T15:09:59.789-04:00[America/New_York]");
@@ -200,7 +200,7 @@ pub fn parse(string: &str) -> Result<Zoned, Error> {
 ///
 /// let zdt = date(2024, 7, 13)
 ///     .at(15, 9, 59, 789_000_000)
-///     .intz("America/New_York")?;
+///     .in_tz("America/New_York")?;
 /// // The default format (i.e., Temporal) guarantees lossless
 /// // serialization.
 /// assert_eq!(zdt.to_string(), "2024-07-13T15:09:59.789-04:00[America/New_York]");
@@ -252,7 +252,7 @@ impl DateTimeParser {
     ///     .relaxed_weekday(true);
     /// assert_eq!(
     ///     P.parse_zoned(string)?,
-    ///     date(2024, 7, 13).at(15, 9, 59, 0).intz("America/New_York")?,
+    ///     date(2024, 7, 13).at(15, 9, 59, 0).in_tz("America/New_York")?,
     /// );
     /// // But note that something that isn't recognized as a valid weekday
     /// // will still result in an error:
@@ -1048,7 +1048,7 @@ impl DateTimeParser {
 ///
 /// const PRINTER: DateTimePrinter = DateTimePrinter::new();
 ///
-/// let zdt = date(2024, 6, 15).at(7, 0, 0, 0).intz("Australia/Tasmania")?;
+/// let zdt = date(2024, 6, 15).at(7, 0, 0, 0).in_tz("Australia/Tasmania")?;
 ///
 /// let mut buf = String::new();
 /// PRINTER.print_zoned(&zdt, &mut buf)?;
@@ -1071,7 +1071,7 @@ impl DateTimeParser {
 ///
 /// use jiff::{civil::date, fmt::{StdIoWrite, rfc2822::DateTimePrinter}};
 ///
-/// let zdt = date(2024, 6, 15).at(7, 0, 0, 0).intz("Asia/Kolkata")?;
+/// let zdt = date(2024, 6, 15).at(7, 0, 0, 0).in_tz("Asia/Kolkata")?;
 ///
 /// let path = Path::new("/tmp/output");
 /// let mut file = BufWriter::new(File::create(path)?);
@@ -1137,7 +1137,7 @@ impl DateTimePrinter {
     ///
     /// const PRINTER: DateTimePrinter = DateTimePrinter::new();
     ///
-    /// let zdt = date(2024, 6, 15).at(7, 0, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 6, 15).at(7, 0, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(
     ///     PRINTER.zoned_to_string(&zdt)?,
     ///     "Sat, 15 Jun 2024 07:00:00 -0400",
@@ -1284,7 +1284,7 @@ impl DateTimePrinter {
     ///
     /// const PRINTER: DateTimePrinter = DateTimePrinter::new();
     ///
-    /// let zdt = date(2024, 6, 15).at(7, 0, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 6, 15).at(7, 0, 0, 0).in_tz("America/New_York")?;
     ///
     /// let mut buf = String::new();
     /// PRINTER.print_zoned(&zdt, &mut buf)?;
@@ -1841,23 +1841,23 @@ mod tests {
 
         let zdt = date(2024, 1, 10)
             .at(5, 34, 45, 0)
-            .intz("America/New_York")
+            .in_tz("America/New_York")
             .unwrap();
         insta::assert_snapshot!(p(&zdt), @"Wed, 10 Jan 2024 05:34:45 -0500");
 
         let zdt = date(2024, 2, 5)
             .at(5, 34, 45, 0)
-            .intz("America/New_York")
+            .in_tz("America/New_York")
             .unwrap();
         insta::assert_snapshot!(p(&zdt), @"Mon, 5 Feb 2024 05:34:45 -0500");
 
         let zdt = date(2024, 7, 31)
             .at(5, 34, 45, 0)
-            .intz("America/New_York")
+            .in_tz("America/New_York")
             .unwrap();
         insta::assert_snapshot!(p(&zdt), @"Wed, 31 Jul 2024 05:34:45 -0400");
 
-        let zdt = date(2024, 3, 5).at(5, 34, 45, 0).intz("UTC").unwrap();
+        let zdt = date(2024, 3, 5).at(5, 34, 45, 0).in_tz("UTC").unwrap();
         // Notice that this prints a +0000 offset.
         // But when printing a Timestamp, a -0000 offset is used.
         // This is because in the case of Timestamp, the "true"
@@ -1879,27 +1879,30 @@ mod tests {
 
         let ts = date(2024, 1, 10)
             .at(5, 34, 45, 0)
-            .intz("America/New_York")
+            .in_tz("America/New_York")
             .unwrap()
             .timestamp();
         insta::assert_snapshot!(p(ts), @"Wed, 10 Jan 2024 10:34:45 -0000");
 
         let ts = date(2024, 2, 5)
             .at(5, 34, 45, 0)
-            .intz("America/New_York")
+            .in_tz("America/New_York")
             .unwrap()
             .timestamp();
         insta::assert_snapshot!(p(ts), @"Mon, 5 Feb 2024 10:34:45 -0000");
 
         let ts = date(2024, 7, 31)
             .at(5, 34, 45, 0)
-            .intz("America/New_York")
+            .in_tz("America/New_York")
             .unwrap()
             .timestamp();
         insta::assert_snapshot!(p(ts), @"Wed, 31 Jul 2024 09:34:45 -0000");
 
-        let ts =
-            date(2024, 3, 5).at(5, 34, 45, 0).intz("UTC").unwrap().timestamp();
+        let ts = date(2024, 3, 5)
+            .at(5, 34, 45, 0)
+            .in_tz("UTC")
+            .unwrap()
+            .timestamp();
         // Notice that this prints a +0000 offset.
         // But when printing a Timestamp, a -0000 offset is used.
         // This is because in the case of Timestamp, the "true"
@@ -1923,27 +1926,30 @@ mod tests {
 
         let ts = date(2024, 1, 10)
             .at(5, 34, 45, 0)
-            .intz("America/New_York")
+            .in_tz("America/New_York")
             .unwrap()
             .timestamp();
         insta::assert_snapshot!(p(ts), @"Wed, 10 Jan 2024 10:34:45 GMT");
 
         let ts = date(2024, 2, 5)
             .at(5, 34, 45, 0)
-            .intz("America/New_York")
+            .in_tz("America/New_York")
             .unwrap()
             .timestamp();
         insta::assert_snapshot!(p(ts), @"Mon, 05 Feb 2024 10:34:45 GMT");
 
         let ts = date(2024, 7, 31)
             .at(5, 34, 45, 0)
-            .intz("America/New_York")
+            .in_tz("America/New_York")
             .unwrap()
             .timestamp();
         insta::assert_snapshot!(p(ts), @"Wed, 31 Jul 2024 09:34:45 GMT");
 
-        let ts =
-            date(2024, 3, 5).at(5, 34, 45, 0).intz("UTC").unwrap().timestamp();
+        let ts = date(2024, 3, 5)
+            .at(5, 34, 45, 0)
+            .in_tz("UTC")
+            .unwrap()
+            .timestamp();
         // Notice that this prints a +0000 offset.
         // But when printing a Timestamp, a -0000 offset is used.
         // This is because in the case of Timestamp, the "true"
@@ -1965,8 +1971,10 @@ mod tests {
                 .to_string()
         };
 
-        let zdt =
-            date(-1, 1, 10).at(5, 34, 45, 0).intz("America/New_York").unwrap();
+        let zdt = date(-1, 1, 10)
+            .at(5, 34, 45, 0)
+            .in_tz("America/New_York")
+            .unwrap();
         insta::assert_snapshot!(p(&zdt), @"datetime -000001-01-10T05:34:45 has negative year, which cannot be formatted with RFC 2822");
     }
 
@@ -1986,7 +1994,7 @@ mod tests {
 
         let ts = date(-1, 1, 10)
             .at(5, 34, 45, 0)
-            .intz("America/New_York")
+            .in_tz("America/New_York")
             .unwrap()
             .timestamp();
         insta::assert_snapshot!(p(ts), @"datetime -000001-01-10T10:30:47 has negative year, which cannot be formatted with RFC 2822");

--- a/src/fmt/serde.rs
+++ b/src/fmt/serde.rs
@@ -107,7 +107,10 @@ struct Record {
 
 let json = r#"{"span":"1 year 2 months 36 hours 1100ms"}"#;
 let got: Record = serde_json::from_str(&json)?;
-assert_eq!(got.span, 1.year().months(2).hours(36).milliseconds(1100));
+assert_eq!(
+    got.span,
+    1.year().months(2).hours(36).milliseconds(1100).fieldwise(),
+);
 
 let expected = r#"{"span":"1y 2mo 36h 1100ms"}"#;
 assert_eq!(serde_json::to_string(&got).unwrap(), expected);
@@ -315,7 +318,10 @@ pub mod duration {
 ///
 /// let json = r#"{"duration": "1 year 2 months 36 hours 1100ms"}"#;
 /// let got: Data = serde_json::from_str(&json).unwrap();
-/// assert_eq!(got.duration, 1.year().months(2).hours(36).milliseconds(1100));
+/// assert_eq!(
+///     got.duration,
+///     1.year().months(2).hours(36).milliseconds(1100).fieldwise(),
+/// );
 ///
 /// let expected = r#"{"duration":"1 year, 2 months, 36:00:01.100"}"#;
 /// assert_eq!(serde_json::to_string(&got).unwrap(), expected);
@@ -1075,7 +1081,9 @@ pub mod timestamp {
 
 #[cfg(test)]
 mod tests {
-    use crate::{SignedDuration, Span, Timestamp, ToSpan};
+    use crate::{
+        span::span_eq, SignedDuration, Span, SpanFieldwise, Timestamp, ToSpan,
+    };
 
     #[test]
     fn duration_friendly_compact_required() {
@@ -1131,7 +1139,7 @@ mod tests {
 
         let json = r#"{"span":"1 year 2 months 36 hours 1100ms"}"#;
         let got: Data = serde_json::from_str(&json).unwrap();
-        assert_eq!(got.span, 1.year().months(2).hours(36).milliseconds(1100));
+        span_eq!(got.span, 1.year().months(2).hours(36).milliseconds(1100));
 
         let expected = r#"{"span":"1y 2mo 36h 1100ms"}"#;
         assert_eq!(serde_json::to_string(&got).unwrap(), expected);
@@ -1150,8 +1158,8 @@ mod tests {
         let json = r#"{"span":"1 year 2 months 36 hours 1100ms"}"#;
         let got: Data = serde_json::from_str(&json).unwrap();
         assert_eq!(
-            got.span,
-            Some(1.year().months(2).hours(36).milliseconds(1100))
+            got.span.map(SpanFieldwise),
+            Some(1.year().months(2).hours(36).milliseconds(1100).fieldwise())
         );
 
         let expected = r#"{"span":"1y 2mo 36h 1100ms"}"#;

--- a/src/fmt/strtime/format.rs
+++ b/src/fmt/strtime/format.rs
@@ -746,7 +746,7 @@ mod tests {
 
         let zdt = date(2024, 7, 14)
             .at(22, 24, 0, 0)
-            .intz("America/New_York")
+            .in_tz("America/New_York")
             .unwrap();
         insta::assert_snapshot!(f("%z", &zdt), @"-0400");
         insta::assert_snapshot!(f("%:z", &zdt), @"-04:00");
@@ -808,7 +808,7 @@ mod tests {
 
         let zdt = date(2024, 7, 14)
             .at(22, 24, 0, 0)
-            .intz("America/New_York")
+            .in_tz("America/New_York")
             .unwrap();
         insta::assert_snapshot!(f("%Z", &zdt), @"EDT");
         insta::assert_snapshot!(f("%^Z", &zdt), @"EDT");
@@ -828,7 +828,7 @@ mod tests {
 
         let zdt = date(2024, 7, 14)
             .at(22, 24, 0, 0)
-            .intz("America/New_York")
+            .in_tz("America/New_York")
             .unwrap();
         insta::assert_snapshot!(f("%V", &zdt), @"America/New_York");
         insta::assert_snapshot!(f("%:V", &zdt), @"America/New_York");

--- a/src/fmt/strtime/format.rs
+++ b/src/fmt/strtime/format.rs
@@ -46,24 +46,38 @@ impl<'f, 't, 'w, W: Write> Formatter<'f, 't, 'w, W> {
                 b'a' => self.fmt_weekday_abbrev(ext).context("%a failed")?,
                 b'B' => self.fmt_month_full(ext).context("%B failed")?,
                 b'b' => self.fmt_month_abbrev(ext).context("%b failed")?,
+                b'C' => self.fmt_century(ext).context("%C failed")?,
                 b'D' => self.fmt_american_date(ext).context("%D failed")?,
                 b'd' => self.fmt_day_zero(ext).context("%d failed")?,
                 b'e' => self.fmt_day_space(ext).context("%e failed")?,
                 b'F' => self.fmt_iso_date(ext).context("%F failed")?,
                 b'f' => self.fmt_fractional(ext).context("%f failed")?,
-                b'H' => self.fmt_hour24(ext).context("%H failed")?,
+                b'G' => self.fmt_iso_week_year(ext).context("%G failed")?,
+                b'g' => self.fmt_iso_week_year2(ext).context("%g failed")?,
+                b'H' => self.fmt_hour24_zero(ext).context("%H failed")?,
                 b'h' => self.fmt_month_abbrev(ext).context("%b failed")?,
-                b'I' => self.fmt_hour12(ext).context("%H failed")?,
+                b'I' => self.fmt_hour12_zero(ext).context("%H failed")?,
+                b'j' => self.fmt_day_of_year(ext).context("%j failed")?,
+                b'k' => self.fmt_hour24_space(ext).context("%k failed")?,
+                b'l' => self.fmt_hour12_space(ext).context("%l failed")?,
                 b'M' => self.fmt_minute(ext).context("%M failed")?,
                 b'm' => self.fmt_month(ext).context("%m failed")?,
+                b'n' => self.fmt_literal("\n").context("%n failed")?,
                 b'P' => self.fmt_ampm_lower(ext).context("%P failed")?,
                 b'p' => self.fmt_ampm_upper(ext).context("%p failed")?,
                 b'Q' => self.fmt_iana_nocolon(b'Q').context("%Q failed")?,
+                b'R' => self.fmt_clock_nosecs(ext).context("%R failed")?,
                 b'S' => self.fmt_second(ext).context("%S failed")?,
-                b'T' => self.fmt_clock(ext).context("%T failed")?,
+                b's' => self.fmt_timestamp(ext).context("%s failed")?,
+                b'T' => self.fmt_clock_secs(ext).context("%T failed")?,
+                b't' => self.fmt_literal("\t").context("%t failed")?,
+                b'U' => self.fmt_week_sun(ext).context("%U failed")?,
+                b'u' => self.fmt_weekday_mon(ext).context("%u failed")?,
                 b'V' => self.fmt_iana_nocolon(b'V').context("%V failed")?,
+                b'W' => self.fmt_week_mon(ext).context("%W failed")?,
+                b'w' => self.fmt_weekday_sun(ext).context("%w failed")?,
                 b'Y' => self.fmt_year(ext).context("%Y failed")?,
-                b'y' => self.fmt_year_2digit(ext).context("%y failed")?,
+                b'y' => self.fmt_year2(ext).context("%y failed")?,
                 b'Z' => self.fmt_tzabbrev(ext).context("%Z failed")?,
                 b'z' => self.fmt_offset_nocolon().context("%z failed")?,
                 b':' => {
@@ -245,13 +259,21 @@ impl<'f, 't, 'w, W: Write> Formatter<'f, 't, 'w, W> {
         self.wtr.write_char('/')?;
         self.fmt_day_zero(ext)?;
         self.wtr.write_char('/')?;
-        self.fmt_year_2digit(ext)?;
+        self.fmt_year2(ext)?;
+        Ok(())
+    }
+
+    /// %R
+    fn fmt_clock_nosecs(&mut self, ext: Extension) -> Result<(), Error> {
+        self.fmt_hour24_zero(ext)?;
+        self.wtr.write_char(':')?;
+        self.fmt_minute(ext)?;
         Ok(())
     }
 
     /// %T
-    fn fmt_clock(&mut self, ext: Extension) -> Result<(), Error> {
-        self.fmt_hour24(ext)?;
+    fn fmt_clock_secs(&mut self, ext: Extension) -> Result<(), Error> {
+        self.fmt_hour24_zero(ext)?;
         self.wtr.write_char(':')?;
         self.fmt_minute(ext)?;
         self.wtr.write_char(':')?;
@@ -280,7 +302,7 @@ impl<'f, 't, 'w, W: Write> Formatter<'f, 't, 'w, W> {
     }
 
     /// %I
-    fn fmt_hour12(&mut self, ext: Extension) -> Result<(), Error> {
+    fn fmt_hour12_zero(&mut self, ext: Extension) -> Result<(), Error> {
         let mut hour = self
             .tm
             .hour
@@ -295,13 +317,38 @@ impl<'f, 't, 'w, W: Write> Formatter<'f, 't, 'w, W> {
     }
 
     /// %H
-    fn fmt_hour24(&mut self, ext: Extension) -> Result<(), Error> {
+    fn fmt_hour24_zero(&mut self, ext: Extension) -> Result<(), Error> {
         let hour = self
             .tm
             .hour
             .ok_or_else(|| err!("requires time to format hour"))?
             .get();
         ext.write_int(b'0', Some(2), hour, self.wtr)
+    }
+
+    /// %l
+    fn fmt_hour12_space(&mut self, ext: Extension) -> Result<(), Error> {
+        let mut hour = self
+            .tm
+            .hour
+            .ok_or_else(|| err!("requires time to format hour"))?
+            .get();
+        if hour == 0 {
+            hour = 12;
+        } else if hour > 12 {
+            hour -= 12;
+        }
+        ext.write_int(b' ', Some(2), hour, self.wtr)
+    }
+
+    /// %k
+    fn fmt_hour24_space(&mut self, ext: Extension) -> Result<(), Error> {
+        let hour = self
+            .tm
+            .hour
+            .ok_or_else(|| err!("requires time to format hour"))?
+            .get();
+        ext.write_int(b' ', Some(2), hour, self.wtr)
     }
 
     /// %F
@@ -420,6 +467,17 @@ impl<'f, 't, 'w, W: Write> Formatter<'f, 't, 'w, W> {
         ext.write_int(b'0', Some(2), second, self.wtr)
     }
 
+    /// %s
+    fn fmt_timestamp(&mut self, ext: Extension) -> Result<(), Error> {
+        let timestamp = self.tm.to_timestamp().map_err(|_| {
+            err!(
+                "requires instant (a date, time and offset) \
+                 to format Unix timestamp",
+            )
+        })?;
+        ext.write_int(b' ', None, timestamp.as_second(), self.wtr)
+    }
+
     /// %f
     fn fmt_fractional(&mut self, ext: Extension) -> Result<(), Error> {
         let subsec = self.tm.subsec.ok_or_else(|| {
@@ -466,6 +524,7 @@ impl<'f, 't, 'w, W: Write> Formatter<'f, 't, 'w, W> {
         let weekday = self
             .tm
             .weekday
+            .or_else(|| self.tm.to_date().ok().map(|d| d.weekday()))
             .ok_or_else(|| err!("requires date to format weekday"))?;
         ext.write_str(Case::AsIs, weekday_name_full(weekday), self.wtr)
     }
@@ -475,8 +534,91 @@ impl<'f, 't, 'w, W: Write> Formatter<'f, 't, 'w, W> {
         let weekday = self
             .tm
             .weekday
+            .or_else(|| self.tm.to_date().ok().map(|d| d.weekday()))
             .ok_or_else(|| err!("requires date to format weekday"))?;
         ext.write_str(Case::AsIs, weekday_name_abbrev(weekday), self.wtr)
+    }
+
+    /// %u
+    fn fmt_weekday_mon(&mut self, ext: Extension) -> Result<(), Error> {
+        let weekday = self
+            .tm
+            .weekday
+            .or_else(|| self.tm.to_date().ok().map(|d| d.weekday()))
+            .ok_or_else(|| err!("requires date to format weekday number"))?;
+        ext.write_int(b' ', None, weekday.to_monday_one_offset(), self.wtr)
+    }
+
+    /// %w
+    fn fmt_weekday_sun(&mut self, ext: Extension) -> Result<(), Error> {
+        let weekday = self
+            .tm
+            .weekday
+            .or_else(|| self.tm.to_date().ok().map(|d| d.weekday()))
+            .ok_or_else(|| err!("requires date to format weekday number"))?;
+        ext.write_int(b' ', None, weekday.to_sunday_zero_offset(), self.wtr)
+    }
+
+    /// %U
+    fn fmt_week_sun(&mut self, ext: Extension) -> Result<(), Error> {
+        // Short circuit if the week number was explicitly set.
+        if let Some(weeknum) = self.tm.week_sun {
+            return ext.write_int(b'0', Some(2), weeknum, self.wtr);
+        }
+        let day = self
+            .tm
+            .day_of_year
+            .map(|day| day.get())
+            .or_else(|| self.tm.to_date().ok().map(|d| d.day_of_year()))
+            .ok_or_else(|| {
+                err!("requires date to format Sunday-based week number")
+            })?;
+        let weekday = self
+            .tm
+            .weekday
+            .or_else(|| self.tm.to_date().ok().map(|d| d.weekday()))
+            .ok_or_else(|| {
+                err!("requires date to format Sunday-based week number")
+            })?
+            .to_sunday_zero_offset();
+        // Example: 2025-01-05 is the first Sunday in 2025, and thus the start
+        // of week 1. This means that 2025-01-04 (Saturday) is in week 0.
+        //
+        // So for 2025-01-05, day=5 and weekday=0. Thus we get 11/7 = 1.
+        // For 2025-01-04, day=4 and weekday=6. Thus we get 4/7 = 0.
+        let weeknum = (day + 6 - i16::from(weekday)) / 7;
+        ext.write_int(b'0', Some(2), weeknum, self.wtr)
+    }
+
+    /// %W
+    fn fmt_week_mon(&mut self, ext: Extension) -> Result<(), Error> {
+        // Short circuit if the week number was explicitly set.
+        if let Some(weeknum) = self.tm.week_mon {
+            return ext.write_int(b'0', Some(2), weeknum, self.wtr);
+        }
+        let day = self
+            .tm
+            .day_of_year
+            .map(|day| day.get())
+            .or_else(|| self.tm.to_date().ok().map(|d| d.day_of_year()))
+            .ok_or_else(|| {
+                err!("requires date to format Monday-based week number")
+            })?;
+        let weekday = self
+            .tm
+            .weekday
+            .or_else(|| self.tm.to_date().ok().map(|d| d.weekday()))
+            .ok_or_else(|| {
+                err!("requires date to format Monday-based week number")
+            })?
+            .to_sunday_zero_offset();
+        // Example: 2025-01-06 is the first Monday in 2025, and thus the start
+        // of week 1. This means that 2025-01-05 (Sunday) is in week 0.
+        //
+        // So for 2025-01-06, day=6 and weekday=1. Thus we get 12/7 = 1.
+        // For 2025-01-05, day=5 and weekday=7. Thus we get 5/7 = 0.
+        let weeknum = (day + 6 - ((i16::from(weekday) + 6) % 7)) / 7;
+        ext.write_int(b'0', Some(2), weeknum, self.wtr)
     }
 
     /// %Y
@@ -490,7 +632,7 @@ impl<'f, 't, 'w, W: Write> Formatter<'f, 't, 'w, W> {
     }
 
     /// %y
-    fn fmt_year_2digit(&mut self, ext: Extension) -> Result<(), Error> {
+    fn fmt_year2(&mut self, ext: Extension) -> Result<(), Error> {
         let year = self
             .tm
             .year
@@ -504,6 +646,74 @@ impl<'f, 't, 'w, W: Write> Formatter<'f, 't, 'w, W> {
         }
         let year = year % 100;
         ext.write_int(b'0', Some(2), year, self.wtr)
+    }
+
+    /// %C
+    fn fmt_century(&mut self, ext: Extension) -> Result<(), Error> {
+        let year = self
+            .tm
+            .year
+            .ok_or_else(|| err!("requires date to format century (2-digit)"))?
+            .get();
+        let century = year / 100;
+        ext.write_int(b' ', None, century, self.wtr)
+    }
+
+    /// %G
+    fn fmt_iso_week_year(&mut self, ext: Extension) -> Result<(), Error> {
+        let year = self
+            .tm
+            .iso_week_year
+            .or_else(|| {
+                self.tm.to_date().ok().map(|d| d.iso_week_date().year_ranged())
+            })
+            .ok_or_else(|| {
+                err!("requires date to format ISO 8601 week-based year")
+            })?
+            .get();
+        ext.write_int(b'0', Some(4), year, self.wtr)
+    }
+
+    /// %g
+    fn fmt_iso_week_year2(&mut self, ext: Extension) -> Result<(), Error> {
+        let year = self
+            .tm
+            .iso_week_year
+            .or_else(|| {
+                self.tm.to_date().ok().map(|d| d.iso_week_date().year_ranged())
+            })
+            .ok_or_else(|| {
+                err!(
+                    "requires date to format \
+                     ISO 8601 week-based year (2-digit)"
+                )
+            })?
+            .get();
+        if !(1969 <= year && year <= 2068) {
+            return Err(err!(
+                "formatting a 2-digit ISO 8601 week-based year \
+                 requires that it be in \
+                 the inclusive range 1969 to 2068, but got {year}",
+            ));
+        }
+        let year = year % 100;
+        ext.write_int(b'0', Some(2), year, self.wtr)
+    }
+
+    /// %j
+    fn fmt_day_of_year(&mut self, ext: Extension) -> Result<(), Error> {
+        let day = self
+            .tm
+            .day_of_year
+            .map(|day| day.get())
+            .or_else(|| self.tm.to_date().ok().map(|d| d.day_of_year()))
+            .ok_or_else(|| err!("requires date to format day of year"))?;
+        ext.write_int(b'0', Some(3), day, self.wtr)
+    }
+
+    /// %n, %t
+    fn fmt_literal(&mut self, literal: &str) -> Result<(), Error> {
+        self.wtr.write_str(literal)
     }
 }
 
@@ -639,9 +849,9 @@ impl Case {
 #[cfg(test)]
 mod tests {
     use crate::{
-        civil::{date, time, Date, Time},
+        civil::{date, time, Date, DateTime, Time},
         fmt::strtime::format,
-        Zoned,
+        Timestamp, Zoned,
     };
 
     #[test]
@@ -675,6 +885,7 @@ mod tests {
     fn ok_format_clock() {
         let f = |fmt: &str, time: Time| format(fmt, time).unwrap();
 
+        insta::assert_snapshot!(f("%R", time(23, 59, 8, 0)), @"23:59");
         insta::assert_snapshot!(f("%T", time(23, 59, 8, 0)), @"23:59:08");
     }
 
@@ -716,6 +927,16 @@ mod tests {
         insta::assert_snapshot!(f("%I", time(11, 0, 0, 0)), @"11");
         insta::assert_snapshot!(f("%I", time(23, 0, 0, 0)), @"11");
         insta::assert_snapshot!(f("%I", time(0, 0, 0, 0)), @"12");
+
+        insta::assert_snapshot!(f("%k", time(9, 0, 0, 0)), @" 9");
+        insta::assert_snapshot!(f("%k", time(11, 0, 0, 0)), @"11");
+        insta::assert_snapshot!(f("%k", time(23, 0, 0, 0)), @"23");
+        insta::assert_snapshot!(f("%k", time(0, 0, 0, 0)), @" 0");
+
+        insta::assert_snapshot!(f("%l", time(9, 0, 0, 0)), @" 9");
+        insta::assert_snapshot!(f("%l", time(11, 0, 0, 0)), @"11");
+        insta::assert_snapshot!(f("%l", time(23, 0, 0, 0)), @"11");
+        insta::assert_snapshot!(f("%l", time(0, 0, 0, 0)), @"12");
     }
 
     #[test]
@@ -875,6 +1096,9 @@ mod tests {
 
         insta::assert_snapshot!(f("%#A", date(2024, 7, 14)), @"Sunday");
         insta::assert_snapshot!(f("%^A", date(2024, 7, 14)), @"SUNDAY");
+
+        insta::assert_snapshot!(f("%u", date(2024, 7, 14)), @"7");
+        insta::assert_snapshot!(f("%w", date(2024, 7, 14)), @"0");
     }
 
     #[test]
@@ -884,6 +1108,16 @@ mod tests {
         insta::assert_snapshot!(f("%Y", date(2024, 7, 14)), @"2024");
         insta::assert_snapshot!(f("%Y", date(24, 7, 14)), @"0024");
         insta::assert_snapshot!(f("%Y", date(-24, 7, 14)), @"-0024");
+
+        insta::assert_snapshot!(f("%C", date(2024, 7, 14)), @"20");
+        insta::assert_snapshot!(f("%C", date(1815, 7, 14)), @"18");
+        insta::assert_snapshot!(f("%C", date(915, 7, 14)), @"9");
+        insta::assert_snapshot!(f("%C", date(1, 7, 14)), @"0");
+        insta::assert_snapshot!(f("%C", date(0, 7, 14)), @"0");
+        insta::assert_snapshot!(f("%C", date(-1, 7, 14)), @"0");
+        insta::assert_snapshot!(f("%C", date(-2024, 7, 14)), @"-20");
+        insta::assert_snapshot!(f("%C", date(-1815, 7, 14)), @"-18");
+        insta::assert_snapshot!(f("%C", date(-915, 7, 14)), @"-9");
     }
 
     #[test]
@@ -901,6 +1135,42 @@ mod tests {
     }
 
     #[test]
+    fn ok_format_iso_week_year() {
+        let f = |fmt: &str, date: Date| format(fmt, date).unwrap();
+
+        insta::assert_snapshot!(f("%G", date(2019, 11, 30)), @"2019");
+        insta::assert_snapshot!(f("%G", date(19, 11, 30)), @"0019");
+        insta::assert_snapshot!(f("%G", date(-19, 11, 30)), @"-0019");
+
+        // tricksy
+        insta::assert_snapshot!(f("%G", date(2019, 12, 30)), @"2020");
+    }
+
+    #[test]
+    fn ok_format_week_num() {
+        let f = |fmt: &str, date: Date| format(fmt, date).unwrap();
+
+        insta::assert_snapshot!(f("%U", date(2025, 1, 4)), @"00");
+        insta::assert_snapshot!(f("%U", date(2025, 1, 5)), @"01");
+
+        insta::assert_snapshot!(f("%W", date(2025, 1, 5)), @"00");
+        insta::assert_snapshot!(f("%W", date(2025, 1, 6)), @"01");
+    }
+
+    #[test]
+    fn ok_format_timestamp() {
+        let f = |fmt: &str, ts: Timestamp| format(fmt, ts).unwrap();
+
+        let ts = "1970-01-01T00:00Z".parse().unwrap();
+        insta::assert_snapshot!(f("%s", ts), @"0");
+        insta::assert_snapshot!(f("%3s", ts), @"  0");
+        insta::assert_snapshot!(f("%03s", ts), @"000");
+
+        let ts = "2025-01-20T13:09-05[US/Eastern]".parse().unwrap();
+        insta::assert_snapshot!(f("%s", ts), @"1737396540");
+    }
+
+    #[test]
     fn err_format_subsec_nanosecond() {
         let f = |fmt: &str, time: Time| format(fmt, time).unwrap_err();
         let mk = |subsec| time(0, 0, 0, subsec);
@@ -908,6 +1178,17 @@ mod tests {
         insta::assert_snapshot!(
             f("%00f", mk(123_456_789)),
             @"strftime formatting failed: %f failed: zero precision with %f is not allowed",
+        );
+    }
+
+    #[test]
+    fn err_format_timestamp() {
+        let f = |fmt: &str, dt: DateTime| format(fmt, dt).unwrap_err();
+
+        let dt = date(2025, 1, 20).at(13, 9, 0, 0);
+        insta::assert_snapshot!(
+            f("%s", dt),
+            @"strftime formatting failed: %s failed: requires instant (a date, time and offset) to format Unix timestamp",
         );
     }
 }

--- a/src/fmt/strtime/mod.rs
+++ b/src/fmt/strtime/mod.rs
@@ -161,31 +161,45 @@ strings, the strings are matched without regard to ASCII case.
 | `%%` | `%%` | A literal `%`. |
 | `%A`, `%a` | `Sunday`, `Sun` | The full and abbreviated weekday, respectively. |
 | `%B`, `%b`, `%h` | `June`, `Jun`, `Jun` | The full and abbreviated month name, respectively. |
+| `%C` | `20` | The century of the year. No padding. |
 | `%D` | `7/14/24` | Equivalent to `%m/%d/%y`. |
 | `%d`, `%e` | `25`, ` 5` | The day of the month. `%d` is zero-padded, `%e` is space padded. |
 | `%F` | `2024-07-14` | Equivalent to `%Y-%m-%d`. |
 | `%f` | `000456` | Fractional seconds, up to nanosecond precision. |
 | `%.f` | `.000456` | Optional fractional seconds, with dot, up to nanosecond precision. |
+| `%G` | `2024` | An [ISO 8601 week-based] year. Zero padded to 4 digits. |
+| `%g` | `24` | A two-digit [ISO 8601 week-based] year. Represents only 1969-2068. Zero padded. |
 | `%H` | `23` | The hour in a 24 hour clock. Zero padded. |
 | `%I` | `11` | The hour in a 12 hour clock. Zero padded. |
+| `%j` | `060` | The day of the year. Range is `1..=366`. Zero padded to 3 digits. |
+| `%k` | `15` | The hour in a 24 hour clock. Space padded. |
+| `%l` | ` 3` | The hour in a 12 hour clock. Space padded. |
 | `%M` | `04` | The minute. Zero padded. |
 | `%m` | `01` | The month. Zero padded. |
+| `%n` | `\n` | Formats as a newline character. Parses arbitrary whitespace. |
 | `%P` | `am` | Whether the time is in the AM or PM, lowercase. |
 | `%p` | `PM` | Whether the time is in the AM or PM, uppercase. |
 | `%Q` | `America/New_York`, `+0530` | An IANA time zone identifier, or `%z` if one doesn't exist. |
 | `%:Q` | `America/New_York`, `+05:30` | An IANA time zone identifier, or `%:z` if one doesn't exist. |
+| `%R` | `23:30` | Equivalent to `%H:%M`. |
 | `%S` | `59` | The second. Zero padded. |
+| `%s` | `1737396540` | A Unix timestamp, in seconds. |
 | `%T` | `23:30:59` | Equivalent to `%H:%M:%S`. |
+| `%t` | `\t` | Formats as a tab character. Parses arbitrary whitespace. |
+| `%U` | `03` | Week number. Week 1 is the first week starting with a Sunday. Zero padded. |
+| `%u` | `7` | The day of the week beginning with Monday at `1`. |
+| `%W` | `03` | Week number. Week 1 is the first week starting with a Monday. Zero padded. |
+| `%w` | `0` | The day of the week beginning with Sunday at `0`. |
 | `%Y` | `2024` | A full year, including century. Zero padded to 4 digits. |
 | `%y` | `24` | A two-digit year. Represents only 1969-2068. Zero padded. |
 | `%Z` | `EDT` | A time zone abbreviation. Supported when formatting only. |
 | `%z` | `+0530` | A time zone offset in the format `[+-]HHMM[SS]`. |
 | `%:z` | `+05:30` | A time zone offset in the format `[+-]HH:MM[:SS]`. |
 
-These specifiers are deprecated. Specifically, in `jiff 0.2`, `%V` will parse
-or print the ISO 8601 week number and `%:V` will no longer be recognized. To
-emit an IANA time zone identifier (which is what `%V` does in `jiff 0.1`) in
-a forward compatible way, please use the `%Q` or `%:Q` specifier (as listed
+The following specifiers are deprecated. Specifically, in `jiff 0.2`, `%V` will
+parse or print the ISO 8601 week number and `%:V` will no longer be recognized.
+To emit an IANA time zone identifier (which is what `%V` does in `jiff 0.1`)
+in a forward compatible way, please use the `%Q` or `%:Q` specifier (as listed
 above).
 
 | Specifier | Example | Description |
@@ -215,7 +229,7 @@ than 256. The number formed by these digits will correspond to the minimum
 amount of padding (to the left).
 
 The flags and padding amount above may be used when parsing as well. Most
-settings are ignoring during parsing except for padding. For example, if one
+settings are ignored during parsing except for padding. For example, if one
 wanted to parse `003` as the day `3`, then one should use `%03d`. Otherwise, by
 default, `%d` will only try to consume at most 2 digits.
 
@@ -243,12 +257,16 @@ is variable width data. If you have a use case for this, please
 The following things are currently unsupported:
 
 * Parsing or formatting fractional seconds in the time time zone offset.
-* Conversion specifiers related to week numbers.
-* Conversion specifiers related to day-of-year numbers, like the Julian day.
-* The `%s` conversion specifier, for Unix timestamps in seconds.
+* A conversion specifier for an ISO 8601 week number. It is planned to support
+  this, via `%V`, in `jiff 0.2`.
+* Locale oriented conversion specifiers, such as `%c`, `%r` and `%+`, are not
+  supported by Jiff. For locale oriented datetime formatting, please use the
+  [`icu`] crate.
 
 [`strftime`]: https://pubs.opengroup.org/onlinepubs/009695399/functions/strftime.html
 [`strptime`]: https://pubs.opengroup.org/onlinepubs/009695399/functions/strptime.html
+[ISO 8601 week-based]: https://en.wikipedia.org/wiki/ISO_week_date
+[`icu`]: https://docs.rs/icu
 */
 
 use crate::{
@@ -455,7 +473,7 @@ pub fn format(
 // the rest of Jiff's API. e.g., If a `DateTime` is requested but the format
 // string has no directives for time, we'll happy default to midnight. The
 // only catch is that you can't omit time units bigger than any present time
-// unit. For example, `%M` doesn't fly. If you want to parse minutes, you
+// unit. For example, only `%M` doesn't fly. If you want to parse minutes, you
 // also have to parse hours.
 //
 // This design does also let us possibly do "incomplete" parsing by asking
@@ -468,14 +486,19 @@ pub struct BrokenDownTime {
     year: Option<t::Year>,
     month: Option<t::Month>,
     day: Option<t::Day>,
+    day_of_year: Option<t::DayOfYear>,
+    iso_week_year: Option<t::ISOYear>,
+    week_sun: Option<t::WeekNum>,
+    week_mon: Option<t::WeekNum>,
     hour: Option<t::Hour>,
     minute: Option<t::Minute>,
     second: Option<t::Second>,
     subsec: Option<t::SubsecNanosecond>,
     offset: Option<Offset>,
-    // Only used to confirm that it is consistent
-    // with the date given. But otherwise cannot
-    // pick a date on its own.
+    // Used to confirm that it is consistent
+    // with the date given. It usually isn't
+    // used to pick a date on its own, but can
+    // be for week dates.
     weekday: Option<Weekday>,
     // Only generally useful with %I. But can still
     // be used with, say, %H. In that case, AM will
@@ -880,10 +903,15 @@ impl BrokenDownTime {
 
     /// Extracts a civil date from this broken down time.
     ///
+    /// This requires that the year is set along with a way to identify the day
+    /// in the year. This can be done by either setting the month and the day
+    /// of the month (`%m` and `%d`), or by setting the day of the year (`%j`).
+    ///
     /// # Errors
     ///
-    /// This returns an error if there weren't enough components to construct a
-    /// civil date. This means there must be at least a year, month and day.
+    /// This returns an error if there weren't enough components to construct
+    /// a civil date. This means there must be at least a year and either the
+    /// month and day or the day of the year.
     ///
     /// It's okay if there are more units than are needed to construct a civil
     /// datetime. For example, if this broken down time contain a civil time,
@@ -904,25 +932,24 @@ impl BrokenDownTime {
     #[inline]
     pub fn to_date(&self) -> Result<Date, Error> {
         let Some(year) = self.year else {
+            return Err(err!("missing year, date cannot be created"));
+        };
+        let mut date = self.to_date_from_gregorian(year)?;
+        if date.is_none() {
+            date = self.to_date_from_day_of_year(year)?;
+        }
+        if date.is_none() {
+            date = self.to_date_from_week_sun(year)?;
+        }
+        if date.is_none() {
+            date = self.to_date_from_week_mon(year)?;
+        }
+        let Some(date) = date else {
             return Err(err!(
-                "parsing format did not include year directive, \
-                 without it, a date cannot be created",
+                "a month/day, day-of-year or week date must be \
+                 present to create a date, but none were found",
             ));
         };
-        let Some(month) = self.month else {
-            return Err(err!(
-                "parsing format did not include month directive, \
-                 without it, a date cannot be created",
-            ));
-        };
-        let Some(day) = self.day else {
-            return Err(err!(
-                "parsing format did not include day directive, \
-                 without it, a date cannot be created",
-            ));
-        };
-        let date =
-            Date::new_ranged(year, month, day).context("invalid date")?;
         if let Some(weekday) = self.weekday {
             if weekday != date.weekday() {
                 return Err(err!(
@@ -934,6 +961,129 @@ impl BrokenDownTime {
             }
         }
         Ok(date)
+    }
+
+    #[inline]
+    fn to_date_from_gregorian(
+        &self,
+        year: t::Year,
+    ) -> Result<Option<Date>, Error> {
+        let (Some(month), Some(day)) = (self.month, self.day) else {
+            return Ok(None);
+        };
+        Ok(Some(Date::new_ranged(year, month, day).context("invalid date")?))
+    }
+
+    #[inline]
+    fn to_date_from_day_of_year(
+        &self,
+        year: t::Year,
+    ) -> Result<Option<Date>, Error> {
+        let Some(doy) = self.day_of_year else { return Ok(None) };
+        Ok(Some({
+            let first = Date::new_ranged(year, C(1), C(1)).unwrap();
+            first
+                .with()
+                .day_of_year(doy.get())
+                .build()
+                .context("invalid date")?
+        }))
+    }
+
+    #[inline]
+    fn to_date_from_week_sun(
+        &self,
+        year: t::Year,
+    ) -> Result<Option<Date>, Error> {
+        let (Some(week), Some(weekday)) = (self.week_sun, self.weekday) else {
+            return Ok(None);
+        };
+        let week = i16::from(week);
+        let wday = i16::from(weekday.to_sunday_zero_offset());
+        let first_of_year =
+            Date::new_ranged(year, C(1), C(1)).context("invalid date")?;
+        let first_sunday = first_of_year
+            .nth_weekday_of_month(1, Weekday::Sunday)
+            .map(|d| d.day_of_year())
+            .context("invalid date")?;
+        let doy = if week == 0 {
+            let days_before_first_sunday = 7 - wday;
+            let doy = first_sunday
+                .checked_sub(days_before_first_sunday)
+                .ok_or_else(|| {
+                    err!(
+                        "weekday `{weekday:?}` is not valid for \
+                         Sunday based week number `{week}` \
+                         in year `{year}`",
+                    )
+                })?;
+            if doy == 0 {
+                return Err(err!(
+                    "weekday `{weekday:?}` is not valid for \
+                     Sunday based week number `{week}` \
+                     in year `{year}`",
+                ));
+            }
+            doy
+        } else {
+            let days_since_first_sunday = (week - 1) * 7 + wday;
+            let doy = first_sunday + days_since_first_sunday;
+            doy
+        };
+        let date = first_of_year
+            .with()
+            .day_of_year(doy)
+            .build()
+            .context("invalid date")?;
+        Ok(Some(date))
+    }
+
+    #[inline]
+    fn to_date_from_week_mon(
+        &self,
+        year: t::Year,
+    ) -> Result<Option<Date>, Error> {
+        let (Some(week), Some(weekday)) = (self.week_mon, self.weekday) else {
+            return Ok(None);
+        };
+        let week = i16::from(week);
+        let wday = i16::from(weekday.to_monday_zero_offset());
+        let first_of_year =
+            Date::new_ranged(year, C(1), C(1)).context("invalid date")?;
+        let first_monday = first_of_year
+            .nth_weekday_of_month(1, Weekday::Monday)
+            .map(|d| d.day_of_year())
+            .context("invalid date")?;
+        let doy = if week == 0 {
+            let days_before_first_monday = 7 - wday;
+            let doy = first_monday
+                .checked_sub(days_before_first_monday)
+                .ok_or_else(|| {
+                    err!(
+                        "weekday `{weekday:?}` is not valid for \
+                         Monday based week number `{week}` \
+                         in year `{year}`",
+                    )
+                })?;
+            if doy == 0 {
+                return Err(err!(
+                    "weekday `{weekday:?}` is not valid for \
+                     Monday based week number `{week}` \
+                     in year `{year}`",
+                ));
+            }
+            doy
+        } else {
+            let days_since_first_monday = (week - 1) * 7 + wday;
+            let doy = first_monday + days_since_first_monday;
+            doy
+        };
+        let date = first_of_year
+            .with()
+            .day_of_year(doy)
+            .build()
+            .context("invalid date")?;
+        Ok(Some(date))
     }
 
     /// Extracts a civil time from this broken down time.
@@ -1173,6 +1323,166 @@ impl BrokenDownTime {
     #[inline]
     pub fn day(&self) -> Option<i8> {
         self.day.map(|x| x.get())
+    }
+
+    /// Returns the parsed day of the year (1-366), if available.
+    ///
+    /// # Example
+    ///
+    /// This shows how to parse the day of the year:
+    ///
+    /// ```
+    /// use jiff::fmt::strtime::BrokenDownTime;
+    ///
+    /// let tm = BrokenDownTime::parse("%j", "5")?;
+    /// assert_eq!(tm.day_of_year(), Some(5));
+    /// assert_eq!(tm.to_string("%j")?, "005");
+    /// assert_eq!(tm.to_string("%-j")?, "5");
+    ///
+    /// // Parsing the day of the year works for all possible legal
+    /// // values, even if, e.g., 366 isn't valid for all possible
+    /// // year/month combinations.
+    /// let tm = BrokenDownTime::parse("%j", "366")?;
+    /// assert_eq!(tm.day_of_year(), Some(366));
+    /// // This is true even if you're parsing a year:
+    /// let tm = BrokenDownTime::parse("%Y/%j", "2023/366")?;
+    /// assert_eq!(tm.day_of_year(), Some(366));
+    /// // An error only occurs when you try to extract a date:
+    /// assert_eq!(
+    ///     tm.to_date().unwrap_err().to_string(),
+    ///     "invalid date: parameter 'day-of-year' with value 366 \
+    ///      is not in the required range of 1..=365",
+    /// );
+    /// // But parsing a value that is always illegal will
+    /// // result in an error:
+    /// assert!(BrokenDownTime::parse("%j", "0").is_err());
+    /// assert!(BrokenDownTime::parse("%j", "367").is_err());
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// # Example: extract a [`Date`]
+    ///
+    /// This example shows how parsing a year and a day of the year enables
+    /// the extraction of a date:
+    ///
+    /// ```
+    /// use jiff::{civil::date, fmt::strtime::BrokenDownTime};
+    ///
+    /// let tm = BrokenDownTime::parse("%Y-%j", "2024-60")?;
+    /// assert_eq!(tm.to_date()?, date(2024, 2, 29));
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// When all of `%m`, `%d` and `%j` are used, then `%m` and `%d` take
+    /// priority over `%j` when extracting a `Date` from a `BrokenDownTime`.
+    /// However, `%j` is still parsed and accessible:
+    ///
+    /// ```
+    /// use jiff::{civil::date, fmt::strtime::BrokenDownTime};
+    ///
+    /// let tm = BrokenDownTime::parse(
+    ///     "%Y-%m-%d (day of year: %j)",
+    ///     "2024-02-29 (day of year: 1)",
+    /// )?;
+    /// assert_eq!(tm.to_date()?, date(2024, 2, 29));
+    /// assert_eq!(tm.day_of_year(), Some(1));
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[inline]
+    pub fn day_of_year(&self) -> Option<i16> {
+        self.day_of_year.map(|x| x.get())
+    }
+
+    /// Returns the parsed ISO 8601 week-based year, if available.
+    ///
+    /// This is also set when a 2 digit ISO 8601 week-based year is parsed.
+    /// (But that's limited to the years 1969 to 2068, inclusive.)
+    ///
+    /// # Example
+    ///
+    /// This shows how to parse just an ISO 8601 week-based year:
+    ///
+    /// ```
+    /// use jiff::fmt::strtime::BrokenDownTime;
+    ///
+    /// let tm = BrokenDownTime::parse("%G", "2024")?;
+    /// assert_eq!(tm.iso_week_year(), Some(2024));
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// And 2-digit years are supported too:
+    ///
+    /// ```
+    /// use jiff::fmt::strtime::BrokenDownTime;
+    ///
+    /// let tm = BrokenDownTime::parse("%g", "24")?;
+    /// assert_eq!(tm.iso_week_year(), Some(2024));
+    /// let tm = BrokenDownTime::parse("%g", "00")?;
+    /// assert_eq!(tm.iso_week_year(), Some(2000));
+    /// let tm = BrokenDownTime::parse("%g", "69")?;
+    /// assert_eq!(tm.iso_week_year(), Some(1969));
+    ///
+    /// // 2-digit years have limited range. They must
+    /// // be in the range 0-99.
+    /// assert!(BrokenDownTime::parse("%g", "2024").is_err());
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[inline]
+    pub fn iso_week_year(&self) -> Option<i16> {
+        self.iso_week_year.map(|x| x.get())
+    }
+
+    /// Returns the Sunday based week number.
+    ///
+    /// The week number returned is always in the range `0..=53`. Week `1`
+    /// begins on the first Sunday of the year. Any days in the year prior to
+    /// week `1` are in week `0`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::{civil::{Weekday, date}, fmt::strtime::BrokenDownTime};
+    ///
+    /// let tm = BrokenDownTime::parse("%Y-%U-%w", "2025-01-0")?;
+    /// assert_eq!(tm.year(), Some(2025));
+    /// assert_eq!(tm.sunday_based_week(), Some(1));
+    /// assert_eq!(tm.weekday(), Some(Weekday::Sunday));
+    /// assert_eq!(tm.to_date()?, date(2025, 1, 5));
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[inline]
+    pub fn sunday_based_week(&self) -> Option<i8> {
+        self.week_sun.map(|x| x.get())
+    }
+
+    /// Returns the Monday based week number.
+    ///
+    /// The week number returned is always in the range `0..=53`. Week `1`
+    /// begins on the first Monday of the year. Any days in the year prior to
+    /// week `1` are in week `0`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::{civil::{Weekday, date}, fmt::strtime::BrokenDownTime};
+    ///
+    /// let tm = BrokenDownTime::parse("%Y-%U-%w", "2025-01-1")?;
+    /// assert_eq!(tm.year(), Some(2025));
+    /// assert_eq!(tm.sunday_based_week(), Some(1));
+    /// assert_eq!(tm.weekday(), Some(Weekday::Monday));
+    /// assert_eq!(tm.to_date()?, date(2025, 1, 6));
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[inline]
+    pub fn monday_based_week(&self) -> Option<i8> {
+        self.week_mon.map(|x| x.get())
     }
 
     /// Returns the parsed hour, if available.
@@ -1534,6 +1844,137 @@ impl BrokenDownTime {
         Ok(())
     }
 
+    /// Set the day of year on this broken down time.
+    ///
+    /// # Errors
+    ///
+    /// This returns an error if the given day is out of range.
+    ///
+    /// Note that setting a day to a value that is legal in any context
+    /// is always valid, even if it isn't valid for the year, month and
+    /// day-of-month components already set.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::fmt::strtime::BrokenDownTime;
+    ///
+    /// let mut tm = BrokenDownTime::default();
+    /// // out of range
+    /// assert!(tm.set_day_of_year(Some(367)).is_err());
+    /// tm.set_day_of_year(Some(31))?;
+    /// assert_eq!(tm.to_string("%j")?, "031");
+    ///
+    /// // Works even if the resulting date is invalid.
+    /// let mut tm = BrokenDownTime::default();
+    /// tm.set_year(Some(2023))?;
+    /// tm.set_day_of_year(Some(366))?; // 2023 wasn't a leap year
+    /// assert_eq!(tm.to_string("%Y/%j")?, "2023/366");
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[inline]
+    pub fn set_day_of_year(&mut self, day: Option<i16>) -> Result<(), Error> {
+        self.day_of_year = match day {
+            None => None,
+            Some(day) => Some(t::DayOfYear::try_new("day-of-year", day)?),
+        };
+        Ok(())
+    }
+
+    /// Set the ISO 8601 week-based year on this broken down time.
+    ///
+    /// # Errors
+    ///
+    /// This returns an error if the given year is out of range.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::fmt::strtime::BrokenDownTime;
+    ///
+    /// let mut tm = BrokenDownTime::default();
+    /// // out of range
+    /// assert!(tm.set_iso_week_year(Some(10_000)).is_err());
+    /// tm.set_iso_week_year(Some(2024))?;
+    /// assert_eq!(tm.to_string("%G")?, "2024");
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[inline]
+    pub fn set_iso_week_year(
+        &mut self,
+        year: Option<i16>,
+    ) -> Result<(), Error> {
+        self.iso_week_year = match year {
+            None => None,
+            Some(year) => Some(t::ISOYear::try_new("year", year)?),
+        };
+        Ok(())
+    }
+
+    /// Set the Sunday based week number.
+    ///
+    /// The week number returned is always in the range `0..=53`. Week `1`
+    /// begins on the first Sunday of the year. Any days in the year prior to
+    /// week `1` are in week `0`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::fmt::strtime::BrokenDownTime;
+    ///
+    /// let mut tm = BrokenDownTime::default();
+    /// // out of range
+    /// assert!(tm.set_sunday_based_week(Some(56)).is_err());
+    /// tm.set_sunday_based_week(Some(9))?;
+    /// assert_eq!(tm.to_string("%U")?, "09");
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[inline]
+    pub fn set_sunday_based_week(
+        &mut self,
+        week_number: Option<i8>,
+    ) -> Result<(), Error> {
+        self.week_sun = match week_number {
+            None => None,
+            Some(wk) => Some(t::WeekNum::try_new("week-number", wk)?),
+        };
+        Ok(())
+    }
+
+    /// Set the Monday based week number.
+    ///
+    /// The week number returned is always in the range `0..=53`. Week `1`
+    /// begins on the first Monday of the year. Any days in the year prior to
+    /// week `1` are in week `0`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::fmt::strtime::BrokenDownTime;
+    ///
+    /// let mut tm = BrokenDownTime::default();
+    /// // out of range
+    /// assert!(tm.set_monday_based_week(Some(56)).is_err());
+    /// tm.set_monday_based_week(Some(9))?;
+    /// assert_eq!(tm.to_string("%W")?, "09");
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[inline]
+    pub fn set_monday_based_week(
+        &mut self,
+        week_number: Option<i8>,
+    ) -> Result<(), Error> {
+        self.week_mon = match week_number {
+            None => None,
+            Some(wk) => Some(t::WeekNum::try_new("week-number", wk)?),
+        };
+        Ok(())
+    }
+
     /// Set the hour on this broken down time.
     ///
     /// # Errors
@@ -1856,7 +2297,7 @@ impl<'a> From<&'a Zoned> for BrokenDownTime {
 
 impl From<Timestamp> for BrokenDownTime {
     fn from(ts: Timestamp) -> BrokenDownTime {
-        let dt = TimeZone::UTC.to_datetime(ts);
+        let dt = Offset::UTC.to_datetime(ts);
         BrokenDownTime {
             offset: Some(Offset::UTC),
             ..BrokenDownTime::from(dt)
@@ -1875,7 +2316,6 @@ impl From<DateTime> for BrokenDownTime {
             minute: Some(t.minute_ranged()),
             second: Some(t.second_ranged()),
             subsec: Some(t.subsec_nanosecond_ranged()),
-            weekday: Some(d.weekday()),
             meridiem: Some(Meridiem::from(t)),
             ..BrokenDownTime::default()
         }
@@ -1888,7 +2328,6 @@ impl From<Date> for BrokenDownTime {
             year: Some(d.year_ranged()),
             month: Some(d.month_ranged()),
             day: Some(d.day_ranged()),
-            weekday: Some(d.weekday()),
             ..BrokenDownTime::default()
         }
     }

--- a/src/fmt/strtime/mod.rs
+++ b/src/fmt/strtime/mod.rs
@@ -38,7 +38,7 @@ And this shows how to format a zoned datetime with a time zone abbreviation:
 ```
 use jiff::civil::date;
 
-let zdt = date(2024, 7, 15).at(17, 30, 59, 0).intz("Australia/Tasmania")?;
+let zdt = date(2024, 7, 15).at(17, 30, 59, 0).in_tz("Australia/Tasmania")?;
 // %-I instead of %I means no padding.
 let string = zdt.strftime("%A, %B %d, %Y at %-I:%M%P %Z").to_string();
 assert_eq!(string, "Monday, July 15, 2024 at 5:30pm AEST");
@@ -57,7 +57,7 @@ let zdt = Zoned::strptime(
 )?;
 assert_eq!(
     zdt,
-    date(2024, 7, 15).at(17, 30, 0, 0).intz("Australia/Tasmania")?,
+    date(2024, 7, 15).at(17, 30, 0, 0).in_tz("Australia/Tasmania")?,
 );
 
 # Ok::<(), Box<dyn std::error::Error>>(())
@@ -310,7 +310,7 @@ mod parse;
 /// )?.to_zoned()?;
 /// assert_eq!(
 ///     zdt,
-///     date(2024, 7, 15).at(16, 24, 59, 123_456_789).intz("America/New_York")?,
+///     date(2024, 7, 15).at(16, 24, 59, 123_456_789).in_tz("America/New_York")?,
 /// );
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -351,7 +351,7 @@ pub fn parse(
 /// ```
 /// use jiff::{civil::date, fmt::strtime, tz};
 ///
-/// let zdt = date(2024, 7, 15).at(16, 24, 59, 0).intz("America/New_York")?;
+/// let zdt = date(2024, 7, 15).at(16, 24, 59, 0).in_tz("America/New_York")?;
 /// let string = strtime::format("%a, %-d %b %Y %T %z", &zdt)?;
 /// assert_eq!(string, "Mon, 15 Jul 2024 16:24:59 -0400");
 ///
@@ -371,7 +371,7 @@ pub fn parse(
 /// ```
 /// use jiff::{civil::date, fmt::strtime, tz};
 ///
-/// let zdt = date(2024, 7, 15).at(16, 24, 59, 0).intz("America/New_York")?;
+/// let zdt = date(2024, 7, 15).at(16, 24, 59, 0).in_tz("America/New_York")?;
 /// let string = strtime::format("%a %b %e %I:%M:%S %p %Z %Y", &zdt)?;
 /// assert_eq!(string, "Mon Jul 15 04:24:59 PM EDT 2024");
 ///
@@ -385,7 +385,7 @@ pub fn parse(
 ///
 /// let zdt = date(2024, 7, 15)
 ///     .at(16, 24, 59, 123_456_789)
-///     .intz("America/New_York")?;
+///     .in_tz("America/New_York")?;
 /// let string = strtime::format("%Y-%m-%dT%H:%M:%S%.f%:z", &zdt)?;
 /// assert_eq!(string, "2024-07-15T16:24:59.123456789-04:00");
 ///
@@ -556,7 +556,7 @@ impl BrokenDownTime {
     /// ```
     /// use jiff::{civil::date, fmt::strtime::BrokenDownTime};
     ///
-    /// let zdt = date(2024, 7, 9).at(16, 24, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 7, 9).at(16, 24, 0, 0).in_tz("America/New_York")?;
     /// let tm = BrokenDownTime::from(&zdt);
     ///
     /// let mut buf = String::new();
@@ -606,7 +606,7 @@ impl BrokenDownTime {
     /// ```
     /// use jiff::{civil::date, fmt::strtime::BrokenDownTime};
     ///
-    /// let zdt = date(2024, 7, 9).at(16, 24, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 7, 9).at(16, 24, 0, 0).in_tz("America/New_York")?;
     /// let tm = BrokenDownTime::from(&zdt);
     /// let string = tm.to_string("%a %b %e %I:%M:%S %p %Z %Y")?;
     /// assert_eq!(string, "Tue Jul  9 04:24:00 PM EDT 2024");
@@ -1694,7 +1694,7 @@ impl BrokenDownTime {
     /// ```
     /// use jiff::{civil::date, fmt::strtime::BrokenDownTime, tz};
     ///
-    /// let zdt = date(2024, 8, 28).at(14, 56, 0, 0).intz("US/Eastern")?;
+    /// let zdt = date(2024, 8, 28).at(14, 56, 0, 0).in_tz("US/Eastern")?;
     /// let mut tm = BrokenDownTime::from(&zdt);
     /// tm.set_offset(Some(tz::offset(12)));
     /// assert_eq!(
@@ -1753,7 +1753,7 @@ impl BrokenDownTime {
     /// ```
     /// use jiff::{civil::date, fmt::strtime::BrokenDownTime, tz};
     ///
-    /// let zdt = date(2024, 8, 28).at(14, 56, 0, 0).intz("US/Eastern")?;
+    /// let zdt = date(2024, 8, 28).at(14, 56, 0, 0).in_tz("US/Eastern")?;
     /// let mut tm = BrokenDownTime::from(&zdt);
     /// tm.set_iana_time_zone(Some(String::from("Australia/Tasmania")));
     /// assert_eq!(
@@ -1937,7 +1937,7 @@ impl From<Time> for BrokenDownTime {
 /// ```
 /// use jiff::{civil::date, fmt::strtime, tz};
 ///
-/// let zdt = date(2024, 7, 15).at(16, 24, 59, 0).intz("America/New_York")?;
+/// let zdt = date(2024, 7, 15).at(16, 24, 59, 0).in_tz("America/New_York")?;
 /// let string = zdt.strftime("%a, %-d %b %Y %T %z").to_string();
 /// assert_eq!(string, "Mon, 15 Jul 2024 16:24:59 -0400");
 ///
@@ -1949,7 +1949,7 @@ impl From<Time> for BrokenDownTime {
 /// ```
 /// use jiff::{civil::date, fmt::strtime, tz};
 ///
-/// let zdt = date(2024, 7, 15).at(16, 24, 59, 0).intz("America/New_York")?;
+/// let zdt = date(2024, 7, 15).at(16, 24, 59, 0).in_tz("America/New_York")?;
 ///
 /// let string = format!("the date is: {}", zdt.strftime("%-m/%-d/%-Y"));
 /// assert_eq!(string, "the date is: 7/15/2024");

--- a/src/fmt/strtime/parse.rs
+++ b/src/fmt/strtime/parse.rs
@@ -10,7 +10,7 @@ use crate::{
         rangeint::{ri8, RFrom},
         t::{self, C},
     },
-    Error,
+    Error, Timestamp,
 };
 
 // Custom offset value ranges. They're the same as what we use for `Offset`,
@@ -56,24 +56,38 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
                 b'a' => self.parse_weekday_abbrev().context("%a failed")?,
                 b'B' => self.parse_month_name_full().context("%B failed")?,
                 b'b' => self.parse_month_name_abbrev().context("%b failed")?,
+                b'C' => self.parse_century(ext).context("%C failed")?,
                 b'D' => self.parse_american_date().context("%D failed")?,
                 b'd' => self.parse_day(ext).context("%d failed")?,
                 b'e' => self.parse_day(ext).context("%e failed")?,
                 b'F' => self.parse_iso_date().context("%F failed")?,
                 b'f' => self.parse_fractional(ext).context("%f failed")?,
-                b'H' => self.parse_hour(ext).context("%H failed")?,
+                b'G' => self.parse_iso_week_year(ext).context("%G failed")?,
+                b'g' => self.parse_iso_week_year2(ext).context("%g failed")?,
+                b'H' => self.parse_hour24(ext).context("%H failed")?,
                 b'h' => self.parse_month_name_abbrev().context("%h failed")?,
                 b'I' => self.parse_hour12(ext).context("%I failed")?,
+                b'j' => self.parse_day_of_year(ext).context("%j failed")?,
+                b'k' => self.parse_hour24(ext).context("%k failed")?,
+                b'l' => self.parse_hour12(ext).context("%l failed")?,
                 b'M' => self.parse_minute(ext).context("%M failed")?,
                 b'm' => self.parse_month(ext).context("%m failed")?,
+                b'n' => self.parse_whitespace().context("%n failed")?,
                 b'P' => self.parse_ampm().context("%P failed")?,
                 b'p' => self.parse_ampm().context("%p failed")?,
                 b'Q' => self.parse_iana_nocolon(b'Q').context("%Q failed")?,
+                b'R' => self.parse_clock_nosecs().context("%R failed")?,
                 b'S' => self.parse_second(ext).context("%S failed")?,
-                b'T' => self.parse_clock().context("%T failed")?,
+                b's' => self.parse_timestamp(ext).context("%s failed")?,
+                b'T' => self.parse_clock_secs().context("%T failed")?,
+                b't' => self.parse_whitespace().context("%t failed")?,
+                b'U' => self.parse_week_sun(ext).context("%U failed")?,
+                b'u' => self.parse_weekday_mon(ext).context("%u failed")?,
                 b'V' => self.parse_iana_nocolon(b'V').context("%V failed")?,
+                b'W' => self.parse_week_mon(ext).context("%W failed")?,
+                b'w' => self.parse_weekday_sun(ext).context("%w failed")?,
                 b'Y' => self.parse_year(ext).context("%Y failed")?,
-                b'y' => self.parse_year_2digit(ext).context("%y failed")?,
+                b'y' => self.parse_year2(ext).context("%y failed")?,
                 b'z' => self.parse_offset_nocolon().context("%z failed")?,
                 b':' => {
                     if !self.bump_fmt() {
@@ -222,6 +236,17 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
         Ok(())
     }
 
+    /// Parses an arbitrary (zero or more) amount ASCII whitespace.
+    ///
+    /// This is for `%n` and `%t`.
+    fn parse_whitespace(&mut self) -> Result<(), Error> {
+        if !self.inp.is_empty() {
+            while self.i().is_ascii_whitespace() && self.bump_input() {}
+        }
+        self.bump_fmt();
+        Ok(())
+    }
+
     /// Parses a literal '%' from the input.
     fn parse_percent(&mut self) -> Result<(), Error> {
         if self.i() != b'%' {
@@ -265,8 +290,17 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
     }
 
     /// Parses `%T`, which is equivalent to `%H:%M:%S`.
-    fn parse_clock(&mut self) -> Result<(), Error> {
+    fn parse_clock_secs(&mut self) -> Result<(), Error> {
         let mut p = Parser { fmt: b"%H:%M:%S", inp: self.inp, tm: self.tm };
+        p.parse()?;
+        self.inp = p.inp;
+        self.bump_fmt();
+        Ok(())
+    }
+
+    /// Parses `%R`, which is equivalent to `%H:%M`.
+    fn parse_clock_nosecs(&mut self) -> Result<(), Error> {
+        let mut p = Parser { fmt: b"%H:%M", inp: self.inp, tm: self.tm };
         p.parse()?;
         self.inp = p.inp;
         self.bump_fmt();
@@ -275,8 +309,7 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
 
     /// Parses `%d` and `%e`, which is equivalent to the day of the month.
     ///
-    /// We merely require that it is in the range 1-31 here. It isn't
-    /// validated as an actual date until `Pieces` is used.
+    /// We merely require that it is in the range 1-31 here.
     fn parse_day(&mut self, ext: Extension) -> Result<(), Error> {
         let (day, inp) = ext
             .parse_number(2, Flag::PadZero, self.inp)
@@ -290,8 +323,24 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
         Ok(())
     }
 
+    /// Parses `%j`, which is equivalent to the day of the year.
+    ///
+    /// We merely require that it is in the range 1-366 here.
+    fn parse_day_of_year(&mut self, ext: Extension) -> Result<(), Error> {
+        let (day, inp) = ext
+            .parse_number(3, Flag::PadZero, self.inp)
+            .context("failed to parse day of year")?;
+        self.inp = inp;
+
+        let day = t::DayOfYear::try_new("day-of-year", day)
+            .context("day of year number is invalid")?;
+        self.tm.day_of_year = Some(day);
+        self.bump_fmt();
+        Ok(())
+    }
+
     /// Parses `%H`, which is equivalent to the hour.
-    fn parse_hour(&mut self, ext: Extension) -> Result<(), Error> {
+    fn parse_hour24(&mut self, ext: Extension) -> Result<(), Error> {
         let (hour, inp) = ext
             .parse_number(2, Flag::PadZero, self.inp)
             .context("failed to parse hour")?;
@@ -567,6 +616,50 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
         Ok(())
     }
 
+    /// Parses `%s`, which is equivalent to a Unix timestamp.
+    fn parse_timestamp(&mut self, ext: Extension) -> Result<(), Error> {
+        let (sign, inp) = parse_optional_sign(self.inp);
+        let (timestamp, inp) = ext
+            // 19 comes from `i64::MAX.to_string().len()`.
+            .parse_number(19, Flag::PadSpace, inp)
+            .context("failed to parse Unix timestamp (in seconds)")?;
+        // I believe this error case is actually impossible. Since `timestamp`
+        // is guaranteed to be positive, and negating any positive `i64` will
+        // always result in a valid `i64`.
+        let timestamp = timestamp.checked_mul(sign).ok_or_else(|| {
+            err!(
+                "parsed Unix timestamp `{timestamp}` with a \
+                 leading `-` sign, which causes overflow",
+            )
+        })?;
+        let timestamp =
+            Timestamp::from_second(timestamp).with_context(|| {
+                err!(
+                    "parsed Unix timestamp `{timestamp}`, \
+                     but out of range of valid Jiff `Timestamp`",
+                )
+            })?;
+        self.inp = inp;
+
+        // This is basically just repeating the
+        // `From<Timestamp> for BrokenDownTime`
+        // trait implementation.
+        let dt = Offset::UTC.to_datetime(timestamp);
+        let (d, t) = (dt.date(), dt.time());
+        self.tm.offset = Some(Offset::UTC);
+        self.tm.year = Some(d.year_ranged());
+        self.tm.month = Some(d.month_ranged());
+        self.tm.day = Some(d.day_ranged());
+        self.tm.hour = Some(t.hour_ranged());
+        self.tm.minute = Some(t.minute_ranged());
+        self.tm.second = Some(t.second_ranged());
+        self.tm.subsec = Some(t.subsec_nanosecond_ranged());
+        self.tm.meridiem = Some(Meridiem::from(t));
+
+        self.bump_fmt();
+        Ok(())
+    }
+
     /// Parses `%f`, which is equivalent to a fractional second up to
     /// nanosecond precision. This must always parse at least one decimal digit
     /// and does not parse any leading dot.
@@ -714,6 +807,71 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
         Ok(())
     }
 
+    /// Parse `%u`, which is a weekday number with Monday being `1` and
+    /// Sunday being `7`.
+    fn parse_weekday_mon(&mut self, ext: Extension) -> Result<(), Error> {
+        let (weekday, inp) = ext
+            .parse_number(1, Flag::NoPad, self.inp)
+            .context("failed to parse weekday number")?;
+        self.inp = inp;
+
+        let weekday = i8::try_from(weekday).map_err(|_| {
+            err!("parsed weekday number `{weekday}` is invalid")
+        })?;
+        let weekday = Weekday::from_monday_one_offset(weekday)
+            .context("weekday number is invalid")?;
+        self.tm.weekday = Some(weekday);
+        self.bump_fmt();
+        Ok(())
+    }
+
+    /// Parse `%w`, which is a weekday number with Sunday being `0`.
+    fn parse_weekday_sun(&mut self, ext: Extension) -> Result<(), Error> {
+        let (weekday, inp) = ext
+            .parse_number(1, Flag::NoPad, self.inp)
+            .context("failed to parse weekday number")?;
+        self.inp = inp;
+
+        let weekday = i8::try_from(weekday).map_err(|_| {
+            err!("parsed weekday number `{weekday}` is invalid")
+        })?;
+        let weekday = Weekday::from_sunday_zero_offset(weekday)
+            .context("weekday number is invalid")?;
+        self.tm.weekday = Some(weekday);
+        self.bump_fmt();
+        Ok(())
+    }
+
+    /// Parse `%U`, which is a week number with Sunday being the first day
+    /// in the first week numbered `01`.
+    fn parse_week_sun(&mut self, ext: Extension) -> Result<(), Error> {
+        let (week, inp) = ext
+            .parse_number(2, Flag::PadZero, self.inp)
+            .context("failed to parse Sunday-based week number")?;
+        self.inp = inp;
+
+        let week = t::WeekNum::try_new("week", week)
+            .context("Sunday-based week number is invalid")?;
+        self.tm.week_sun = Some(week);
+        self.bump_fmt();
+        Ok(())
+    }
+
+    /// Parse `%W`, which is a week number with Monday being the first day
+    /// in the first week numbered `01`.
+    fn parse_week_mon(&mut self, ext: Extension) -> Result<(), Error> {
+        let (week, inp) = ext
+            .parse_number(2, Flag::PadZero, self.inp)
+            .context("failed to parse Monday-based week number")?;
+        self.inp = inp;
+
+        let week = t::WeekNum::try_new("week", week)
+            .context("Monday-based week number is invalid")?;
+        self.tm.week_mon = Some(week);
+        self.bump_fmt();
+        Ok(())
+    }
+
     /// Parses `%Y`, which we permit to be any year, including a negative year.
     fn parse_year(&mut self, ext: Extension) -> Result<(), Error> {
         let (sign, inp) = parse_optional_sign(self.inp);
@@ -735,7 +893,7 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
     /// Parses `%y`, which is equivalent to a 2-digit year.
     ///
     /// The numbers 69-99 refer to 1969-1999, while 00-68 refer to 2000-2068.
-    fn parse_year_2digit(&mut self, ext: Extension) -> Result<(), Error> {
+    fn parse_year2(&mut self, ext: Extension) -> Result<(), Error> {
         type Year2Digit = ri8<0, 99>;
 
         let (year, inp) = ext
@@ -752,6 +910,71 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
             year += C(1900);
         }
         self.tm.year = Some(year);
+        self.bump_fmt();
+        Ok(())
+    }
+
+    /// Parses `%C`, which we permit to just be a century, including a negative
+    /// century.
+    fn parse_century(&mut self, ext: Extension) -> Result<(), Error> {
+        let (sign, inp) = parse_optional_sign(self.inp);
+        let (century, inp) = ext
+            .parse_number(2, Flag::NoPad, inp)
+            .context("failed to parse century")?;
+        self.inp = inp;
+
+        // OK because sign=={1,-1} and century can't be bigger than 2 digits
+        // so overflow isn't possible.
+        let century = sign.checked_mul(century).unwrap();
+        // Similarly, we have 64-bit integers here. Two digits multiplied by
+        // 100 will never overflow.
+        let year = century.checked_mul(100).unwrap();
+        // I believe the error condition here is impossible.
+        let year = t::Year::try_new("year", year)
+            .context("year number (from century) is invalid")?;
+        self.tm.year = Some(year);
+        self.bump_fmt();
+        Ok(())
+    }
+
+    /// Parses `%G`, which we permit to be any year, including a negative year.
+    fn parse_iso_week_year(&mut self, ext: Extension) -> Result<(), Error> {
+        let (sign, inp) = parse_optional_sign(self.inp);
+        let (year, inp) = ext
+            .parse_number(4, Flag::PadZero, inp)
+            .context("failed to parse ISO 8601 week-based year")?;
+        self.inp = inp;
+
+        // OK because sign=={1,-1} and year can't be bigger than 4 digits
+        // so overflow isn't possible.
+        let year = sign.checked_mul(year).unwrap();
+        let year = t::ISOYear::try_new("year", year)
+            .context("ISO 8601 week-based year number is invalid")?;
+        self.tm.iso_week_year = Some(year);
+        self.bump_fmt();
+        Ok(())
+    }
+
+    /// Parses `%g`, which is equivalent to a 2-digit ISO 8601 week-based year.
+    ///
+    /// The numbers 69-99 refer to 1969-1999, while 00-68 refer to 2000-2068.
+    fn parse_iso_week_year2(&mut self, ext: Extension) -> Result<(), Error> {
+        type Year2Digit = ri8<0, 99>;
+
+        let (year, inp) = ext
+            .parse_number(2, Flag::PadZero, self.inp)
+            .context("failed to parse 2-digit ISO 8601 week-based year")?;
+        self.inp = inp;
+
+        let year = Year2Digit::try_new("year (2 digits)", year)
+            .context("ISO 8601 week-based year number is invalid")?;
+        let mut year = t::ISOYear::rfrom(year);
+        if year <= 68 {
+            year += C(2000);
+        } else {
+            year += C(1900);
+        }
+        self.tm.iso_week_year = Some(year);
         self.bump_fmt();
         Ok(())
     }
@@ -778,7 +1001,7 @@ impl Extension {
         self,
         default_pad_width: usize,
         default_flag: Flag,
-        inp: &'i [u8],
+        mut inp: &'i [u8],
     ) -> Result<(i64, &'i [u8]), Error> {
         let flag = self.flag.unwrap_or(default_flag);
         let zero_pad_width = match flag {
@@ -787,6 +1010,10 @@ impl Extension {
         };
         let max_digits = default_pad_width.max(zero_pad_width);
 
+        // Strip and ignore any whitespace we might see here.
+        while inp.get(0).map_or(false, |b| b.is_ascii_whitespace()) {
+            inp = &inp[1..];
+        }
         let mut digits = 0;
         while digits < inp.len()
             && digits < zero_pad_width
@@ -1147,6 +1374,39 @@ mod tests {
             p("%h %d, %Y %H:%M:%S %:z", "Apr 1, 2022 20:46:15 -04:00:59"),
             @"2022-04-02T00:47:14Z",
         );
+
+        insta::assert_debug_snapshot!(
+            p("%s", "0"),
+            @"1970-01-01T00:00:00Z",
+        );
+        insta::assert_debug_snapshot!(
+            p("%s", "-0"),
+            @"1970-01-01T00:00:00Z",
+        );
+        insta::assert_debug_snapshot!(
+            p("%s", "-1"),
+            @"1969-12-31T23:59:59Z",
+        );
+        insta::assert_debug_snapshot!(
+            p("%s", "1"),
+            @"1970-01-01T00:00:01Z",
+        );
+        insta::assert_debug_snapshot!(
+            p("%s", "+1"),
+            @"1970-01-01T00:00:01Z",
+        );
+        insta::assert_debug_snapshot!(
+            p("%s", "1737396540"),
+            @"2025-01-20T18:09:00Z",
+        );
+        insta::assert_debug_snapshot!(
+            p("%s", "-377705023201"),
+            @"-009999-01-02T01:59:59Z",
+        );
+        insta::assert_debug_snapshot!(
+            p("%s", "253402207200"),
+            @"9999-12-30T22:00:00Z",
+        );
     }
 
     #[test]
@@ -1250,6 +1510,78 @@ mod tests {
             p("%5Y%m%d", "009990111"),
             @"0999-01-11",
         );
+
+        insta::assert_debug_snapshot!(
+            p("%C-%m-%d", "20-07-01"),
+            @"2000-07-01",
+        );
+        insta::assert_debug_snapshot!(
+            p("%C-%m-%d", "-20-07-01"),
+            @"-002000-07-01",
+        );
+        insta::assert_debug_snapshot!(
+            p("%C-%m-%d", "9-07-01"),
+            @"0900-07-01",
+        );
+        insta::assert_debug_snapshot!(
+            p("%C-%m-%d", "-9-07-01"),
+            @"-000900-07-01",
+        );
+        insta::assert_debug_snapshot!(
+            p("%C-%m-%d", "09-07-01"),
+            @"0900-07-01",
+        );
+        insta::assert_debug_snapshot!(
+            p("%C-%m-%d", "-09-07-01"),
+            @"-000900-07-01",
+        );
+        insta::assert_debug_snapshot!(
+            p("%C-%m-%d", "0-07-01"),
+            @"0000-07-01",
+        );
+        insta::assert_debug_snapshot!(
+            p("%C-%m-%d", "-0-07-01"),
+            @"0000-07-01",
+        );
+
+        insta::assert_snapshot!(
+            p("%u %m/%d/%Y", "7 7/14/2024"),
+            @"2024-07-14",
+        );
+        insta::assert_snapshot!(
+            p("%w %m/%d/%Y", "0 7/14/2024"),
+            @"2024-07-14",
+        );
+
+        insta::assert_snapshot!(
+            p("%Y-%U-%u", "2025-00-6"),
+            @"2025-01-04",
+        );
+        insta::assert_snapshot!(
+            p("%Y-%U-%u", "2025-01-7"),
+            @"2025-01-05",
+        );
+        insta::assert_snapshot!(
+            p("%Y-%U-%u", "2025-01-1"),
+            @"2025-01-06",
+        );
+
+        insta::assert_snapshot!(
+            p("%Y-%W-%u", "2025-00-6"),
+            @"2025-01-04",
+        );
+        insta::assert_snapshot!(
+            p("%Y-%W-%u", "2025-00-7"),
+            @"2025-01-05",
+        );
+        insta::assert_snapshot!(
+            p("%Y-%W-%u", "2025-01-1"),
+            @"2025-01-06",
+        );
+        insta::assert_snapshot!(
+            p("%Y-%W-%u", "2025-01-2"),
+            @"2025-01-07",
+        );
     }
 
     #[test]
@@ -1261,10 +1593,6 @@ mod tests {
                 .unwrap()
         };
 
-        insta::assert_debug_snapshot!(
-            p("%H", "15"),
-            @"15:00:00",
-        );
         insta::assert_debug_snapshot!(
             p("%H:%M", "15:48"),
             @"15:48:00",
@@ -1280,6 +1608,10 @@ mod tests {
         insta::assert_debug_snapshot!(
             p("%T", "15:48:59"),
             @"15:48:59",
+        );
+        insta::assert_debug_snapshot!(
+            p("%R", "15:48"),
+            @"15:48:00",
         );
 
         insta::assert_debug_snapshot!(
@@ -1351,6 +1683,95 @@ mod tests {
         insta::assert_debug_snapshot!(
             p("%H:%M:%S.%3f", "15:48:01.123456"),
             @"15:48:01.123456",
+        );
+
+        insta::assert_debug_snapshot!(
+            p("%H", "09"),
+            @"09:00:00",
+        );
+        insta::assert_debug_snapshot!(
+            p("%H", " 9"),
+            @"09:00:00",
+        );
+        insta::assert_debug_snapshot!(
+            p("%H", "15"),
+            @"15:00:00",
+        );
+        insta::assert_debug_snapshot!(
+            p("%k", "09"),
+            @"09:00:00",
+        );
+        insta::assert_debug_snapshot!(
+            p("%k", " 9"),
+            @"09:00:00",
+        );
+        insta::assert_debug_snapshot!(
+            p("%k", "15"),
+            @"15:00:00",
+        );
+
+        insta::assert_debug_snapshot!(
+            p("%I", "09"),
+            @"09:00:00",
+        );
+        insta::assert_debug_snapshot!(
+            p("%I", " 9"),
+            @"09:00:00",
+        );
+        insta::assert_debug_snapshot!(
+            p("%l", "09"),
+            @"09:00:00",
+        );
+        insta::assert_debug_snapshot!(
+            p("%l", " 9"),
+            @"09:00:00",
+        );
+    }
+
+    #[test]
+    fn ok_parse_whitespace() {
+        let p = |fmt: &str, input: &str| {
+            BrokenDownTime::parse_mono(fmt.as_bytes(), input.as_bytes())
+                .unwrap()
+                .to_time()
+                .unwrap()
+        };
+
+        insta::assert_debug_snapshot!(
+            p("%H%M", "1548"),
+            @"15:48:00",
+        );
+        insta::assert_debug_snapshot!(
+            p("%H%M", "15\n48"),
+            @"15:48:00",
+        );
+        insta::assert_debug_snapshot!(
+            p("%H%M", "15\t48"),
+            @"15:48:00",
+        );
+        insta::assert_debug_snapshot!(
+            p("%H%n%M", "1548"),
+            @"15:48:00",
+        );
+        insta::assert_debug_snapshot!(
+            p("%H%n%M", "15\n48"),
+            @"15:48:00",
+        );
+        insta::assert_debug_snapshot!(
+            p("%H%n%M", "15\t48"),
+            @"15:48:00",
+        );
+        insta::assert_debug_snapshot!(
+            p("%H%t%M", "1548"),
+            @"15:48:00",
+        );
+        insta::assert_debug_snapshot!(
+            p("%H%t%M", "15\n48"),
+            @"15:48:00",
+        );
+        insta::assert_debug_snapshot!(
+            p("%H%t%M", "15\t48"),
+            @"15:48:00",
         );
     }
 
@@ -1510,6 +1931,40 @@ mod tests {
             p("%Q", "America/+"),
             @r###"strptime parsing failed: %Q failed: expected the start of an IANA time zone identifier name or component, but found "+" instead"###,
         );
+
+        insta::assert_snapshot!(
+            p("%s", "-377705023202"),
+            @"strptime parsing failed: %s failed: parsed Unix timestamp `-377705023202`, but out of range of valid Jiff `Timestamp`: parameter 'second' with value -377705023202 is not in the required range of -377705023201..=253402207200",
+        );
+        insta::assert_snapshot!(
+            p("%s", "253402207201"),
+            @"strptime parsing failed: %s failed: parsed Unix timestamp `253402207201`, but out of range of valid Jiff `Timestamp`: parameter 'second' with value 253402207201 is not in the required range of -377705023201..=253402207200",
+        );
+        insta::assert_snapshot!(
+            p("%s", "-9999999999999999999"),
+            @"strptime parsing failed: %s failed: failed to parse Unix timestamp (in seconds): number '9999999999999999999' too big to parse into 64-bit integer",
+        );
+        insta::assert_snapshot!(
+            p("%s", "9999999999999999999"),
+            @"strptime parsing failed: %s failed: failed to parse Unix timestamp (in seconds): number '9999999999999999999' too big to parse into 64-bit integer",
+        );
+
+        insta::assert_snapshot!(
+            p("%u", "0"),
+            @"strptime parsing failed: %u failed: weekday number is invalid: parameter 'weekday' with value 0 is not in the required range of 1..=7",
+        );
+        insta::assert_snapshot!(
+            p("%w", "7"),
+            @"strptime parsing failed: %w failed: weekday number is invalid: parameter 'weekday' with value 7 is not in the required range of 0..=6",
+        );
+        insta::assert_snapshot!(
+            p("%u", "128"),
+            @r###"strptime expects to consume the entire input, but "28" remains unparsed"###,
+        );
+        insta::assert_snapshot!(
+            p("%w", "128"),
+            @r###"strptime expects to consume the entire input, but "28" remains unparsed"###,
+        );
     }
 
     #[test]
@@ -1524,27 +1979,27 @@ mod tests {
 
         insta::assert_snapshot!(
             p("%Y", "2024"),
-            @"parsing format did not include month directive, without it, a date cannot be created",
+            @"a month/day, day-of-year or week date must be present to create a date, but none were found",
         );
         insta::assert_snapshot!(
             p("%m", "7"),
-            @"parsing format did not include year directive, without it, a date cannot be created",
+            @"missing year, date cannot be created",
         );
         insta::assert_snapshot!(
             p("%d", "25"),
-            @"parsing format did not include year directive, without it, a date cannot be created",
+            @"missing year, date cannot be created",
         );
         insta::assert_snapshot!(
             p("%Y-%m", "2024-7"),
-            @"parsing format did not include day directive, without it, a date cannot be created",
+            @"a month/day, day-of-year or week date must be present to create a date, but none were found",
         );
         insta::assert_snapshot!(
             p("%Y-%d", "2024-25"),
-            @"parsing format did not include month directive, without it, a date cannot be created",
+            @"a month/day, day-of-year or week date must be present to create a date, but none were found",
         );
         insta::assert_snapshot!(
             p("%m-%d", "7-25"),
-            @"parsing format did not include year directive, without it, a date cannot be created",
+            @"missing year, date cannot be created",
         );
 
         insta::assert_snapshot!(
@@ -1562,6 +2017,15 @@ mod tests {
         insta::assert_snapshot!(
             p("%A %m/%d/%y", "Monday 7/14/24"),
             @"parsed weekday Monday does not match weekday Sunday from parsed date 2024-07-14",
+        );
+
+        insta::assert_snapshot!(
+            p("%Y-%U-%u", "2025-00-2"),
+            @"weekday `Tuesday` is not valid for Sunday based week number `0` in year `2025`",
+        );
+        insta::assert_snapshot!(
+            p("%Y-%W-%u", "2025-00-2"),
+            @"weekday `Tuesday` is not valid for Monday based week number `0` in year `2025`",
         );
     }
 

--- a/src/fmt/temporal/mod.rs
+++ b/src/fmt/temporal/mod.rs
@@ -106,7 +106,11 @@ let spans = [
 ];
 for (string, span) in spans {
     let parsed: Span = string.parse()?;
-    assert_eq!(span, parsed, "result of parsing {string:?}");
+    assert_eq!(
+        span.fieldwise(),
+        parsed.fieldwise(),
+        "result of parsing {string:?}",
+    );
 }
 
 # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1640,7 +1644,10 @@ impl DateTimePrinter {
 /// static PARSER: SpanParser = SpanParser::new();
 ///
 /// let span = PARSER.parse_span(b"P3y7m25dT7h36m")?;
-/// assert_eq!(span, 3.years().months(7).days(25).hours(7).minutes(36));
+/// assert_eq!(
+///     span,
+///     3.years().months(7).days(25).hours(7).minutes(36).fieldwise(),
+/// );
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
@@ -1673,7 +1680,7 @@ impl SpanParser {
     /// static PARSER: SpanParser = SpanParser::new();
     ///
     /// let span = PARSER.parse_span(b"PT48m")?;
-    /// assert_eq!(span, 48.minutes());
+    /// assert_eq!(span, 48.minutes().fieldwise());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -1687,7 +1694,7 @@ impl SpanParser {
     /// use jiff::{Span, ToSpan};
     ///
     /// let span = "PT48m".parse::<Span>()?;
-    /// assert_eq!(span, 48.minutes());
+    /// assert_eq!(span, 48.minutes().fieldwise());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```

--- a/src/fmt/temporal/mod.rs
+++ b/src/fmt/temporal/mod.rs
@@ -913,7 +913,7 @@ impl DateTimeParser {
 /// // A printer can be created in a const context.
 /// const PRINTER: DateTimePrinter = DateTimePrinter::new().separator(b' ');
 ///
-/// let zdt = date(2024, 6, 15).at(7, 0, 0, 123456789).intz("America/New_York")?;
+/// let zdt = date(2024, 6, 15).at(7, 0, 0, 123456789).in_tz("America/New_York")?;
 ///
 /// let mut buf = String::new();
 /// // Printing to a `String` can never fail.
@@ -937,7 +937,7 @@ impl DateTimeParser {
 ///
 /// use jiff::{civil::date, fmt::{StdIoWrite, temporal::DateTimePrinter}};
 ///
-/// let zdt = date(2024, 6, 15).at(7, 0, 0, 0).intz("America/New_York")?;
+/// let zdt = date(2024, 6, 15).at(7, 0, 0, 0).in_tz("America/New_York")?;
 ///
 /// let path = Path::new("/tmp/output");
 /// let mut file = BufWriter::new(File::create(path)?);
@@ -975,7 +975,7 @@ impl DateTimePrinter {
     ///
     /// const PRINTER: DateTimePrinter = DateTimePrinter::new().lowercase(true);
     ///
-    /// let zdt = date(2024, 6, 15).at(7, 0, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 6, 15).at(7, 0, 0, 0).in_tz("America/New_York")?;
     ///
     /// let mut buf = String::new();
     /// // Printing to a `String` can never fail.
@@ -1007,7 +1007,7 @@ impl DateTimePrinter {
     /// // use this method with an ASCII space.
     /// const PRINTER: DateTimePrinter = DateTimePrinter::new().separator(b'~');
     ///
-    /// let zdt = date(2024, 6, 15).at(7, 0, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 6, 15).at(7, 0, 0, 0).in_tz("America/New_York")?;
     ///
     /// let mut buf = String::new();
     /// // Printing to a `String` can never fail.
@@ -1040,7 +1040,7 @@ impl DateTimePrinter {
     /// const PRINTER: DateTimePrinter =
     ///     DateTimePrinter::new().precision(Some(3));
     ///
-    /// let zdt = date(2024, 6, 15).at(7, 0, 0, 123_456_789).intz("US/Eastern")?;
+    /// let zdt = date(2024, 6, 15).at(7, 0, 0, 123_456_789).in_tz("US/Eastern")?;
     ///
     /// let mut buf = String::new();
     /// // Printing to a `String` can never fail.
@@ -1059,7 +1059,7 @@ impl DateTimePrinter {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt = date(2024, 6, 15).at(7, 0, 0, 123_000_000).intz("US/Eastern")?;
+    /// let zdt = date(2024, 6, 15).at(7, 0, 0, 123_000_000).in_tz("US/Eastern")?;
     /// assert_eq!(
     ///     format!("{zdt:.6}"),
     ///     "2024-06-15T07:00:00.123000-04:00[US/Eastern]",
@@ -1099,7 +1099,7 @@ impl DateTimePrinter {
     ///
     /// const PRINTER: DateTimePrinter = DateTimePrinter::new();
     ///
-    /// let zdt = date(2024, 6, 15).at(7, 0, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 6, 15).at(7, 0, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(
     ///     PRINTER.zoned_to_string(&zdt),
     ///     "2024-06-15T07:00:00-04:00[America/New_York]",
@@ -1351,7 +1351,7 @@ impl DateTimePrinter {
     ///
     /// const PRINTER: DateTimePrinter = DateTimePrinter::new();
     ///
-    /// let zdt = date(2024, 6, 15).at(7, 0, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 6, 15).at(7, 0, 0, 0).in_tz("America/New_York")?;
     ///
     /// let mut buf = String::new();
     /// // Printing to a `String` can never fail.

--- a/src/fmt/temporal/pieces.rs
+++ b/src/fmt/temporal/pieces.rs
@@ -810,7 +810,10 @@ impl<'n> Pieces<'n> {
     /// use jiff::{Timestamp, ToSpan, Unit};
     ///
     /// let ts: Timestamp = "1970-01-01T00:00:00-05:00".parse()?;
-    /// assert_eq!(ts.since((Unit::Hour, Timestamp::UNIX_EPOCH))?, 5.hours());
+    /// assert_eq!(
+    ///     ts.since((Unit::Hour, Timestamp::UNIX_EPOCH))?,
+    ///     5.hours().fieldwise(),
+    /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```

--- a/src/fmt/temporal/printer.rs
+++ b/src/fmt/temporal/printer.rs
@@ -493,13 +493,13 @@ mod tests {
         }
 
         let dt = date(2024, 3, 10).at(5, 34, 45, 0);
-        let zoned: Zoned = dt.intz("America/New_York").unwrap();
+        let zoned: Zoned = dt.in_tz("America/New_York").unwrap();
         let mut buf = String::new();
         DateTimePrinter::new().print_zoned(&zoned, &mut buf).unwrap();
         assert_eq!(buf, "2024-03-10T05:34:45-04:00[America/New_York]");
 
         let dt = date(2024, 3, 10).at(5, 34, 45, 0);
-        let zoned: Zoned = dt.intz("America/New_York").unwrap();
+        let zoned: Zoned = dt.in_tz("America/New_York").unwrap();
         let zoned = zoned.with_time_zone(TimeZone::UTC);
         let mut buf = String::new();
         DateTimePrinter::new().print_zoned(&zoned, &mut buf).unwrap();
@@ -513,7 +513,7 @@ mod tests {
         }
 
         let dt = date(2024, 3, 10).at(5, 34, 45, 0);
-        let zoned: Zoned = dt.intz("America/New_York").unwrap();
+        let zoned: Zoned = dt.in_tz("America/New_York").unwrap();
         let mut buf = String::new();
         DateTimePrinter::new()
             .print_timestamp(&zoned.timestamp(), None, &mut buf)
@@ -521,7 +521,7 @@ mod tests {
         assert_eq!(buf, "2024-03-10T09:34:45Z");
 
         let dt = date(-2024, 3, 10).at(5, 34, 45, 0);
-        let zoned: Zoned = dt.intz("America/New_York").unwrap();
+        let zoned: Zoned = dt.in_tz("America/New_York").unwrap();
         let mut buf = String::new();
         DateTimePrinter::new()
             .print_timestamp(&zoned.timestamp(), None, &mut buf)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -506,7 +506,7 @@ a "odd" custom format into a zoned datetime:
 use jiff::Zoned;
 
 let zdt = Zoned::strptime(
-    "%A, %B %d, %Y at %I:%M%p %V",
+    "%A, %B %d, %Y at %I:%M%p %Q",
     "Monday, July 15, 2024 at 5:30pm US/Eastern",
 )?;
 assert_eq!(zdt.to_string(), "2024-07-15T17:30:00-04:00[US/Eastern]");
@@ -531,7 +531,7 @@ assert_eq!(string, "Monday, July 15, 2024 at 5:30pm AEST");
 
 However, time zone abbreviations aren't parsable because they are ambiguous.
 For example, `CST` can stand for `Central Standard Time`, `Cuba Standard Time`
-or `China Standard Time`. Instead, it is recommended to use `%V` to format an
+or `China Standard Time`. Instead, it is recommended to use `%Q` to format an
 IANA time zone identifier (which can be parsed, as shown above):
 
 ```
@@ -539,7 +539,7 @@ use jiff::civil::date;
 
 let zdt = date(2024, 7, 15).at(17, 30, 59, 0).in_tz("Australia/Tasmania")?;
 // %-I instead of %I means no padding.
-let string = zdt.strftime("%A, %B %d, %Y at %-I:%M%P %V").to_string();
+let string = zdt.strftime("%A, %B %d, %Y at %-I:%M%P %Q").to_string();
 assert_eq!(string, "Monday, July 15, 2024 at 5:30pm Australia/Tasmania");
 
 # Ok::<(), Box<dyn std::error::Error>>(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ it:
 use jiff::{Timestamp, ToSpan};
 
 let time: Timestamp = "2024-07-11T01:14:00Z".parse()?;
-let zoned = time.intz("America/New_York")?.checked_add(1.month().hours(2))?;
+let zoned = time.in_tz("America/New_York")?.checked_add(1.month().hours(2))?;
 assert_eq!(zoned.to_string(), "2024-08-10T23:14:00-04:00[America/New_York]");
 // Or, if you want an RFC3339 formatted string:
 assert_eq!(zoned.timestamp().to_string(), "2024-08-11T03:14:00Z");
@@ -324,13 +324,13 @@ assert_eq!(ts.to_string(), "2024-07-10T21:19:25.567Z");
 This example demonstrates the convenience constructor, [`civil::date`],
 for a [`civil::Date`]. And use the [`civil::Date::at`] method to create
 a [`civil::DateTime`]. Once we have a civil datetime, we can use
-[`civil::DateTime::intz`] to do a time zone lookup and convert it to a precise
+[`civil::DateTime::in_tz`] to do a time zone lookup and convert it to a precise
 instant in time:
 
 ```
 use jiff::civil::date;
 
-let zdt = date(2023, 12, 31).at(18, 30, 0, 0).intz("America/New_York")?;
+let zdt = date(2023, 12, 31).at(18, 30, 0, 0).in_tz("America/New_York")?;
 assert_eq!(zdt.to_string(), "2023-12-31T18:30:00-05:00[America/New_York]");
 
 # Ok::<(), Box<dyn std::error::Error>>(())
@@ -347,8 +347,8 @@ This shows how to find the civil time, in New York, when World War 1 ended:
 ```
 use jiff::civil::date;
 
-let zdt1 = date(1918, 11, 11).at(11, 0, 0, 0).intz("Europe/Paris")?;
-let zdt2 = zdt1.intz("America/New_York")?;
+let zdt1 = date(1918, 11, 11).at(11, 0, 0, 0).in_tz("Europe/Paris")?;
+let zdt2 = zdt1.in_tz("America/New_York")?;
 assert_eq!(
     zdt2.to_string(),
     "1918-11-11T06:00:00-05:00[America/New_York]",
@@ -366,8 +366,8 @@ datetimes via the `-` operator:
 ```
 use jiff::civil::date;
 
-let zdt1 = date(2020, 8, 26).at(6, 27, 0, 0).intz("America/New_York")?;
-let zdt2 = date(2023, 12, 31).at(18, 30, 0, 0).intz("America/New_York")?;
+let zdt1 = date(2020, 8, 26).at(6, 27, 0, 0).in_tz("America/New_York")?;
+let zdt2 = date(2023, 12, 31).at(18, 30, 0, 0).in_tz("America/New_York")?;
 let span = &zdt2 - &zdt1;
 assert_eq!(format!("{span:#}"), "29341h 3m");
 
@@ -382,8 +382,8 @@ via [`Zoned::until`] to make the span more comprehensible:
 ```
 use jiff::{civil::date, Unit};
 
-let zdt1 = date(2020, 8, 26).at(6, 27, 0, 0).intz("America/New_York")?;
-let zdt2 = date(2023, 12, 31).at(18, 30, 0, 0).intz("America/New_York")?;
+let zdt1 = date(2020, 8, 26).at(6, 27, 0, 0).in_tz("America/New_York")?;
+let zdt2 = date(2023, 12, 31).at(18, 30, 0, 0).in_tz("America/New_York")?;
 let span = zdt1.until((Unit::Year, &zdt2))?;
 assert_eq!(format!("{span:#}"), "3y 4mo 5d 12h 3m");
 
@@ -399,7 +399,7 @@ trait for convenience construction of `Span` values.
 ```
 use jiff::{civil::date, ToSpan};
 
-let zdt1 = date(2020, 8, 26).at(6, 27, 0, 0).intz("America/New_York")?;
+let zdt1 = date(2020, 8, 26).at(6, 27, 0, 0).in_tz("America/New_York")?;
 let span = 3.years().months(4).days(5).hours(12).minutes(3);
 let zdt2 = zdt1.checked_add(span)?;
 assert_eq!(zdt2.to_string(), "2023-12-31T18:30:00-05:00[America/New_York]");
@@ -423,12 +423,12 @@ use jiff::civil::date;
 
 // 2:30 on 2024-03-10 in New York didn't exist. It's a "gap."
 // The compatible strategy selects the datetime after the gap.
-let zdt = date(2024, 3, 10).at(2, 30, 0, 0).intz("America/New_York")?;
+let zdt = date(2024, 3, 10).at(2, 30, 0, 0).in_tz("America/New_York")?;
 assert_eq!(zdt.to_string(), "2024-03-10T03:30:00-04:00[America/New_York]");
 
 // 1:30 on 2024-11-03 in New York appeared twice. It's a "fold."
 // The compatible strategy selects the datetime before the fold.
-let zdt = date(2024, 11, 3).at(1, 30, 0, 0).intz("America/New_York")?;
+let zdt = date(2024, 11, 3).at(1, 30, 0, 0).in_tz("America/New_York")?;
 assert_eq!(zdt.to_string(), "2024-11-03T01:30:00-04:00[America/New_York]");
 
 # Ok::<(), Box<dyn std::error::Error>>(())
@@ -484,9 +484,9 @@ or email). Parsing and printing of RFC 2822 datetimes is done via the
 use jiff::fmt::rfc2822;
 
 let zdt1 = rfc2822::parse("Thu, 29 Feb 2024 05:34 -0500")?;
-let zdt2 = zdt1.intz("Australia/Tasmania")?;
+let zdt2 = zdt1.in_tz("Australia/Tasmania")?;
 assert_eq!(rfc2822::to_string(&zdt2)?, "Thu, 29 Feb 2024 21:34:00 +1100");
-let zdt3 = zdt1.intz("Asia/Kolkata")?;
+let zdt3 = zdt1.in_tz("Asia/Kolkata")?;
 assert_eq!(rfc2822::to_string(&zdt3)?, "Thu, 29 Feb 2024 16:04:00 +0530");
 
 # Ok::<(), Box<dyn std::error::Error>>(())
@@ -521,7 +521,7 @@ available) instead of an offset (`%Z` can't be used for parsing):
 ```
 use jiff::civil::date;
 
-let zdt = date(2024, 7, 15).at(17, 30, 59, 0).intz("Australia/Tasmania")?;
+let zdt = date(2024, 7, 15).at(17, 30, 59, 0).in_tz("Australia/Tasmania")?;
 // %-I instead of %I means no padding.
 let string = zdt.strftime("%A, %B %d, %Y at %-I:%M%P %Z").to_string();
 assert_eq!(string, "Monday, July 15, 2024 at 5:30pm AEST");
@@ -537,7 +537,7 @@ IANA time zone identifier (which can be parsed, as shown above):
 ```
 use jiff::civil::date;
 
-let zdt = date(2024, 7, 15).at(17, 30, 59, 0).intz("Australia/Tasmania")?;
+let zdt = date(2024, 7, 15).at(17, 30, 59, 0).in_tz("Australia/Tasmania")?;
 // %-I instead of %I means no padding.
 let string = zdt.strftime("%A, %B %d, %Y at %-I:%M%P %V").to_string();
 assert_eq!(string, "Monday, July 15, 2024 at 5:30pm Australia/Tasmania");
@@ -596,7 +596,7 @@ For more, see the [`fmt::serde`] sub-module. (This requires enabling Jiff's
   bundle the Time Zone Database), then Jiff has nearly full functionality
   without `std` enabled, excepting things like `std::error::Error` trait
   implementations and a global time zone database (which is required for
-  things like [`Timestamp::intz`] to work).
+  things like [`Timestamp::in_tz`] to work).
 * **alloc** (enabled by default) -
   When enabled, Jiff will depend on the `alloc` crate. In particular, this
   enables functionality that requires or greatly benefits from dynamic memory
@@ -710,8 +710,8 @@ pub use crate::{
     error::Error,
     signed_duration::{SignedDuration, SignedDurationRound},
     span::{
-        Span, SpanArithmetic, SpanCompare, SpanRelativeTo, SpanRound,
-        SpanTotal, ToSpan, Unit,
+        Span, SpanArithmetic, SpanCompare, SpanFieldwise, SpanRelativeTo,
+        SpanRound, SpanTotal, ToSpan, Unit,
     },
     timestamp::{
         Timestamp, TimestampArithmetic, TimestampDifference,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -669,7 +669,15 @@ For more, see the [`fmt::serde`] sub-module. (This requires enabling Jiff's
     deny(rustdoc::broken_intra_doc_links)
 )]
 // These are just too annoying to squash otherwise.
-#![cfg_attr(not(feature = "std"), allow(dead_code, unused_imports))]
+#![cfg_attr(
+    not(all(
+        feature = "std",
+        feature = "tzdb-zoneinfo",
+        feature = "tzdb-concatenated",
+        feature = "tz-system",
+    )),
+    allow(dead_code, unused_imports)
+)]
 // No clue why this thing is still unstable because it's pretty amazing. This
 // adds Cargo feature annotations to items in the rustdoc output. Which is
 // sadly hugely beneficial for this crate due to the number of features.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,7 +448,7 @@ use jiff::Span;
 
 let span: Span = "P5y1w10dT5h59m".parse()?;
 let expected = Span::new().years(5).weeks(1).days(10).hours(5).minutes(59);
-assert_eq!(span, expected);
+assert_eq!(span, expected.fieldwise());
 
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
@@ -464,11 +464,11 @@ use jiff::Span;
 
 let expected = Span::new().years(5).weeks(1).days(10).hours(5).minutes(59);
 let span: Span = "5 years, 1 week, 10 days, 5 hours, 59 minutes".parse()?;
-assert_eq!(span, expected);
+assert_eq!(span, expected.fieldwise());
 let span: Span = "5yrs 1wk 10d 5hrs 59mins".parse()?;
-assert_eq!(span, expected);
+assert_eq!(span, expected.fieldwise());
 let span: Span = "5y 1w 10d 5h 59m".parse()?;
-assert_eq!(span, expected);
+assert_eq!(span, expected.fieldwise());
 
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```

--- a/src/signed_duration.rs
+++ b/src/signed_duration.rs
@@ -71,7 +71,7 @@ use crate::util::libm::Float;
 /// use jiff::{civil::date, SignedDuration, Span};
 ///
 /// let span: Span = "P1d".parse()?;
-/// let relative = date(2024, 11, 3).intz("US/Eastern")?;
+/// let relative = date(2024, 11, 3).in_tz("US/Eastern")?;
 /// let duration = span.to_jiff_duration(&relative)?;
 /// // This example also motivates *why* a relative date
 /// // is required. Not all days are the same length!
@@ -232,13 +232,13 @@ use crate::util::libm::Float;
 /// ```
 /// use jiff::{civil::date, SignedDuration};
 ///
-/// let zdt = date(2024, 3, 10).at(1, 59, 0, 0).intz("US/Eastern")?;
+/// let zdt = date(2024, 3, 10).at(1, 59, 0, 0).in_tz("US/Eastern")?;
 /// assert_eq!(
 ///     zdt.checked_add(SignedDuration::from_hours(1))?,
 ///     // Time on the clock skipped an hour, but in this time
 ///     // zone, 03:59 is actually precisely 1 hour later than
 ///     // 01:59.
-///     date(2024, 3, 10).at(3, 59, 0, 0).intz("US/Eastern")?,
+///     date(2024, 3, 10).at(3, 59, 0, 0).in_tz("US/Eastern")?,
 /// );
 /// // The same would apply if you used a `Span`:
 /// assert_eq!(
@@ -246,7 +246,7 @@ use crate::util::libm::Float;
 ///     // Time on the clock skipped an hour, but in this time
 ///     // zone, 03:59 is actually precisely 1 hour later than
 ///     // 01:59.
-///     date(2024, 3, 10).at(3, 59, 0, 0).intz("US/Eastern")?,
+///     date(2024, 3, 10).at(3, 59, 0, 0).in_tz("US/Eastern")?,
 /// );
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -262,10 +262,10 @@ use crate::util::libm::Float;
 /// ```
 /// use jiff::{civil::date, SignedDuration};
 ///
-/// let zdt = date(2024, 3, 8).at(17, 0, 0, 0).intz("US/Eastern")?;
+/// let zdt = date(2024, 3, 8).at(17, 0, 0, 0).in_tz("US/Eastern")?;
 /// assert_eq!(
 ///     zdt.checked_add(SignedDuration::from_hours(7 * 24))?,
-///     date(2024, 3, 15).at(18, 0, 0, 0).intz("US/Eastern")?,
+///     date(2024, 3, 15).at(18, 0, 0, 0).in_tz("US/Eastern")?,
 /// );
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -280,11 +280,11 @@ use crate::util::libm::Float;
 /// ```
 /// use jiff::{civil::date, ToSpan};
 ///
-/// let zdt = date(2024, 3, 8).at(17, 0, 0, 0).intz("US/Eastern")?;
+/// let zdt = date(2024, 3, 8).at(17, 0, 0, 0).in_tz("US/Eastern")?;
 /// assert_eq!(
 ///     zdt.checked_add(1.week())?,
 ///     // The expected time!
-///     date(2024, 3, 15).at(17, 0, 0, 0).intz("US/Eastern")?,
+///     date(2024, 3, 15).at(17, 0, 0, 0).in_tz("US/Eastern")?,
 /// );
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -27,7 +27,7 @@ use crate::{
 ///
 /// To obtain civil or "local" datetime units like year, month, day or hour, a
 /// timestamp needs to be combined with a [`TimeZone`] to create a [`Zoned`].
-/// That can be done with [`Timestamp::intz`] or [`Timestamp::to_zoned`].
+/// That can be done with [`Timestamp::in_tz`] or [`Timestamp::to_zoned`].
 ///
 /// The integer count of nanoseconds since the Unix epoch is signed, where
 /// the Unix epoch is `1970-01-01 00:00:00Z`. A positive timestamp indicates
@@ -247,8 +247,8 @@ use crate::{
 /// assert_eq!(after_hour_jump.to_string(), "2024-03-10T07:30:00Z");
 ///
 /// // Now let's attach each instant to an `America/New_York` time zone.
-/// let zdt_before = before_hour_jump.intz("America/New_York")?;
-/// let zdt_after = after_hour_jump.intz("America/New_York")?;
+/// let zdt_before = before_hour_jump.in_tz("America/New_York")?;
+/// let zdt_after = after_hour_jump.in_tz("America/New_York")?;
 /// // And now we can see that even though the original instant refers to
 /// // the 2 o'clock hour, since that hour never existed on the clocks in
 /// // `America/New_York`, an instant with a time zone correctly adjusts.
@@ -308,7 +308,7 @@ use crate::{
 /// ```
 /// use jiff::civil::date;
 ///
-/// let clock = date(2024, 6, 30).at(8, 36, 0, 0).intz("America/New_York")?;
+/// let clock = date(2024, 6, 30).at(8, 36, 0, 0).in_tz("America/New_York")?;
 /// assert_eq!(clock.timestamp().to_string(), "2024-06-30T12:36:00Z");
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1035,7 +1035,7 @@ impl Timestamp {
     /// use jiff::Timestamp;
     ///
     /// let ts = Timestamp::new(123_456_789, 0).unwrap();
-    /// let zdt = ts.intz("America/New_York")?;
+    /// let zdt = ts.in_tz("America/New_York")?;
     /// assert_eq!(zdt.to_string(), "1973-11-29T16:33:09-05:00[America/New_York]");
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1048,7 +1048,7 @@ impl Timestamp {
     /// use jiff::Timestamp;
     ///
     /// // Time zone database lookups are case insensitive!
-    /// let zdt = Timestamp::UNIX_EPOCH.intz("australia/tasmania")?;
+    /// let zdt = Timestamp::UNIX_EPOCH.in_tz("australia/tasmania")?;
     /// assert_eq!(zdt.to_string(), "1970-01-01T11:00:00+11:00[Australia/Tasmania]");
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1061,10 +1061,10 @@ impl Timestamp {
     /// ```
     /// use jiff::Timestamp;
     ///
-    /// assert!(Timestamp::UNIX_EPOCH.intz("does not exist").is_err());
+    /// assert!(Timestamp::UNIX_EPOCH.in_tz("does not exist").is_err());
     /// ```
     #[inline]
-    pub fn intz(self, time_zone_name: &str) -> Result<Zoned, Error> {
+    pub fn in_tz(self, time_zone_name: &str) -> Result<Zoned, Error> {
         let tz = crate::tz::db().get(time_zone_name)?;
         Ok(self.to_zoned(tz))
     }
@@ -1081,7 +1081,7 @@ impl Timestamp {
     /// a gap, typically DST starting).
     ///
     /// In the common case of a time zone being represented as a name string,
-    /// like `Australia/Tasmania`, consider using [`Timestamp::intz`]
+    /// like `Australia/Tasmania`, consider using [`Timestamp::in_tz`]
     /// instead.
     ///
     /// # Example
@@ -2146,6 +2146,17 @@ impl Timestamp {
         let nanosecond = u32::try_from(self.subsec_nanosecond().abs())
             .expect("nanosecond always fit in a u32");
         (self.signum(), core::time::Duration::new(second, nanosecond))
+    }
+
+    /// A deprecated equivalent to [`Timestamp::in_tz`].
+    ///
+    /// This will be removed in `jiff 0.2`. The method was renamed to make
+    /// it clearer that the name stood for "in time zone."
+    #[deprecated(since = "0.1.25", note = "use Timestamp::in_tz instead")]
+    #[inline]
+    pub fn intz(self, time_zone_name: &str) -> Result<Zoned, Error> {
+        let tz = crate::tz::db().get(time_zone_name)?;
+        Ok(self.to_zoned(tz))
     }
 }
 

--- a/src/tz/db/mod.rs
+++ b/src/tz/db/mod.rs
@@ -15,7 +15,7 @@ mod zoneinfo;
 /// Returns a copy of the global [`TimeZoneDatabase`].
 ///
 /// This is the same database used for convenience routines like
-/// [`Timestamp::intz`](crate::Timestamp::intz) and parsing routines
+/// [`Timestamp::in_tz`](crate::Timestamp::in_tz) and parsing routines
 /// for [`Zoned`](crate::Zoned) that need to do IANA time zone identifier
 /// lookups. Basically, whenever an implicit time zone database is needed,
 /// it is *this* copy of the time zone database that is used.
@@ -105,7 +105,7 @@ pub fn db() -> &'static TimeZoneDatabase {
 /// and parsing the time zone transitions out of that file requires
 /// a fair amount of work, a `TimeZoneDatabase` does a fair bit of
 /// caching. This means that the vast majority of calls to, for example,
-/// [`Timestamp::intz`](crate::Timestamp::intz) don't actually need to hit
+/// [`Timestamp::in_tz`](crate::Timestamp::in_tz) don't actually need to hit
 /// disk. It will just find a cached copy of a [`TimeZone`] and return that.
 ///
 /// Of course, with caching comes problems of cache invalidation. Invariably,

--- a/src/tz/mod.rs
+++ b/src/tz/mod.rs
@@ -8,7 +8,7 @@ converts a civil datetime to a zone aware datetime:
 ```
 use jiff::civil::date;
 
-let zdt = date(2024, 7, 10).at(20, 48, 0, 0).intz("America/New_York")?;
+let zdt = date(2024, 7, 10).at(20, 48, 0, 0).in_tz("America/New_York")?;
 assert_eq!(zdt.to_string(), "2024-07-10T20:48:00-04:00[America/New_York]");
 
 # Ok::<(), Box<dyn std::error::Error>>(())
@@ -149,7 +149,7 @@ mod zic;
 /// use jiff::Timestamp;
 ///
 /// let ts = Timestamp::from_second(1_456_789_123)?;
-/// let zdt = ts.intz("America/New_York")?;
+/// let zdt = ts.in_tz("America/New_York")?;
 /// assert_eq!(zdt.to_string(), "2016-02-29T18:38:43-05:00[America/New_York]");
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -162,7 +162,7 @@ mod zic;
 /// use jiff::civil::date;
 ///
 /// let dt = date(2024, 7, 15).at(21, 27, 0, 0);
-/// let zdt = dt.intz("America/New_York")?;
+/// let zdt = dt.in_tz("America/New_York")?;
 /// assert_eq!(zdt.to_string(), "2024-07-15T21:27:00-04:00[America/New_York]");
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -174,8 +174,8 @@ mod zic;
 /// use jiff::civil::date;
 ///
 /// let dt = date(2024, 7, 15).at(21, 27, 0, 0);
-/// let zdt1 = dt.intz("America/New_York")?;
-/// let zdt2 = zdt1.intz("Israel")?;
+/// let zdt1 = dt.in_tz("America/New_York")?;
+/// let zdt2 = zdt1.in_tz("Israel")?;
 /// assert_eq!(zdt2.to_string(), "2024-07-16T04:27:00+03:00[Israel]");
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -664,7 +664,7 @@ impl TimeZone {
     /// ```
     /// use jiff::{tz::TimeZone, Timestamp};
     ///
-    /// let zdt = Timestamp::UNIX_EPOCH.intz("Europe/Rome")?;
+    /// let zdt = Timestamp::UNIX_EPOCH.in_tz("Europe/Rome")?;
     /// assert_eq!(zdt.datetime().to_string(), "1970-01-01T01:00:00");
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())

--- a/src/tz/mod.rs
+++ b/src/tz/mod.rs
@@ -100,7 +100,7 @@ pub use self::{
     offset::{Dst, Offset, OffsetArithmetic, OffsetConflict},
 };
 
-#[cfg(feature = "alloc")]
+#[cfg(feature = "tzdb-concatenated")]
 mod concatenated;
 mod db;
 mod offset;

--- a/src/tz/offset.rs
+++ b/src/tz/offset.rs
@@ -786,12 +786,12 @@ impl Offset {
     ///
     /// assert_eq!(
     ///     tz::offset(-5).until(tz::Offset::UTC),
-    ///     (5 * 60 * 60).seconds(),
+    ///     (5 * 60 * 60).seconds().fieldwise(),
     /// );
     /// // Flipping the operands in this case results in a negative span.
     /// assert_eq!(
     ///     tz::Offset::UTC.until(tz::offset(-5)),
-    ///     -(5 * 60 * 60).seconds(),
+    ///     -(5 * 60 * 60).seconds().fieldwise(),
     /// );
     /// ```
     #[inline]
@@ -817,12 +817,12 @@ impl Offset {
     ///
     /// assert_eq!(
     ///     tz::Offset::UTC.since(tz::offset(-5)),
-    ///     (5 * 60 * 60).seconds(),
+    ///     (5 * 60 * 60).seconds().fieldwise(),
     /// );
     /// // Flipping the operands in this case results in a negative span.
     /// assert_eq!(
     ///     tz::offset(-5).since(tz::Offset::UTC),
-    ///     -(5 * 60 * 60).seconds(),
+    ///     -(5 * 60 * 60).seconds().fieldwise(),
     /// );
     /// ```
     #[inline]

--- a/src/tz/snapshots/jiff__tz__zic__tests__parse_zic_man1.snap
+++ b/src/tz/snapshots/jiff__tz__zic__tests__parse_zic_man1.snap
@@ -22,11 +22,15 @@ ZicP {
                     weekday: Sunday,
                 },
                 at: RuleAtP {
-                    span: 2h,
+                    span: SpanFieldwise(
+                        2h,
+                    ),
                     suffix: None,
                 },
                 save: RuleSaveP {
-                    span: 0s,
+                    span: SpanFieldwise(
+                        0s,
+                    ),
                     suffix: None,
                 },
                 letters: RuleLettersP {
@@ -50,11 +54,15 @@ ZicP {
                     weekday: Sunday,
                 },
                 at: RuleAtP {
-                    span: 2h,
+                    span: SpanFieldwise(
+                        2h,
+                    ),
                     suffix: None,
                 },
                 save: RuleSaveP {
-                    span: 1h,
+                    span: SpanFieldwise(
+                        1h,
+                    ),
                     suffix: None,
                 },
                 letters: RuleLettersP {
@@ -70,7 +78,9 @@ ZicP {
                     name: "America/Menominee",
                 },
                 stdoff: ZoneStdoffP {
-                    span: 5h ago,
+                    span: SpanFieldwise(
+                        5h ago,
+                    ),
                 },
                 rules: None,
                 format: Static {
@@ -86,7 +96,9 @@ ZicP {
                             day: 29,
                         },
                         duration: RuleAtP {
-                            span: 2h,
+                            span: SpanFieldwise(
+                                2h,
+                            ),
                             suffix: None,
                         },
                     },
@@ -95,7 +107,9 @@ ZicP {
             continuations: [
                 ZoneContinuationP {
                     stdoff: ZoneStdoffP {
-                        span: 6h ago,
+                        span: SpanFieldwise(
+                            6h ago,
+                        ),
                     },
                     rules: Named(
                         RuleNameP {

--- a/src/tz/snapshots/jiff__tz__zic__tests__parse_zic_man2.snap
+++ b/src/tz/snapshots/jiff__tz__zic__tests__parse_zic_man2.snap
@@ -23,13 +23,17 @@ ZicP {
                     day: 1,
                 },
                 at: RuleAtP {
-                    span: 1h,
+                    span: SpanFieldwise(
+                        1h,
+                    ),
                     suffix: Some(
                         Universal,
                     ),
                 },
                 save: RuleSaveP {
-                    span: 1h,
+                    span: SpanFieldwise(
+                        1h,
+                    ),
                     suffix: None,
                 },
                 letters: RuleLettersP {
@@ -51,13 +55,17 @@ ZicP {
                     weekday: Sunday,
                 },
                 at: RuleAtP {
-                    span: 1h,
+                    span: SpanFieldwise(
+                        1h,
+                    ),
                     suffix: Some(
                         Universal,
                     ),
                 },
                 save: RuleSaveP {
-                    span: 0s,
+                    span: SpanFieldwise(
+                        0s,
+                    ),
                     suffix: None,
                 },
                 letters: RuleLettersP {
@@ -79,13 +87,17 @@ ZicP {
                     day: 1,
                 },
                 at: RuleAtP {
-                    span: 1h,
+                    span: SpanFieldwise(
+                        1h,
+                    ),
                     suffix: Some(
                         Universal,
                     ),
                 },
                 save: RuleSaveP {
-                    span: 0s,
+                    span: SpanFieldwise(
+                        0s,
+                    ),
                     suffix: None,
                 },
                 letters: RuleLettersP {
@@ -109,13 +121,17 @@ ZicP {
                     weekday: Sunday,
                 },
                 at: RuleAtP {
-                    span: 1h,
+                    span: SpanFieldwise(
+                        1h,
+                    ),
                     suffix: Some(
                         Universal,
                     ),
                 },
                 save: RuleSaveP {
-                    span: 0s,
+                    span: SpanFieldwise(
+                        0s,
+                    ),
                     suffix: None,
                 },
                 letters: RuleLettersP {
@@ -137,13 +153,17 @@ ZicP {
                     weekday: Sunday,
                 },
                 at: RuleAtP {
-                    span: 1h,
+                    span: SpanFieldwise(
+                        1h,
+                    ),
                     suffix: Some(
                         Universal,
                     ),
                 },
                 save: RuleSaveP {
-                    span: 1h,
+                    span: SpanFieldwise(
+                        1h,
+                    ),
                     suffix: None,
                 },
                 letters: RuleLettersP {
@@ -165,13 +185,17 @@ ZicP {
                     weekday: Sunday,
                 },
                 at: RuleAtP {
-                    span: 1h,
+                    span: SpanFieldwise(
+                        1h,
+                    ),
                     suffix: Some(
                         Universal,
                     ),
                 },
                 save: RuleSaveP {
-                    span: 0s,
+                    span: SpanFieldwise(
+                        0s,
+                    ),
                     suffix: None,
                 },
                 letters: RuleLettersP {
@@ -198,11 +222,15 @@ ZicP {
                     day: 1,
                 },
                 at: RuleAtP {
-                    span: 1h,
+                    span: SpanFieldwise(
+                        1h,
+                    ),
                     suffix: None,
                 },
                 save: RuleSaveP {
-                    span: 1h,
+                    span: SpanFieldwise(
+                        1h,
+                    ),
                     suffix: None,
                 },
                 letters: RuleLettersP {
@@ -227,11 +255,15 @@ ZicP {
                     day: 1,
                 },
                 at: RuleAtP {
-                    span: 2h,
+                    span: SpanFieldwise(
+                        2h,
+                    ),
                     suffix: None,
                 },
                 save: RuleSaveP {
-                    span: 0s,
+                    span: SpanFieldwise(
+                        0s,
+                    ),
                     suffix: None,
                 },
                 letters: RuleLettersP {
@@ -247,7 +279,9 @@ ZicP {
                     name: "Europe/Zurich",
                 },
                 stdoff: ZoneStdoffP {
-                    span: 34m 8s,
+                    span: SpanFieldwise(
+                        34m 8s,
+                    ),
                 },
                 rules: None,
                 format: Static {
@@ -268,7 +302,9 @@ ZicP {
             continuations: [
                 ZoneContinuationP {
                     stdoff: ZoneStdoffP {
-                        span: 29m 45s 500ms,
+                        span: SpanFieldwise(
+                            29m 45s 500ms,
+                        ),
                     },
                     rules: None,
                     format: Static {
@@ -285,7 +321,9 @@ ZicP {
                 },
                 ZoneContinuationP {
                     stdoff: ZoneStdoffP {
-                        span: 1h,
+                        span: SpanFieldwise(
+                            1h,
+                        ),
                     },
                     rules: Named(
                         RuleNameP {
@@ -304,7 +342,9 @@ ZicP {
                 },
                 ZoneContinuationP {
                     stdoff: ZoneStdoffP {
-                        span: 1h,
+                        span: SpanFieldwise(
+                            1h,
+                        ),
                     },
                     rules: Named(
                         RuleNameP {

--- a/src/util/round/mode.rs
+++ b/src/util/round/mode.rs
@@ -27,10 +27,16 @@ use crate::{
 /// use jiff::{RoundMode, SpanRound, ToSpan, Unit};
 ///
 /// // The default rounds like how you were taught in school:
-/// assert_eq!(1.hour().minutes(59).round(Unit::Hour)?, 2.hours());
+/// assert_eq!(
+///     1.hour().minutes(59).round(Unit::Hour)?,
+///     2.hours().fieldwise(),
+/// );
 /// // But we can change the mode, e.g., truncation:
 /// let options = SpanRound::new().smallest(Unit::Hour).mode(RoundMode::Trunc);
-/// assert_eq!(1.hour().minutes(59).round(options)?, 1.hour());
+/// assert_eq!(
+///     1.hour().minutes(59).round(options)?,
+///     1.hour().fieldwise(),
+/// );
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```

--- a/src/util/t.rs
+++ b/src/util/t.rs
@@ -146,9 +146,13 @@ pub(crate) type WeekdayOne = ri8<1, 7>;
 /// is being used.
 pub(crate) type Day = ri8<1, 31>;
 
+pub(crate) type DayOfYear = ri16<1, 366>;
+
 pub(crate) type ISOYear = ri16<-9999, 9999>;
 
 pub(crate) type ISOWeek = ri8<1, 53>;
+
+pub(crate) type WeekNum = ri8<0, 53>;
 
 /// The range of possible hour values.
 pub(crate) type Hour = ri8<0, 23>;

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -141,8 +141,8 @@ use crate::{
 /// ```
 /// use jiff::civil::date;
 ///
-/// let zdt1 = date(2024, 3, 11).at(1, 25, 15, 0).intz("America/New_York")?;
-/// let zdt2 = date(2025, 1, 31).at(0, 30, 0, 0).intz("America/New_York")?;
+/// let zdt1 = date(2024, 3, 11).at(1, 25, 15, 0).in_tz("America/New_York")?;
+/// let zdt2 = date(2025, 1, 31).at(0, 30, 0, 0).in_tz("America/New_York")?;
 /// assert!(zdt1 < zdt2);
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -156,8 +156,8 @@ use crate::{
 /// ```
 /// use jiff::civil::date;
 ///
-/// let zdt1 = date(2024, 7, 4).at(12, 0, 0, 0).intz("America/New_York")?;
-/// let zdt2 = date(2024, 7, 4).at(11, 0, 0, 0).intz("America/Los_Angeles")?;
+/// let zdt1 = date(2024, 7, 4).at(12, 0, 0, 0).in_tz("America/New_York")?;
+/// let zdt2 = date(2024, 7, 4).at(11, 0, 0, 0).in_tz("America/Los_Angeles")?;
 /// assert!(zdt1 < zdt2);
 /// // But if we only compare civil datetime, the result is flipped:
 /// assert!(zdt1.datetime() > zdt2.datetime());
@@ -171,8 +171,8 @@ use crate::{
 /// ```
 /// use jiff::civil::date;
 ///
-/// let zdt1 = date(2024, 7, 4).at(12, 0, 0, 0).intz("America/New_York")?;
-/// let zdt2 = date(2024, 7, 4).at(9, 0, 0, 0).intz("America/Los_Angeles")?;
+/// let zdt1 = date(2024, 7, 4).at(12, 0, 0, 0).in_tz("America/New_York")?;
+/// let zdt2 = date(2024, 7, 4).at(9, 0, 0, 0).in_tz("America/Los_Angeles")?;
 /// assert_eq!(zdt1, zdt2);
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -206,7 +206,7 @@ use crate::{
 /// ```
 /// use jiff::{civil::date, ToSpan};
 ///
-/// let start = date(2024, 2, 25).at(15, 45, 0, 0).intz("America/New_York")?;
+/// let start = date(2024, 2, 25).at(15, 45, 0, 0).in_tz("America/New_York")?;
 /// // `Zoned` doesn't implement `Copy`, so we use `&start` instead of `start`.
 /// let one_week_later = &start + 1.weeks();
 /// assert_eq!(one_week_later.datetime(), date(2024, 3, 3).at(15, 45, 0, 0));
@@ -221,8 +221,8 @@ use crate::{
 /// ```
 /// use jiff::{civil::date, ToSpan};
 ///
-/// let zdt1 = date(2024, 5, 3).at(23, 30, 0, 0).intz("America/New_York")?;
-/// let zdt2 = date(2024, 2, 25).at(7, 0, 0, 0).intz("America/New_York")?;
+/// let zdt1 = date(2024, 5, 3).at(23, 30, 0, 0).in_tz("America/New_York")?;
+/// let zdt2 = date(2024, 2, 25).at(7, 0, 0, 0).in_tz("America/New_York")?;
 /// assert_eq!(&zdt1 - &zdt2, 1647.hours().minutes(30));
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -235,8 +235,8 @@ use crate::{
 /// ```
 /// use jiff::{civil::date, ToSpan, Unit};
 ///
-/// let zdt1 = date(2024, 5, 3).at(23, 30, 0, 0).intz("America/New_York")?;
-/// let zdt2 = date(2024, 2, 25).at(7, 0, 0, 0).intz("America/New_York")?;
+/// let zdt1 = date(2024, 5, 3).at(23, 30, 0, 0).in_tz("America/New_York")?;
+/// let zdt2 = date(2024, 2, 25).at(7, 0, 0, 0).in_tz("America/New_York")?;
 /// assert_eq!(
 ///     zdt1.since((Unit::Year, &zdt2))?,
 ///     2.months().days(7).hours(16).minutes(30),
@@ -250,8 +250,8 @@ use crate::{
 /// ```
 /// use jiff::{civil::date, RoundMode, ToSpan, Unit, ZonedDifference};
 ///
-/// let zdt1 = date(2024, 5, 3).at(23, 30, 0, 0).intz("America/New_York")?;
-/// let zdt2 = date(2024, 2, 25).at(7, 0, 0, 0).intz("America/New_York")?;
+/// let zdt1 = date(2024, 5, 3).at(23, 30, 0, 0).in_tz("America/New_York")?;
+/// let zdt2 = date(2024, 2, 25).at(7, 0, 0, 0).in_tz("America/New_York")?;
 /// assert_eq!(
 ///     zdt1.since(
 ///         ZonedDifference::new(&zdt2)
@@ -287,16 +287,16 @@ use crate::{
 ///
 /// let zdt = date(2024, 6, 19)
 ///     .at(16, 27, 29, 999_999_999)
-///     .intz("America/New_York")?;
+///     .in_tz("America/New_York")?;
 /// assert_eq!(
 ///     zdt.round(ZonedRound::new().smallest(Unit::Hour).increment(3))?,
-///     date(2024, 6, 19).at(15, 0, 0, 0).intz("America/New_York")?,
+///     date(2024, 6, 19).at(15, 0, 0, 0).in_tz("America/New_York")?,
 /// );
 /// // Or alternatively, make use of the `From<(Unit, i64)> for ZonedRound`
 /// // trait implementation:
 /// assert_eq!(
 ///     zdt.round((Unit::Hour, 3))?,
-///     date(2024, 6, 19).at(15, 0, 0, 0).intz("America/New_York")?,
+///     date(2024, 6, 19).at(15, 0, 0, 0).in_tz("America/New_York")?,
 /// );
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -438,10 +438,10 @@ impl Zoned {
     /// A `Zoned` value can also be created from a civil time via the following
     /// methods:
     ///
-    /// * [`DateTime::intz`] does a Time Zone Database lookup given a time
+    /// * [`DateTime::in_tz`] does a Time Zone Database lookup given a time
     /// zone name string.
     /// * [`DateTime::to_zoned`] accepts a `TimeZone`.
-    /// * [`Date::intz`] does a Time Zone Database lookup given a time zone
+    /// * [`Date::in_tz`] does a Time Zone Database lookup given a time zone
     /// name string and attempts to use midnight as the clock time.
     /// * [`Date::to_zoned`] accepts a `TimeZone` and attempts to use midnight
     /// as the clock time.
@@ -479,8 +479,8 @@ impl Zoned {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt1 = date(1918, 11, 11).at(11, 0, 0, 0).intz("Europe/Paris")?;
-    /// let zdt2 = zdt1.intz("America/New_York")?;
+    /// let zdt1 = date(1918, 11, 11).at(11, 0, 0, 0).in_tz("Europe/Paris")?;
+    /// let zdt2 = zdt1.in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt2.to_string(),
     ///     "1918-11-11T06:00:00-05:00[America/New_York]",
@@ -504,10 +504,10 @@ impl Zoned {
     ///
     /// Note that this doesn't support changing the time zone. If you want a
     /// `Zoned` value of the same instant but in a different time zone, use
-    /// [`Zoned::intz`] or [`Zoned::with_time_zone`]. If you want a `Zoned`
+    /// [`Zoned::in_tz`] or [`Zoned::with_time_zone`]. If you want a `Zoned`
     /// value of the same civil datetime (assuming it isn't ambiguous) but in
     /// a different time zone, then use [`Zoned::datetime`] followed by
-    /// [`DateTime::intz`] or [`DateTime::to_zoned`].
+    /// [`DateTime::in_tz`] or [`DateTime::to_zoned`].
     ///
     /// # Example
     ///
@@ -524,18 +524,18 @@ impl Zoned {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt1 = date(2024, 10, 31).at(0, 0, 0, 0).intz("America/New_York")?;
+    /// let zdt1 = date(2024, 10, 31).at(0, 0, 0, 0).in_tz("America/New_York")?;
     /// let zdt2 = zdt1.with().month(11).day(30).build()?;
     /// assert_eq!(
     ///     zdt2,
-    ///     date(2024, 11, 30).at(0, 0, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 11, 30).at(0, 0, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
-    /// let zdt1 = date(2024, 4, 30).at(0, 0, 0, 0).intz("America/New_York")?;
+    /// let zdt1 = date(2024, 4, 30).at(0, 0, 0, 0).in_tz("America/New_York")?;
     /// let zdt2 = zdt1.with().day(31).month(7).build()?;
     /// assert_eq!(
     ///     zdt2,
-    ///     date(2024, 7, 31).at(0, 0, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 7, 31).at(0, 0, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -596,10 +596,10 @@ impl Zoned {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt1 = date(1918, 11, 11).at(11, 0, 0, 0).intz("Europe/Paris")?;
+    /// let zdt1 = date(1918, 11, 11).at(11, 0, 0, 0).in_tz("Europe/Paris")?;
     /// // Switch zdt1 to a different time zone, but keeping the same instant
     /// // in time. The civil time changes, but not the instant!
-    /// let zdt2 = zdt1.intz("America/New_York")?;
+    /// let zdt2 = zdt1.in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt2.to_string(),
     ///     "1918-11-11T06:00:00-05:00[America/New_York]",
@@ -608,7 +608,7 @@ impl Zoned {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[inline]
-    pub fn intz(&self, name: &str) -> Result<Zoned, Error> {
+    pub fn in_tz(&self, name: &str) -> Result<Zoned, Error> {
         let tz = crate::tz::db().get(name)?;
         Ok(self.with_time_zone(tz))
     }
@@ -644,13 +644,13 @@ impl Zoned {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt1 = date(2024, 3, 9).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt1 = date(2024, 3, 9).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt1.year(), 2024);
     ///
-    /// let zdt2 = date(-2024, 3, 9).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt2 = date(-2024, 3, 9).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt2.year(), -2024);
     ///
-    /// let zdt3 = date(0, 3, 9).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt3 = date(0, 3, 9).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt3.year(), 0);
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -678,22 +678,22 @@ impl Zoned {
     /// ```
     /// use jiff::civil::{Era, date};
     ///
-    /// let zdt = date(2024, 10, 3).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 10, 3).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.era_year(), (2024, Era::CE));
     ///
-    /// let zdt = date(1, 10, 3).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(1, 10, 3).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.era_year(), (1, Era::CE));
     ///
-    /// let zdt = date(0, 10, 3).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(0, 10, 3).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.era_year(), (1, Era::BCE));
     ///
-    /// let zdt = date(-1, 10, 3).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(-1, 10, 3).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.era_year(), (2, Era::BCE));
     ///
-    /// let zdt = date(-10, 10, 3).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(-10, 10, 3).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.era_year(), (11, Era::BCE));
     ///
-    /// let zdt = date(-9_999, 10, 3).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(-9_999, 10, 3).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.era_year(), (10_000, Era::BCE));
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -712,7 +712,7 @@ impl Zoned {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt = date(2024, 3, 9).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 3, 9).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.month(), 3);
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -731,7 +731,7 @@ impl Zoned {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt = date(2024, 2, 29).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 2, 29).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.day(), 29);
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -752,7 +752,7 @@ impl Zoned {
     ///
     /// let zdt = date(2000, 1, 2)
     ///     .at(3, 4, 5, 123_456_789)
-    ///     .intz("America/New_York")?;
+    ///     .in_tz("America/New_York")?;
     /// assert_eq!(zdt.hour(), 3);
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -773,7 +773,7 @@ impl Zoned {
     ///
     /// let zdt = date(2000, 1, 2)
     ///     .at(3, 4, 5, 123_456_789)
-    ///     .intz("America/New_York")?;
+    ///     .in_tz("America/New_York")?;
     /// assert_eq!(zdt.minute(), 4);
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -794,7 +794,7 @@ impl Zoned {
     ///
     /// let zdt = date(2000, 1, 2)
     ///     .at(3, 4, 5, 123_456_789)
-    ///     .intz("America/New_York")?;
+    ///     .in_tz("America/New_York")?;
     /// assert_eq!(zdt.second(), 5);
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -815,7 +815,7 @@ impl Zoned {
     ///
     /// let zdt = date(2000, 1, 2)
     ///     .at(3, 4, 5, 123_456_789)
-    ///     .intz("America/New_York")?;
+    ///     .in_tz("America/New_York")?;
     /// assert_eq!(zdt.millisecond(), 123);
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -836,7 +836,7 @@ impl Zoned {
     ///
     /// let zdt = date(2000, 1, 2)
     ///     .at(3, 4, 5, 123_456_789)
-    ///     .intz("America/New_York")?;
+    ///     .in_tz("America/New_York")?;
     /// assert_eq!(zdt.microsecond(), 456);
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -857,7 +857,7 @@ impl Zoned {
     ///
     /// let zdt = date(2000, 1, 2)
     ///     .at(3, 4, 5, 123_456_789)
-    ///     .intz("America/New_York")?;
+    ///     .in_tz("America/New_York")?;
     /// assert_eq!(zdt.nanosecond(), 789);
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -885,7 +885,7 @@ impl Zoned {
     ///
     /// let zdt1 = date(2000, 1, 2)
     ///     .at(3, 4, 5, 123_456_789)
-    ///     .intz("America/New_York")?;
+    ///     .in_tz("America/New_York")?;
     /// assert_eq!(zdt1.subsec_nanosecond(), 123_456_789);
     ///
     /// let zdt2 = zdt1.with().millisecond(333).build()?;
@@ -903,11 +903,11 @@ impl Zoned {
     /// use jiff::{civil, Timestamp};
     ///
     /// // 1,234 nanoseconds after the Unix epoch.
-    /// let zdt = Timestamp::new(0, 1_234)?.intz("UTC")?;
+    /// let zdt = Timestamp::new(0, 1_234)?.in_tz("UTC")?;
     /// assert_eq!(zdt.subsec_nanosecond(), 1_234);
     ///
     /// // 1,234 nanoseconds before the Unix epoch.
-    /// let zdt = Timestamp::new(0, -1_234)?.intz("UTC")?;
+    /// let zdt = Timestamp::new(0, -1_234)?.in_tz("UTC")?;
     /// // The nanosecond is equal to `1_000_000_000 - 1_234`.
     /// assert_eq!(zdt.subsec_nanosecond(), 999998766);
     /// // Looking at the other components of the time value might help.
@@ -930,7 +930,7 @@ impl Zoned {
     /// use jiff::civil::{Weekday, date};
     ///
     /// // The Unix epoch was on a Thursday.
-    /// let zdt = date(1970, 1, 1).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(1970, 1, 1).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.weekday(), Weekday::Thursday);
     /// // One can also get the weekday as an offset in a variety of schemes.
     /// assert_eq!(zdt.weekday().to_monday_zero_offset(), 3);
@@ -956,13 +956,13 @@ impl Zoned {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt = date(2006, 8, 24).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2006, 8, 24).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.day_of_year(), 236);
     ///
-    /// let zdt = date(2023, 12, 31).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2023, 12, 31).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.day_of_year(), 365);
     ///
-    /// let zdt = date(2024, 12, 31).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 12, 31).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.day_of_year(), 366);
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -987,16 +987,16 @@ impl Zoned {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt = date(2006, 8, 24).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2006, 8, 24).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.day_of_year_no_leap(), Some(236));
     ///
-    /// let zdt = date(2023, 12, 31).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2023, 12, 31).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.day_of_year_no_leap(), Some(365));
     ///
-    /// let zdt = date(2024, 12, 31).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 12, 31).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.day_of_year_no_leap(), Some(365));
     ///
-    /// let zdt = date(2024, 2, 29).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 2, 29).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.day_of_year_no_leap(), None);
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1018,7 +1018,7 @@ impl Zoned {
     /// ```
     /// use jiff::{civil::date, Zoned};
     ///
-    /// let zdt = date(2015, 10, 18).at(12, 0, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2015, 10, 18).at(12, 0, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt.start_of_day()?.to_string(),
     ///     "2015-10-18T00:00:00-04:00[America/New_York]",
@@ -1036,7 +1036,7 @@ impl Zoned {
     /// ```
     /// use jiff::{civil::date, Zoned};
     ///
-    /// let zdt = date(2015, 10, 18).at(12, 0, 0, 0).intz("America/Sao_Paulo")?;
+    /// let zdt = date(2015, 10, 18).at(12, 0, 0, 0).in_tz("America/Sao_Paulo")?;
     /// assert_eq!(
     ///     zdt.start_of_day()?.to_string(),
     ///     // not midnight!
@@ -1090,12 +1090,12 @@ impl Zoned {
     ///
     /// let zdt = date(2024, 7, 3)
     ///     .at(7, 30, 10, 123_456_789)
-    ///     .intz("America/New_York")?;
+    ///     .in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt.end_of_day()?,
     ///     date(2024, 7, 3)
     ///         .at(23, 59, 59, 999_999_999)
-    ///         .intz("America/New_York")?,
+    ///         .in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1123,7 +1123,7 @@ impl Zoned {
     ///     zdt.end_of_day()?,
     ///     date(9999, 12, 29)
     ///         .at(23, 59, 59, 999_999_999)
-    ///         .intz("America/New_York")?,
+    ///         .in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1172,10 +1172,10 @@ impl Zoned {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt = date(2024, 2, 29).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 2, 29).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt.first_of_month()?,
-    ///     date(2024, 2, 1).at(7, 30, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 2, 1).at(7, 30, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1204,10 +1204,10 @@ impl Zoned {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt = date(2024, 2, 5).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 2, 5).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt.last_of_month()?,
-    ///     date(2024, 2, 29).at(7, 30, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 2, 29).at(7, 30, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1232,13 +1232,13 @@ impl Zoned {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt = date(2024, 2, 10).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 2, 10).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.days_in_month(), 29);
     ///
-    /// let zdt = date(2023, 2, 10).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2023, 2, 10).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.days_in_month(), 28);
     ///
-    /// let zdt = date(2024, 8, 15).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 8, 15).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.days_in_month(), 31);
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1255,7 +1255,7 @@ impl Zoned {
     /// ```
     /// use jiff::{civil::date, RoundMode, ToSpan, Unit, ZonedDifference};
     ///
-    /// let first_of_month = date(2011, 12, 1).intz("Pacific/Apia")?;
+    /// let first_of_month = date(2011, 12, 1).in_tz("Pacific/Apia")?;
     /// assert_eq!(first_of_month.days_in_month(), 31);
     /// let one_month_later = first_of_month.checked_add(1.month())?;
     ///
@@ -1297,10 +1297,10 @@ impl Zoned {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt = date(2024, 2, 29).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 2, 29).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt.first_of_year()?,
-    ///     date(2024, 1, 1).at(7, 30, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 1, 1).at(7, 30, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1329,10 +1329,10 @@ impl Zoned {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt = date(2024, 2, 5).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 2, 5).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt.last_of_year()?,
-    ///     date(2024, 12, 31).at(7, 30, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 12, 31).at(7, 30, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1356,10 +1356,10 @@ impl Zoned {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt = date(2024, 7, 10).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 7, 10).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.days_in_year(), 366);
     ///
-    /// let zdt = date(2023, 7, 10).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2023, 7, 10).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.days_in_year(), 365);
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1377,10 +1377,10 @@ impl Zoned {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt = date(2024, 1, 1).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 1, 1).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert!(zdt.in_leap_year());
     ///
-    /// let zdt = date(2023, 12, 31).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2023, 12, 31).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert!(!zdt.in_leap_year());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1414,14 +1414,14 @@ impl Zoned {
     /// ```
     /// use jiff::{civil::date, Timestamp};
     ///
-    /// let zdt = date(2024, 2, 28).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 2, 28).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt.tomorrow()?,
-    ///     date(2024, 2, 29).at(7, 30, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 2, 29).at(7, 30, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// // The max doesn't have a tomorrow.
-    /// assert!(Timestamp::MAX.intz("America/New_York")?.tomorrow().is_err());
+    /// assert!(Timestamp::MAX.in_tz("America/New_York")?.tomorrow().is_err());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -1431,10 +1431,10 @@ impl Zoned {
     /// ```
     /// use jiff::{civil::date, Timestamp};
     ///
-    /// let zdt = date(2024, 3, 9).at(2, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 3, 9).at(2, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt.tomorrow()?,
-    ///     date(2024, 3, 10).at(3, 30, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 3, 10).at(3, 30, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1468,14 +1468,14 @@ impl Zoned {
     /// ```
     /// use jiff::{civil::date, Timestamp};
     ///
-    /// let zdt = date(2024, 3, 1).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 3, 1).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt.yesterday()?,
-    ///     date(2024, 2, 29).at(7, 30, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 2, 29).at(7, 30, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// // The min doesn't have a yesterday.
-    /// assert!(Timestamp::MIN.intz("America/New_York")?.yesterday().is_err());
+    /// assert!(Timestamp::MIN.in_tz("America/New_York")?.yesterday().is_err());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -1485,7 +1485,7 @@ impl Zoned {
     /// ```
     /// use jiff::{civil::date, Timestamp};
     ///
-    /// let zdt = date(2024, 11, 4).at(1, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 11, 4).at(1, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt.yesterday()?.to_string(),
     ///     // Consistent with the "compatible" disambiguation strategy, the
@@ -1538,11 +1538,11 @@ impl Zoned {
     /// ```
     /// use jiff::civil::{Weekday, date};
     ///
-    /// let zdt = date(2017, 3, 1).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2017, 3, 1).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// let second_friday = zdt.nth_weekday_of_month(2, Weekday::Friday)?;
     /// assert_eq!(
     ///     second_friday,
-    ///     date(2017, 3, 10).at(7, 30, 0, 0).intz("America/New_York")?,
+    ///     date(2017, 3, 10).at(7, 30, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1554,11 +1554,11 @@ impl Zoned {
     /// ```
     /// use jiff::civil::{Weekday, date};
     ///
-    /// let zdt = date(2024, 3, 1).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 3, 1).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// let last_thursday = zdt.nth_weekday_of_month(-1, Weekday::Thursday)?;
     /// assert_eq!(
     ///     last_thursday,
-    ///     date(2024, 3, 28).at(7, 30, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 3, 28).at(7, 30, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// let second_last_thursday = zdt.nth_weekday_of_month(
@@ -1567,7 +1567,7 @@ impl Zoned {
     /// )?;
     /// assert_eq!(
     ///     second_last_thursday,
-    ///     date(2024, 3, 21).at(7, 30, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 3, 21).at(7, 30, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1579,11 +1579,11 @@ impl Zoned {
     /// ```
     /// use jiff::civil::{Weekday, date};
     ///
-    /// let zdt = date(2024, 3, 25).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 3, 25).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// let fourth_monday = zdt.nth_weekday_of_month(4, Weekday::Monday)?;
     /// assert_eq!(
     ///     fourth_monday,
-    ///     date(2024, 3, 25).at(7, 30, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 3, 25).at(7, 30, 0, 0).in_tz("America/New_York")?,
     /// );
     /// // There is no 5th Monday.
     /// assert!(zdt.nth_weekday_of_month(5, Weekday::Monday).is_err());
@@ -1643,14 +1643,14 @@ impl Zoned {
     /// use jiff::civil::{Weekday, date};
     ///
     /// // Use a Sunday in March as our start date.
-    /// let zdt = date(2024, 3, 10).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 3, 10).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.weekday(), Weekday::Sunday);
     ///
     /// // The first next Monday is tomorrow!
     /// let next_monday = zdt.nth_weekday(1, Weekday::Monday)?;
     /// assert_eq!(
     ///     next_monday,
-    ///     date(2024, 3, 11).at(7, 30, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 3, 11).at(7, 30, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// // But the next Sunday is a week away, because this doesn't
@@ -1658,14 +1658,14 @@ impl Zoned {
     /// let next_sunday = zdt.nth_weekday(1, Weekday::Sunday)?;
     /// assert_eq!(
     ///     next_sunday,
-    ///     date(2024, 3, 17).at(7, 30, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 3, 17).at(7, 30, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// // "not this Thursday, but next Thursday"
     /// let next_next_thursday = zdt.nth_weekday(2, Weekday::Thursday)?;
     /// assert_eq!(
     ///     next_next_thursday,
-    ///     date(2024, 3, 21).at(7, 30, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 3, 21).at(7, 30, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1678,28 +1678,28 @@ impl Zoned {
     /// use jiff::civil::{Weekday, date};
     ///
     /// // Use a Sunday in March as our start date.
-    /// let zdt = date(2024, 3, 10).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 3, 10).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.weekday(), Weekday::Sunday);
     ///
     /// // "last Saturday" was yesterday!
     /// let last_saturday = zdt.nth_weekday(-1, Weekday::Saturday)?;
     /// assert_eq!(
     ///     last_saturday,
-    ///     date(2024, 3, 9).at(7, 30, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 3, 9).at(7, 30, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// // "last Sunday" was a week ago.
     /// let last_sunday = zdt.nth_weekday(-1, Weekday::Sunday)?;
     /// assert_eq!(
     ///     last_sunday,
-    ///     date(2024, 3, 3).at(7, 30, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 3, 3).at(7, 30, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// // "not last Thursday, but the one before"
     /// let prev_prev_thursday = zdt.nth_weekday(-2, Weekday::Thursday)?;
     /// assert_eq!(
     ///     prev_prev_thursday,
-    ///     date(2024, 2, 29).at(7, 30, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 2, 29).at(7, 30, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1711,11 +1711,11 @@ impl Zoned {
     /// ```
     /// use jiff::{civil::Weekday, Timestamp};
     ///
-    /// let zdt = Timestamp::MAX.intz("America/New_York")?;
+    /// let zdt = Timestamp::MAX.in_tz("America/New_York")?;
     /// assert_eq!(zdt.weekday(), Weekday::Thursday);
     /// assert!(zdt.nth_weekday(1, Weekday::Saturday).is_err());
     ///
-    /// let zdt = Timestamp::MIN.intz("America/New_York")?;
+    /// let zdt = Timestamp::MIN.in_tz("America/New_York")?;
     /// assert_eq!(zdt.weekday(), Weekday::Monday);
     /// assert!(zdt.nth_weekday(-1, Weekday::Sunday).is_err());
     ///
@@ -1732,18 +1732,18 @@ impl Zoned {
     /// ```
     /// use jiff::civil::{Weekday, date};
     ///
-    /// let zdt = date(2024, 3, 15).at(7, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 3, 15).at(7, 30, 0, 0).in_tz("America/New_York")?;
     /// // For weeks starting with Sunday.
     /// let start_of_week = zdt.tomorrow()?.nth_weekday(-1, Weekday::Sunday)?;
     /// assert_eq!(
     ///     start_of_week,
-    ///     date(2024, 3, 10).at(7, 30, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 3, 10).at(7, 30, 0, 0).in_tz("America/New_York")?,
     /// );
     /// // For weeks starting with Monday.
     /// let start_of_week = zdt.tomorrow()?.nth_weekday(-1, Weekday::Monday)?;
     /// assert_eq!(
     ///     start_of_week,
-    ///     date(2024, 3, 11).at(7, 30, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 3, 11).at(7, 30, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1757,23 +1757,23 @@ impl Zoned {
     /// use jiff::civil::{Time, Weekday, date};
     ///
     /// // The start of the week.
-    /// let zdt = date(2024, 3, 10).at(0, 0, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 3, 10).at(0, 0, 0, 0).in_tz("America/New_York")?;
     /// let start_of_week = zdt.tomorrow()?.nth_weekday(-1, Weekday::Sunday)?;
     /// assert_eq!(
     ///     start_of_week,
-    ///     date(2024, 3, 10).at(0, 0, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 3, 10).at(0, 0, 0, 0).in_tz("America/New_York")?,
     /// );
     /// // The end of the week.
     /// let zdt = date(2024, 3, 16)
     ///     .at(23, 59, 59, 999_999_999)
-    ///     .intz("America/New_York")?;
+    ///     .in_tz("America/New_York")?;
     /// let start_of_week = zdt
     ///     .tomorrow()?
     ///     .nth_weekday(-1, Weekday::Sunday)?
     ///     .with().time(Time::midnight()).build()?;
     /// assert_eq!(
     ///     start_of_week,
-    ///     date(2024, 3, 10).at(0, 0, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 3, 10).at(0, 0, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1796,7 +1796,7 @@ impl Zoned {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt = date(2024, 3, 14).at(18, 45, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 3, 14).at(18, 45, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.timestamp().as_second(), 1_710_456_300);
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1813,7 +1813,7 @@ impl Zoned {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt = date(2024, 3, 14).at(18, 45, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 3, 14).at(18, 45, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.datetime(), date(2024, 3, 14).at(18, 45, 0, 0));
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1830,7 +1830,7 @@ impl Zoned {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt = date(2024, 3, 14).at(18, 45, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 3, 14).at(18, 45, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.date(), date(2024, 3, 14));
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1847,7 +1847,7 @@ impl Zoned {
     /// ```
     /// use jiff::civil::{date, time};
     ///
-    /// let zdt = date(2024, 3, 14).at(18, 45, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 3, 14).at(18, 45, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt.time(), time(18, 45, 0, 0));
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -1876,25 +1876,25 @@ impl Zoned {
     /// ```
     /// use jiff::civil::{Date, Time, Weekday, date};
     ///
-    /// let zdt = date(1995, 1, 1).at(18, 45, 0, 0).intz("US/Eastern")?;
+    /// let zdt = date(1995, 1, 1).at(18, 45, 0, 0).in_tz("US/Eastern")?;
     /// let weekdate = zdt.iso_week_date();
     /// assert_eq!(weekdate.year(), 1994);
     /// assert_eq!(weekdate.week(), 52);
     /// assert_eq!(weekdate.weekday(), Weekday::Sunday);
     ///
-    /// let zdt = date(1996, 12, 31).at(18, 45, 0, 0).intz("US/Eastern")?;
+    /// let zdt = date(1996, 12, 31).at(18, 45, 0, 0).in_tz("US/Eastern")?;
     /// let weekdate = zdt.iso_week_date();
     /// assert_eq!(weekdate.year(), 1997);
     /// assert_eq!(weekdate.week(), 1);
     /// assert_eq!(weekdate.weekday(), Weekday::Tuesday);
     ///
-    /// let zdt = date(2019, 12, 30).at(18, 45, 0, 0).intz("US/Eastern")?;
+    /// let zdt = date(2019, 12, 30).at(18, 45, 0, 0).in_tz("US/Eastern")?;
     /// let weekdate = zdt.iso_week_date();
     /// assert_eq!(weekdate.year(), 2020);
     /// assert_eq!(weekdate.week(), 1);
     /// assert_eq!(weekdate.weekday(), Weekday::Monday);
     ///
-    /// let zdt = date(2024, 3, 9).at(18, 45, 0, 0).intz("US/Eastern")?;
+    /// let zdt = date(2024, 3, 9).at(18, 45, 0, 0).in_tz("US/Eastern")?;
     /// let weekdate = zdt.iso_week_date();
     /// assert_eq!(weekdate.year(), 2024);
     /// assert_eq!(weekdate.week(), 10);
@@ -1914,11 +1914,11 @@ impl Zoned {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt = date(2024, 2, 14).at(18, 45, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 2, 14).at(18, 45, 0, 0).in_tz("America/New_York")?;
     /// // -05 because New York is in "standard" time at this point.
     /// assert_eq!(zdt.offset(), jiff::tz::offset(-5));
     ///
-    /// let zdt = date(2024, 7, 14).at(18, 45, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 7, 14).at(18, 45, 0, 0).in_tz("America/New_York")?;
     /// // But we get -04 once "summer" or "daylight saving time" starts.
     /// assert_eq!(zdt.offset(), jiff::tz::offset(-4));
     ///
@@ -1972,18 +1972,18 @@ impl Zoned {
     ///
     /// let zdt = date(1995, 12, 7)
     ///     .at(3, 24, 30, 3_500)
-    ///     .intz("America/New_York")?;
+    ///     .in_tz("America/New_York")?;
     /// let got = zdt.checked_add(20.years().months(4).nanoseconds(500))?;
     /// assert_eq!(
     ///     got,
-    ///     date(2016, 4, 7).at(3, 24, 30, 4_000).intz("America/New_York")?,
+    ///     date(2016, 4, 7).at(3, 24, 30, 4_000).in_tz("America/New_York")?,
     /// );
     ///
-    /// let zdt = date(2019, 1, 31).at(15, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2019, 1, 31).at(15, 30, 0, 0).in_tz("America/New_York")?;
     /// let got = zdt.checked_add(1.months())?;
     /// assert_eq!(
     ///     got,
-    ///     date(2019, 2, 28).at(15, 30, 0, 0).intz("America/New_York")?,
+    ///     date(2019, 2, 28).at(15, 30, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -2001,11 +2001,11 @@ impl Zoned {
     ///
     /// let zdt = date(1995, 12, 7)
     ///     .at(3, 24, 30, 3_500)
-    ///     .intz("America/New_York")?;
+    ///     .in_tz("America/New_York")?;
     /// let got = &zdt + 20.years().months(4).nanoseconds(500);
     /// assert_eq!(
     ///     got,
-    ///     date(2016, 4, 7).at(3, 24, 30, 4_000).intz("America/New_York")?,
+    ///     date(2016, 4, 7).at(3, 24, 30, 4_000).in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -2021,7 +2021,7 @@ impl Zoned {
     /// ```
     /// use jiff::{civil::date, ToSpan};
     ///
-    /// let zdt = date(2024, 3, 10).at(0, 0, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 3, 10).at(0, 0, 0, 0).in_tz("America/New_York")?;
     ///
     /// let one_day_later = zdt.checked_add(1.day())?;
     /// assert_eq!(
@@ -2052,7 +2052,7 @@ impl Zoned {
     /// ```
     /// use jiff::{civil::date, ToSpan};
     ///
-    /// let zdt = date(2024, 3, 9).at(2, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 3, 9).at(2, 30, 0, 0).in_tz("America/New_York")?;
     /// let one_day_later = zdt.checked_add(1.day())?;
     /// assert_eq!(
     ///     one_day_later.to_string(),
@@ -2069,7 +2069,7 @@ impl Zoned {
     /// ```
     /// use jiff::{civil::date, ToSpan};
     ///
-    /// let zdt = date(2024, 11, 2).at(1, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 11, 2).at(1, 30, 0, 0).in_tz("America/New_York")?;
     /// let one_day_later = zdt.checked_add(1.day())?;
     /// assert_eq!(
     ///     one_day_later.to_string(),
@@ -2088,12 +2088,12 @@ impl Zoned {
     ///
     /// let zdt = date(2024, 3, 31)
     ///     .at(19, 5, 59, 999_999_999)
-    ///     .intz("America/New_York")?;
+    ///     .in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt.checked_add(-1.months())?,
     ///     date(2024, 2, 29).
     ///         at(19, 5, 59, 999_999_999)
-    ///         .intz("America/New_York")?,
+    ///         .in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -2104,7 +2104,7 @@ impl Zoned {
     /// ```
     /// use jiff::{civil::date, ToSpan};
     ///
-    /// let zdt = date(2024, 3, 31).at(13, 13, 13, 13).intz("America/New_York")?;
+    /// let zdt = date(2024, 3, 31).at(13, 13, 13, 13).in_tz("America/New_York")?;
     /// assert!(zdt.checked_add(9000.years()).is_err());
     /// assert!(zdt.checked_add(-19000.years()).is_err());
     ///
@@ -2121,28 +2121,28 @@ impl Zoned {
     ///
     /// use jiff::{civil::date, SignedDuration};
     ///
-    /// let zdt = date(2024, 2, 29).at(0, 0, 0, 0).intz("US/Eastern")?;
+    /// let zdt = date(2024, 2, 29).at(0, 0, 0, 0).in_tz("US/Eastern")?;
     ///
     /// let dur = SignedDuration::from_hours(25);
     /// assert_eq!(
     ///     zdt.checked_add(dur)?,
-    ///     date(2024, 3, 1).at(1, 0, 0, 0).intz("US/Eastern")?,
+    ///     date(2024, 3, 1).at(1, 0, 0, 0).in_tz("US/Eastern")?,
     /// );
     /// assert_eq!(
     ///     zdt.checked_add(-dur)?,
-    ///     date(2024, 2, 27).at(23, 0, 0, 0).intz("US/Eastern")?,
+    ///     date(2024, 2, 27).at(23, 0, 0, 0).in_tz("US/Eastern")?,
     /// );
     ///
     /// let dur = Duration::from_secs(25 * 60 * 60);
     /// assert_eq!(
     ///     zdt.checked_add(dur)?,
-    ///     date(2024, 3, 1).at(1, 0, 0, 0).intz("US/Eastern")?,
+    ///     date(2024, 3, 1).at(1, 0, 0, 0).in_tz("US/Eastern")?,
     /// );
     /// // One cannot negate an unsigned duration,
     /// // but you can subtract it!
     /// assert_eq!(
     ///     zdt.checked_sub(dur)?,
-    ///     date(2024, 2, 27).at(23, 0, 0, 0).intz("US/Eastern")?,
+    ///     date(2024, 2, 27).at(23, 0, 0, 0).in_tz("US/Eastern")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -2236,23 +2236,23 @@ impl Zoned {
     ///
     /// let zdt = date(1995, 12, 7)
     ///     .at(3, 24, 30, 3_500)
-    ///     .intz("America/New_York")?;
+    ///     .in_tz("America/New_York")?;
     /// let got = &zdt - 20.years().months(4).nanoseconds(500);
     /// assert_eq!(
     ///     got,
-    ///     date(1975, 8, 7).at(3, 24, 30, 3_000).intz("America/New_York")?,
+    ///     date(1975, 8, 7).at(3, 24, 30, 3_000).in_tz("America/New_York")?,
     /// );
     ///
     /// let dur = SignedDuration::new(24 * 60 * 60, 500);
     /// assert_eq!(
     ///     &zdt - dur,
-    ///     date(1995, 12, 6).at(3, 24, 30, 3_000).intz("America/New_York")?,
+    ///     date(1995, 12, 6).at(3, 24, 30, 3_000).in_tz("America/New_York")?,
     /// );
     ///
     /// let dur = Duration::new(24 * 60 * 60, 500);
     /// assert_eq!(
     ///     &zdt - dur,
-    ///     date(1995, 12, 6).at(3, 24, 30, 3_000).intz("America/New_York")?,
+    ///     date(1995, 12, 6).at(3, 24, 30, 3_000).in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -2281,7 +2281,7 @@ impl Zoned {
     /// ```
     /// use jiff::{civil::date, SignedDuration, Timestamp, ToSpan};
     ///
-    /// let zdt = date(2024, 3, 31).at(13, 13, 13, 13).intz("America/New_York")?;
+    /// let zdt = date(2024, 3, 31).at(13, 13, 13, 13).in_tz("America/New_York")?;
     /// assert_eq!(Timestamp::MAX, zdt.saturating_add(9000.years()).timestamp());
     /// assert_eq!(Timestamp::MIN, zdt.saturating_add(-19000.years()).timestamp());
     /// assert_eq!(Timestamp::MAX, zdt.saturating_add(SignedDuration::MAX).timestamp());
@@ -2314,7 +2314,7 @@ impl Zoned {
     /// ```
     /// use jiff::{civil::date, SignedDuration, Timestamp, ToSpan};
     ///
-    /// let zdt = date(2024, 3, 31).at(13, 13, 13, 13).intz("America/New_York")?;
+    /// let zdt = date(2024, 3, 31).at(13, 13, 13, 13).in_tz("America/New_York")?;
     /// assert_eq!(Timestamp::MIN, zdt.saturating_sub(19000.years()).timestamp());
     /// assert_eq!(Timestamp::MAX, zdt.saturating_sub(-9000.years()).timestamp());
     /// assert_eq!(Timestamp::MIN, zdt.saturating_sub(SignedDuration::MAX).timestamp());
@@ -2395,8 +2395,8 @@ impl Zoned {
     /// ```
     /// use jiff::{civil::date, ToSpan};
     ///
-    /// let earlier = date(2006, 8, 24).at(22, 30, 0, 0).intz("America/New_York")?;
-    /// let later = date(2019, 1, 31).at(21, 0, 0, 0).intz("America/New_York")?;
+    /// let earlier = date(2006, 8, 24).at(22, 30, 0, 0).in_tz("America/New_York")?;
+    /// let later = date(2019, 1, 31).at(21, 0, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(earlier.until(&later)?, 109_031.hours().minutes(30));
     ///
     /// // Flipping the dates is fine, but you'll get a negative span.
@@ -2414,8 +2414,8 @@ impl Zoned {
     /// ```
     /// use jiff::{civil::date, Unit, ToSpan};
     ///
-    /// let zdt1 = date(1995, 12, 07).at(3, 24, 30, 3500).intz("America/New_York")?;
-    /// let zdt2 = date(2019, 01, 31).at(15, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt1 = date(1995, 12, 07).at(3, 24, 30, 3500).in_tz("America/New_York")?;
+    /// let zdt2 = date(2019, 01, 31).at(15, 30, 0, 0).in_tz("America/New_York")?;
     ///
     /// // The default limits durations to using "hours" as the biggest unit.
     /// let span = zdt1.until(&zdt2)?;
@@ -2439,8 +2439,8 @@ impl Zoned {
     /// ```
     /// use jiff::{civil::date, Unit, ToSpan, ZonedDifference};
     ///
-    /// let zdt1 = date(1995, 12, 07).at(3, 24, 30, 3500).intz("America/New_York")?;
-    /// let zdt2 = date(2019, 01, 31).at(15, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt1 = date(1995, 12, 07).at(3, 24, 30, 3500).in_tz("America/New_York")?;
+    /// let zdt2 = date(2019, 01, 31).at(15, 30, 0, 0).in_tz("America/New_York")?;
     ///
     /// let span = zdt1.until(
     ///     ZonedDifference::from(&zdt2).smallest(Unit::Second),
@@ -2467,8 +2467,8 @@ impl Zoned {
     /// ```
     /// use jiff::{civil::date, Unit, ToSpan};
     ///
-    /// let zdt1 = date(2024, 3, 2).at(0, 0, 0, 0).intz("America/New_York")?;
-    /// let zdt2 = date(2024, 5, 1).at(0, 0, 0, 0).intz("America/New_York")?;
+    /// let zdt1 = date(2024, 3, 2).at(0, 0, 0, 0).in_tz("America/New_York")?;
+    /// let zdt2 = date(2024, 5, 1).at(0, 0, 0, 0).in_tz("America/New_York")?;
     ///
     /// let span = zdt1.until((Unit::Month, &zdt2))?;
     /// assert_eq!(span, 1.month().days(29));
@@ -2476,7 +2476,7 @@ impl Zoned {
     /// // Not the same as the original datetime!
     /// assert_eq!(
     ///     maybe_original,
-    ///     date(2024, 3, 3).at(0, 0, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 3, 3).at(0, 0, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// // But in the default configuration, hours are always the biggest unit
@@ -2527,8 +2527,8 @@ impl Zoned {
     /// ```
     /// use jiff::{civil::date, ToSpan};
     ///
-    /// let earlier = date(2006, 8, 24).at(22, 30, 0, 0).intz("America/New_York")?;
-    /// let later = date(2019, 1, 31).at(21, 0, 0, 0).intz("America/New_York")?;
+    /// let earlier = date(2006, 8, 24).at(22, 30, 0, 0).in_tz("America/New_York")?;
+    /// let later = date(2019, 1, 31).at(21, 0, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(&later - &earlier, 109_031.hours().minutes(30));
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -2578,8 +2578,8 @@ impl Zoned {
     /// ```
     /// use jiff::{civil::date, SignedDuration};
     ///
-    /// let earlier = date(2006, 8, 24).at(22, 30, 0, 0).intz("US/Eastern")?;
-    /// let later = date(2019, 1, 31).at(21, 0, 0, 0).intz("US/Eastern")?;
+    /// let earlier = date(2006, 8, 24).at(22, 30, 0, 0).in_tz("US/Eastern")?;
+    /// let later = date(2019, 1, 31).at(21, 0, 0, 0).in_tz("US/Eastern")?;
     /// assert_eq!(
     ///     earlier.duration_until(&later),
     ///     SignedDuration::from_hours(109_031) + SignedDuration::from_mins(30),
@@ -2607,8 +2607,8 @@ impl Zoned {
     /// ```
     /// use jiff::{civil::date, SignedDuration, Span, SpanRound, ToSpan, Unit};
     ///
-    /// let zdt1 = date(2024, 3, 10).at(0, 0, 0, 0).intz("US/Eastern")?;
-    /// let zdt2 = date(2024, 3, 11).at(0, 0, 0, 0).intz("US/Eastern")?;
+    /// let zdt1 = date(2024, 3, 10).at(0, 0, 0, 0).in_tz("US/Eastern")?;
+    /// let zdt2 = date(2024, 3, 11).at(0, 0, 0, 0).in_tz("US/Eastern")?;
     ///
     /// let span = zdt1.until((Unit::Day, &zdt2))?;
     /// assert_eq!(span, 1.day());
@@ -2638,8 +2638,8 @@ impl Zoned {
     ///
     /// use jiff::civil::date;
     ///
-    /// let zdt1 = date(2024, 7, 1).at(0, 0, 0, 0).intz("US/Eastern")?;
-    /// let zdt2 = date(2024, 8, 1).at(0, 0, 0, 0).intz("US/Eastern")?;
+    /// let zdt1 = date(2024, 7, 1).at(0, 0, 0, 0).in_tz("US/Eastern")?;
+    /// let zdt2 = date(2024, 8, 1).at(0, 0, 0, 0).in_tz("US/Eastern")?;
     /// let duration = Duration::try_from(zdt1.duration_until(&zdt2))?;
     /// assert_eq!(duration, Duration::from_secs(31 * 24 * 60 * 60));
     ///
@@ -2663,8 +2663,8 @@ impl Zoned {
     /// ```
     /// use jiff::{civil::date, SignedDuration};
     ///
-    /// let earlier = date(2006, 8, 24).at(22, 30, 0, 0).intz("US/Eastern")?;
-    /// let later = date(2019, 1, 31).at(21, 0, 0, 0).intz("US/Eastern")?;
+    /// let earlier = date(2006, 8, 24).at(22, 30, 0, 0).in_tz("US/Eastern")?;
+    /// let later = date(2019, 1, 31).at(21, 0, 0, 0).in_tz("US/Eastern")?;
     /// assert_eq!(
     ///     later.duration_since(&earlier),
     ///     SignedDuration::from_hours(109_031) + SignedDuration::from_mins(30),
@@ -2727,17 +2727,17 @@ impl Zoned {
     /// use jiff::{civil::date, Unit};
     ///
     /// // rounds up
-    /// let zdt = date(2024, 6, 19).at(15, 0, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 6, 19).at(15, 0, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt.round(Unit::Day)?,
-    ///     date(2024, 6, 20).at(0, 0, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 6, 20).at(0, 0, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// // rounds down
-    /// let zdt = date(2024, 6, 19).at(10, 0, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 6, 19).at(10, 0, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt.round(Unit::Day)?,
-    ///     date(2024, 6, 19).at(0, 0, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 6, 19).at(0, 0, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -2752,10 +2752,10 @@ impl Zoned {
     /// ```
     /// use jiff::{civil::date, RoundMode, Unit, Zoned, ZonedRound};
     ///
-    /// let zdt = date(2024, 6, 19).at(15, 0, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 6, 19).at(15, 0, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt.round(Unit::Day)?,
-    ///     date(2024, 6, 20).at(0, 0, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 6, 20).at(0, 0, 0, 0).in_tz("America/New_York")?,
     /// );
     /// // The default will round up to the next day for any time past noon (as
     /// // shown above), but using truncation rounding will always round down.
@@ -2763,7 +2763,7 @@ impl Zoned {
     ///     zdt.round(
     ///         ZonedRound::new().smallest(Unit::Day).mode(RoundMode::Trunc),
     ///     )?,
-    ///     date(2024, 6, 19).at(0, 0, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 6, 19).at(0, 0, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -2777,18 +2777,18 @@ impl Zoned {
     /// // rounds down
     /// let zdt = date(2024, 6, 19)
     ///     .at(15, 27, 29, 999_999_999)
-    ///     .intz("America/New_York")?;
+    ///     .in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt.round((Unit::Minute, 5))?,
-    ///     date(2024, 6, 19).at(15, 25, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 6, 19).at(15, 25, 0, 0).in_tz("America/New_York")?,
     /// );
     /// // rounds up
     /// let zdt = date(2024, 6, 19)
     ///     .at(15, 27, 30, 0)
-    ///     .intz("America/New_York")?;
+    ///     .in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt.round((Unit::Minute, 5))?,
-    ///     date(2024, 6, 19).at(15, 30, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 6, 19).at(15, 30, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -2858,7 +2858,7 @@ impl Zoned {
     /// ```
     /// use jiff::{Timestamp, Unit};
     ///
-    /// let zdt = Timestamp::MAX.intz("America/New_York")?;
+    /// let zdt = Timestamp::MAX.in_tz("America/New_York")?;
     /// assert!(zdt.round(Unit::Day).is_err());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -2895,7 +2895,7 @@ impl Zoned {
     /// ```
     /// use jiff::{civil::datetime, ToSpan};
     ///
-    /// let start = datetime(2023, 7, 15, 16, 30, 0, 0).intz("America/New_York")?;
+    /// let start = datetime(2023, 7, 15, 16, 30, 0, 0).in_tz("America/New_York")?;
     /// let end = start.checked_add(2.days())?;
     /// let mut scan_times = vec![];
     /// for zdt in start.series(5.hours()).take_while(|zdt| zdt <= end) {
@@ -2924,13 +2924,13 @@ impl Zoned {
     /// ```
     /// use jiff::{civil::date, ToSpan};
     ///
-    /// let zdt = date(2011, 12, 28).intz("Pacific/Apia")?;
+    /// let zdt = date(2011, 12, 28).in_tz("Pacific/Apia")?;
     /// let mut it = zdt.series(1.day());
-    /// assert_eq!(it.next(), Some(date(2011, 12, 28).intz("Pacific/Apia")?));
-    /// assert_eq!(it.next(), Some(date(2011, 12, 29).intz("Pacific/Apia")?));
-    /// assert_eq!(it.next(), Some(date(2011, 12, 30).intz("Pacific/Apia")?));
-    /// assert_eq!(it.next(), Some(date(2011, 12, 31).intz("Pacific/Apia")?));
-    /// assert_eq!(it.next(), Some(date(2012, 01, 01).intz("Pacific/Apia")?));
+    /// assert_eq!(it.next(), Some(date(2011, 12, 28).in_tz("Pacific/Apia")?));
+    /// assert_eq!(it.next(), Some(date(2011, 12, 29).in_tz("Pacific/Apia")?));
+    /// assert_eq!(it.next(), Some(date(2011, 12, 30).in_tz("Pacific/Apia")?));
+    /// assert_eq!(it.next(), Some(date(2011, 12, 31).in_tz("Pacific/Apia")?));
+    /// assert_eq!(it.next(), Some(date(2012, 01, 01).in_tz("Pacific/Apia")?));
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -3037,7 +3037,7 @@ impl Zoned {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt = date(2024, 7, 15).at(16, 24, 59, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 7, 15).at(16, 24, 59, 0).in_tz("America/New_York")?;
     /// let string = zdt.strftime("%a %b %e %I:%M:%S %p %Z %Y").to_string();
     /// assert_eq!(string, "Mon Jul 15 04:24:59 PM EDT 2024");
     ///
@@ -3049,6 +3049,20 @@ impl Zoned {
         format: &'f F,
     ) -> fmt::strtime::Display<'f> {
         fmt::strtime::Display { fmt: format.as_ref(), tm: self.into() }
+    }
+}
+
+/// Deprecated APIs.
+impl Zoned {
+    /// A deprecated equivalent to [`Zoned::in_tz`].
+    ///
+    /// This will be removed in `jiff 0.2`. The method was renamed to make
+    /// it clearer that the name stood for "in time zone."
+    #[deprecated(since = "0.1.25", note = "use Zoned::in_tz instead")]
+    #[inline]
+    pub fn intz(&self, name: &str) -> Result<Zoned, Error> {
+        let tz = crate::tz::db().get(name)?;
+        Ok(self.with_time_zone(tz))
     }
 }
 
@@ -3074,7 +3088,7 @@ impl Default for Zoned {
 /// ```
 /// use jiff::civil::date;
 ///
-/// let zdt = date(2024, 6, 15).at(7, 0, 0, 123_000_000).intz("US/Eastern")?;
+/// let zdt = date(2024, 6, 15).at(7, 0, 0, 123_000_000).in_tz("US/Eastern")?;
 /// assert_eq!(
 ///     format!("{zdt:.6?}"),
 ///     "2024-06-15T07:00:00.123000-04:00[US/Eastern]",
@@ -3111,7 +3125,7 @@ impl core::fmt::Debug for Zoned {
 /// ```
 /// use jiff::civil::date;
 ///
-/// let zdt = date(2024, 6, 15).at(7, 0, 0, 123_000_000).intz("US/Eastern")?;
+/// let zdt = date(2024, 6, 15).at(7, 0, 0, 123_000_000).in_tz("US/Eastern")?;
 /// assert_eq!(
 ///     format!("{zdt:.6}"),
 ///     "2024-06-15T07:00:00.123000-04:00[US/Eastern]",
@@ -3979,7 +3993,7 @@ impl<'a> From<(Unit, &'a Zoned)> for ZonedDifference<'a> {
 /// assert_eq!(
 ///     zdt.round(Unit::Second)?,
 ///     // The second rounds up and causes minutes to increase.
-///     date(2024, 6, 20).at(16, 25, 0, 0).intz("America/New_York")?,
+///     date(2024, 6, 20).at(16, 25, 0, 0).in_tz("America/New_York")?,
 /// );
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -4000,7 +4014,7 @@ impl<'a> From<(Unit, &'a Zoned)> for ZonedDifference<'a> {
 ///         ZonedRound::new().smallest(Unit::Second).mode(RoundMode::Trunc),
 ///     )?,
 ///     // The second just gets truncated as if it wasn't there.
-///     date(2024, 6, 20).at(16, 24, 59, 0).intz("America/New_York")?,
+///     date(2024, 6, 20).at(16, 24, 59, 0).in_tz("America/New_York")?,
 /// );
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -4040,15 +4054,15 @@ impl ZonedRound {
     /// ```
     /// use jiff::{civil::date, Unit, ZonedRound};
     ///
-    /// let zdt = date(2024, 6, 20).at(3, 25, 30, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 6, 20).at(3, 25, 30, 0).in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt.round(ZonedRound::new().smallest(Unit::Minute))?,
-    ///     date(2024, 6, 20).at(3, 26, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 6, 20).at(3, 26, 0, 0).in_tz("America/New_York")?,
     /// );
     /// // Or, utilize the `From<Unit> for ZonedRound` impl:
     /// assert_eq!(
     ///     zdt.round(Unit::Minute)?,
-    ///     date(2024, 6, 20).at(3, 26, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 6, 20).at(3, 26, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -4079,7 +4093,7 @@ impl ZonedRound {
     ///             .smallest(Unit::Minute)
     ///             .mode(RoundMode::Ceil),
     ///     )?,
-    ///     date(2024, 6, 20).at(3, 26, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 6, 20).at(3, 26, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -4121,7 +4135,7 @@ impl ZonedRound {
     /// let zdt: Zoned = "2024-06-20 03:24:59[America/New_York]".parse()?;
     /// assert_eq!(
     ///     zdt.round((Unit::Minute, 10))?,
-    ///     date(2024, 6, 20).at(3, 20, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 6, 20).at(3, 20, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -4191,18 +4205,18 @@ impl From<(Unit, i64)> for ZonedRound {
 /// ```
 /// use jiff::civil::date;
 ///
-/// let zdt1 = date(2024, 10, 31).at(0, 0, 0, 0).intz("America/New_York")?;
+/// let zdt1 = date(2024, 10, 31).at(0, 0, 0, 0).in_tz("America/New_York")?;
 /// let zdt2 = zdt1.with().month(11).day(30).build()?;
 /// assert_eq!(
 ///     zdt2,
-///     date(2024, 11, 30).at(0, 0, 0, 0).intz("America/New_York")?,
+///     date(2024, 11, 30).at(0, 0, 0, 0).in_tz("America/New_York")?,
 /// );
 ///
-/// let zdt1 = date(2024, 4, 30).at(0, 0, 0, 0).intz("America/New_York")?;
+/// let zdt1 = date(2024, 4, 30).at(0, 0, 0, 0).in_tz("America/New_York")?;
 /// let zdt2 = zdt1.with().day(31).month(7).build()?;
 /// assert_eq!(
 ///     zdt2,
-///     date(2024, 7, 31).at(0, 0, 0, 0).intz("America/New_York")?,
+///     date(2024, 7, 31).at(0, 0, 0, 0).in_tz("America/New_York")?,
 /// );
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -4246,17 +4260,17 @@ impl ZonedWith {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt = date(2023, 1, 1).at(12, 0, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2023, 1, 1).at(12, 0, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt.with().day_of_year_no_leap(365).build()?,
-    ///     date(2023, 12, 31).at(12, 0, 0, 0).intz("America/New_York")?,
+    ///     date(2023, 12, 31).at(12, 0, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// // It also works with leap years for the same input:
-    /// let zdt = date(2024, 1, 1).at(12, 0, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 1, 1).at(12, 0, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt.with().day_of_year_no_leap(365).build()?,
-    ///     date(2024, 12, 31).at(12, 0, 0, 0).intz("America/New_York")?,
+    ///     date(2024, 12, 31).at(12, 0, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -4270,10 +4284,10 @@ impl ZonedWith {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt = date(2024, 11, 30).at(15, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 11, 30).at(15, 30, 0, 0).in_tz("America/New_York")?;
     /// assert!(zdt.with().day(31).build().is_err());
     ///
-    /// let zdt = date(2024, 2, 29).at(15, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 2, 29).at(15, 30, 0, 0).in_tz("America/New_York")?;
     /// assert!(zdt.with().year(2023).build().is_err());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -4298,12 +4312,12 @@ impl ZonedWith {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt1 = date(2005, 11, 5).at(15, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt1 = date(2005, 11, 5).at(15, 30, 0, 0).in_tz("America/New_York")?;
     /// let zdt2 = zdt1.with().date(date(2017, 10, 31)).build()?;
     /// // The date changes but the time remains the same.
     /// assert_eq!(
     ///     zdt2,
-    ///     date(2017, 10, 31).at(15, 30, 0, 0).intz("America/New_York")?,
+    ///     date(2017, 10, 31).at(15, 30, 0, 0).in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -4326,14 +4340,14 @@ impl ZonedWith {
     /// ```
     /// use jiff::civil::{date, time};
     ///
-    /// let zdt1 = date(2005, 11, 5).at(15, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt1 = date(2005, 11, 5).at(15, 30, 0, 0).in_tz("America/New_York")?;
     /// let zdt2 = zdt1.with().time(time(23, 59, 59, 123_456_789)).build()?;
     /// // The time changes but the date remains the same.
     /// assert_eq!(
     ///     zdt2,
     ///     date(2005, 11, 5)
     ///         .at(23, 59, 59, 123_456_789)
-    ///         .intz("America/New_York")?,
+    ///         .in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -4362,7 +4376,7 @@ impl ZonedWith {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt1 = date(2005, 11, 5).at(15, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt1 = date(2005, 11, 5).at(15, 30, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt1.year(), 2005);
     /// let zdt2 = zdt1.with().year(2007).build()?;
     /// assert_eq!(zdt2.year(), 2007);
@@ -4378,7 +4392,7 @@ impl ZonedWith {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt = date(2024, 2, 29).at(1, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 2, 29).at(1, 30, 0, 0).in_tz("America/New_York")?;
     /// assert!(zdt.with().year(2023).build().is_err());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -4407,7 +4421,7 @@ impl ZonedWith {
     /// ```
     /// use jiff::civil::{Era, date};
     ///
-    /// let zdt1 = date(2005, 11, 5).at(8, 0, 0, 0).intz("America/New_York")?;
+    /// let zdt1 = date(2005, 11, 5).at(8, 0, 0, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt1.year(), 2005);
     /// let zdt2 = zdt1.with().era_year(2007, Era::CE).build()?;
     /// assert_eq!(zdt2.year(), 2007);
@@ -4425,7 +4439,7 @@ impl ZonedWith {
     /// ```
     /// use jiff::civil::{Era, date};
     ///
-    /// let zdt1 = date(-27, 7, 1).at(8, 22, 30, 0).intz("America/New_York")?;
+    /// let zdt1 = date(-27, 7, 1).at(8, 22, 30, 0).in_tz("America/New_York")?;
     /// assert_eq!(zdt1.year(), -27);
     /// assert_eq!(zdt1.era_year(), (28, Era::BCE));
     ///
@@ -4452,11 +4466,11 @@ impl ZonedWith {
     /// ```
     /// use jiff::civil::{Era, date};
     ///
-    /// let zdt1 = date(2024, 7, 2).at(10, 27, 10, 123).intz("America/New_York")?;
+    /// let zdt1 = date(2024, 7, 2).at(10, 27, 10, 123).in_tz("America/New_York")?;
     /// let zdt2 = zdt1.with().year(2000).era_year(1900, Era::CE).build()?;
     /// assert_eq!(
     ///     zdt2,
-    ///     date(1900, 7, 2).at(10, 27, 10, 123).intz("America/New_York")?,
+    ///     date(1900, 7, 2).at(10, 27, 10, 123).in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -4468,11 +4482,11 @@ impl ZonedWith {
     /// ```
     /// use jiff::civil::{Era, date};
     ///
-    /// let zdt1 = date(2024, 7, 2).at(19, 0, 1, 1).intz("America/New_York")?;
+    /// let zdt1 = date(2024, 7, 2).at(19, 0, 1, 1).in_tz("America/New_York")?;
     /// let zdt2 = zdt1.with().era_year(1900, Era::CE).year(2000).build()?;
     /// assert_eq!(
     ///     zdt2,
-    ///     date(2000, 7, 2).at(19, 0, 1, 1).intz("America/New_York")?,
+    ///     date(2000, 7, 2).at(19, 0, 1, 1).in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -4506,7 +4520,7 @@ impl ZonedWith {
     ///
     /// let zdt1 = date(2005, 11, 5)
     ///     .at(18, 3, 59, 123_456_789)
-    ///     .intz("America/New_York")?;
+    ///     .in_tz("America/New_York")?;
     /// assert_eq!(zdt1.month(), 11);
     ///
     /// let zdt2 = zdt1.with().month(6).build()?;
@@ -4523,7 +4537,7 @@ impl ZonedWith {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt = date(2024, 10, 31).at(0, 0, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 10, 31).at(0, 0, 0, 0).in_tz("America/New_York")?;
     /// assert!(zdt.with().month(11).build().is_err());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -4552,7 +4566,7 @@ impl ZonedWith {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt1 = date(2024, 2, 5).at(21, 59, 1, 999).intz("America/New_York")?;
+    /// let zdt1 = date(2024, 2, 5).at(21, 59, 1, 999).in_tz("America/New_York")?;
     /// assert_eq!(zdt1.day(), 5);
     /// let zdt2 = zdt1.with().day(10).build()?;
     /// assert_eq!(zdt2.day(), 10);
@@ -4571,12 +4585,12 @@ impl ZonedWith {
     ///
     /// let zdt1 = date(2023, 2, 5)
     ///     .at(22, 58, 58, 9_999)
-    ///     .intz("America/New_York")?;
+    ///     .in_tz("America/New_York")?;
     /// // 2023 is not a leap year
     /// assert!(zdt1.with().day(29).build().is_err());
     ///
     /// // September has 30 days, not 31.
-    /// let zdt1 = date(2023, 9, 5).intz("America/New_York")?;
+    /// let zdt1 = date(2023, 9, 5).in_tz("America/New_York")?;
     /// assert!(zdt1.with().day(31).build().is_err());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -4613,12 +4627,12 @@ impl ZonedWith {
     ///
     /// let zdt = date(2024, 1, 1)
     ///     .at(23, 59, 59, 999_999_999)
-    ///     .intz("America/New_York")?;
+    ///     .in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt.with().day_of_year(60).build()?,
     ///     date(2024, 2, 29)
     ///         .at(23, 59, 59, 999_999_999)
-    ///         .intz("America/New_York")?,
+    ///         .in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -4631,12 +4645,12 @@ impl ZonedWith {
     ///
     /// let zdt = date(2023, 1, 1)
     ///     .at(23, 59, 59, 999_999_999)
-    ///     .intz("America/New_York")?;
+    ///     .in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt.with().day_of_year(60).build()?,
     ///     date(2023, 3, 1)
     ///         .at(23, 59, 59, 999_999_999)
-    ///         .intz("America/New_York")?,
+    ///         .in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -4648,10 +4662,10 @@ impl ZonedWith {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt = date(2023, 1, 1).at(0, 0, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2023, 1, 1).at(0, 0, 0, 0).in_tz("America/New_York")?;
     /// assert!(zdt.with().day_of_year(366).build().is_err());
     /// // The maximal year is not a leap year, so it returns an error too.
-    /// let zdt = date(9999, 1, 1).at(0, 0, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(9999, 1, 1).at(0, 0, 0, 0).in_tz("America/New_York")?;
     /// assert!(zdt.with().day_of_year(366).build().is_err());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -4693,22 +4707,22 @@ impl ZonedWith {
     ///
     /// let zdt = date(2023, 1, 1)
     ///     .at(23, 59, 59, 999_999_999)
-    ///     .intz("America/New_York")?;
+    ///     .in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt.with().day_of_year_no_leap(60).build()?,
     ///     date(2023, 3, 1)
     ///         .at(23, 59, 59, 999_999_999)
-    ///         .intz("America/New_York")?,
+    ///         .in_tz("America/New_York")?,
     /// );
     ///
     /// let zdt = date(2024, 1, 1)
     ///     .at(23, 59, 59, 999_999_999)
-    ///     .intz("America/New_York")?;
+    ///     .in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt.with().day_of_year_no_leap(60).build()?,
     ///     date(2024, 3, 1)
     ///         .at(23, 59, 59, 999_999_999)
-    ///         .intz("America/New_York")?,
+    ///         .in_tz("America/New_York")?,
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -4722,7 +4736,7 @@ impl ZonedWith {
     ///
     /// let zdt = date(2023, 1, 1)
     ///     .at(23, 59, 59, 999_999_999)
-    ///     .intz("America/New_York")?;
+    ///     .in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt.with().day_of_year_no_leap(365).build()?,
     ///     zdt.last_of_year()?,
@@ -4730,7 +4744,7 @@ impl ZonedWith {
     ///
     /// let zdt = date(2024, 1, 1)
     ///     .at(23, 59, 59, 999_999_999)
-    ///     .intz("America/New_York")?;
+    ///     .in_tz("America/New_York")?;
     /// assert_eq!(
     ///     zdt.with().day_of_year_no_leap(365).build()?,
     ///     zdt.last_of_year()?,
@@ -4740,7 +4754,7 @@ impl ZonedWith {
     /// // representable with all time zones. For example:
     /// let zdt = date(9999, 1, 1)
     ///     .at(23, 59, 59, 999_999_999)
-    ///     .intz("America/New_York")?;
+    ///     .in_tz("America/New_York")?;
     /// assert!(zdt.with().day_of_year_no_leap(365).build().is_err());
     /// // But with other time zones, it works okay:
     /// let zdt = date(9999, 1, 1)
@@ -4759,7 +4773,7 @@ impl ZonedWith {
     /// ```
     /// use jiff::civil::date;
     ///
-    /// let zdt = date(2024, 1, 1).at(5, 30, 0, 0).intz("America/New_York")?;
+    /// let zdt = date(2024, 1, 1).at(5, 30, 0, 0).in_tz("America/New_York")?;
     /// assert!(zdt.with().day_of_year_no_leap(366).build().is_err());
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -4788,7 +4802,7 @@ impl ZonedWith {
     /// ```
     /// use jiff::civil::time;
     ///
-    /// let zdt1 = time(15, 21, 59, 0).on(2010, 6, 1).intz("America/New_York")?;
+    /// let zdt1 = time(15, 21, 59, 0).on(2010, 6, 1).in_tz("America/New_York")?;
     /// assert_eq!(zdt1.hour(), 15);
     /// let zdt2 = zdt1.with().hour(3).build()?;
     /// assert_eq!(zdt2.hour(), 3);
@@ -4816,7 +4830,7 @@ impl ZonedWith {
     /// ```
     /// use jiff::civil::time;
     ///
-    /// let zdt1 = time(15, 21, 59, 0).on(2010, 6, 1).intz("America/New_York")?;
+    /// let zdt1 = time(15, 21, 59, 0).on(2010, 6, 1).in_tz("America/New_York")?;
     /// assert_eq!(zdt1.minute(), 21);
     /// let zdt2 = zdt1.with().minute(3).build()?;
     /// assert_eq!(zdt2.minute(), 3);
@@ -4844,7 +4858,7 @@ impl ZonedWith {
     /// ```
     /// use jiff::civil::time;
     ///
-    /// let zdt1 = time(15, 21, 59, 0).on(2010, 6, 1).intz("America/New_York")?;
+    /// let zdt1 = time(15, 21, 59, 0).on(2010, 6, 1).in_tz("America/New_York")?;
     /// assert_eq!(zdt1.second(), 59);
     /// let zdt2 = zdt1.with().second(3).build()?;
     /// assert_eq!(zdt2.second(), 3);
@@ -4876,7 +4890,7 @@ impl ZonedWith {
     /// ```
     /// use jiff::civil::time;
     ///
-    /// let zdt1 = time(15, 21, 35, 0).on(2010, 6, 1).intz("America/New_York")?;
+    /// let zdt1 = time(15, 21, 35, 0).on(2010, 6, 1).in_tz("America/New_York")?;
     /// let zdt2 = zdt1.with().millisecond(123).build()?;
     /// assert_eq!(zdt2.subsec_nanosecond(), 123_000_000);
     ///
@@ -4910,7 +4924,7 @@ impl ZonedWith {
     /// ```
     /// use jiff::civil::time;
     ///
-    /// let zdt1 = time(15, 21, 35, 0).on(2010, 6, 1).intz("America/New_York")?;
+    /// let zdt1 = time(15, 21, 35, 0).on(2010, 6, 1).in_tz("America/New_York")?;
     /// let zdt2 = zdt1.with().microsecond(123).build()?;
     /// assert_eq!(zdt2.subsec_nanosecond(), 123_000);
     ///
@@ -4944,7 +4958,7 @@ impl ZonedWith {
     /// ```
     /// use jiff::civil::time;
     ///
-    /// let zdt1 = time(15, 21, 35, 0).on(2010, 6, 1).intz("America/New_York")?;
+    /// let zdt1 = time(15, 21, 35, 0).on(2010, 6, 1).in_tz("America/New_York")?;
     /// let zdt2 = zdt1.with().nanosecond(123).build()?;
     /// assert_eq!(zdt2.subsec_nanosecond(), 123);
     ///
@@ -4980,7 +4994,7 @@ impl ZonedWith {
     /// ```
     /// use jiff::civil::time;
     ///
-    /// let zdt1 = time(15, 21, 35, 0).on(2010, 6, 1).intz("America/New_York")?;
+    /// let zdt1 = time(15, 21, 35, 0).on(2010, 6, 1).in_tz("America/New_York")?;
     /// let zdt2 = zdt1.with().subsec_nanosecond(123_456_789).build()?;
     /// assert_eq!(zdt2.millisecond(), 123);
     /// assert_eq!(zdt2.microsecond(), 456);
@@ -5240,10 +5254,10 @@ mod tests {
 
         let zdt1: Zoned = date(1995, 12, 7)
             .at(3, 24, 30, 3500)
-            .intz("Asia/Kolkata")
+            .in_tz("Asia/Kolkata")
             .unwrap();
         let zdt2: Zoned =
-            date(2019, 1, 31).at(15, 30, 0, 0).intz("Asia/Kolkata").unwrap();
+            date(2019, 1, 31).at(15, 30, 0, 0).in_tz("Asia/Kolkata").unwrap();
         let span = zdt1.until(&zdt2).unwrap();
         assert_eq!(
             span,
@@ -5286,10 +5300,10 @@ mod tests {
         assert_eq!(span, 730641929999996500i64.nanoseconds());
 
         let zdt1: Zoned =
-            date(2020, 1, 1).at(0, 0, 0, 0).intz("America/New_York").unwrap();
+            date(2020, 1, 1).at(0, 0, 0, 0).in_tz("America/New_York").unwrap();
         let zdt2: Zoned = date(2020, 4, 24)
             .at(21, 0, 0, 0)
-            .intz("America/New_York")
+            .in_tz("America/New_York")
             .unwrap();
         let span = zdt1.until(&zdt2).unwrap();
         assert_eq!(span, 2756.hours());
@@ -5298,11 +5312,11 @@ mod tests {
 
         let zdt1: Zoned = date(2000, 10, 29)
             .at(0, 0, 0, 0)
-            .intz("America/Vancouver")
+            .in_tz("America/Vancouver")
             .unwrap();
         let zdt2: Zoned = date(2000, 10, 29)
             .at(23, 0, 0, 5)
-            .intz("America/Vancouver")
+            .in_tz("America/Vancouver")
             .unwrap();
         let span = zdt1.until((Unit::Day, &zdt2)).unwrap();
         assert_eq!(span, 24.hours().nanoseconds(5));
@@ -5348,8 +5362,9 @@ mod tests {
             return;
         }
 
-        let expected =
-            datetime(2024, 10, 31, 16, 33, 53, 123456789).intz("UTC").unwrap();
+        let expected = datetime(2024, 10, 31, 16, 33, 53, 123456789)
+            .in_tz("UTC")
+            .unwrap();
 
         let deserialized: Zoned =
             serde_yml::from_str("2024-10-31T16:33:53.123456789+00:00[UTC]")

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -2972,7 +2972,7 @@ impl Zoned {
     /// datetime. This in turn means it will not perform daylight saving time
     /// safe arithmetic.
     ///
-    /// However, the `%V` directive may be used to both format and parse an
+    /// However, the `%Q` directive may be used to both format and parse an
     /// IANA time zone identifier. It is strongly recommended to use this
     /// directive whenever one is formatting or parsing `Zoned` values.
     ///
@@ -2992,7 +2992,7 @@ impl Zoned {
     /// ```
     /// use jiff::Zoned;
     ///
-    /// let zdt = Zoned::strptime("%F %H:%M %:V", "2024-07-14 21:14 US/Eastern")?;
+    /// let zdt = Zoned::strptime("%F %H:%M %:Q", "2024-07-14 21:14 US/Eastern")?;
     /// assert_eq!(zdt.to_string(), "2024-07-14T21:14:00-04:00[US/Eastern]");
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())

--- a/tests/tc39_262/civil/date/until.rs
+++ b/tests/tc39_262/civil/date/until.rs
@@ -10,13 +10,13 @@ use crate::tc39_262::Result;
 fn basic() {
     let d1 = date(1969, 7, 24);
     let d2 = date(1969, 10, 5);
-    assert_eq!(d2 - d1, 73.days());
+    span_eq!(d2 - d1, 73.days());
 
     let d2 = date(1996, 3, 3);
-    assert_eq!(d2 - d1, 9719.days());
+    span_eq!(d2 - d1, 9719.days());
 
     let d2 = date(2019, 7, 24);
-    assert_eq!(d2 - d1, 18262.days());
+    span_eq!(d2 - d1, 18262.days());
 }
 
 /// Source: https://github.com/tc39/test262/blob/29c6f7028a683b8259140e7d6352ae0ca6448a85/test/built-ins/Temporal/PlainDate/prototype/until/largestunit-higher-units.js
@@ -24,19 +24,19 @@ fn basic() {
 fn largestunit_higher_units() -> Result {
     let d1 = date(1969, 7, 24);
     let d2 = date(2019, 7, 24);
-    assert_eq!(d1.until((Unit::Year, d2))?, 50.years());
+    span_eq!(d1.until((Unit::Year, d2))?, 50.years());
 
     let d1 = date(2020, 2, 1);
     let d2 = date(2021, 2, 1);
-    assert_eq!(d1.until((Unit::Year, d2))?, 1.year());
-    assert_eq!(d1.until((Unit::Month, d2))?, 12.months());
-    assert_eq!(d1.until((Unit::Week, d2))?, 52.weeks().days(2));
+    span_eq!(d1.until((Unit::Year, d2))?, 1.year());
+    span_eq!(d1.until((Unit::Month, d2))?, 12.months());
+    span_eq!(d1.until((Unit::Week, d2))?, 52.weeks().days(2));
 
     let d1 = date(2021, 2, 28);
     let d2 = date(2022, 2, 28);
-    assert_eq!(d1.until((Unit::Year, d2))?, 1.year());
-    assert_eq!(d1.until((Unit::Month, d2))?, 12.months());
-    assert_eq!(d1.until((Unit::Week, d2))?, 52.weeks().days(1));
+    span_eq!(d1.until((Unit::Year, d2))?, 1.year());
+    span_eq!(d1.until((Unit::Month, d2))?, 12.months());
+    span_eq!(d1.until((Unit::Week, d2))?, 52.weeks().days(1));
 
     Ok(())
 }
@@ -71,7 +71,7 @@ fn round_cross_unit_boundary() -> Result {
         .largest(Unit::Year)
         .smallest(Unit::Month)
         .mode(RoundMode::Expand);
-    assert_eq!(d1.until(args)?, 2.years());
+    span_eq!(d1.until(args)?, 2.years());
     Ok(())
 }
 
@@ -84,12 +84,12 @@ fn rounding_relative() -> Result {
     let args = DateDifference::new(d2)
         .smallest(Unit::Month)
         .mode(RoundMode::HalfExpand);
-    assert_eq!(d1.until(args)?, 2.months());
+    span_eq!(d1.until(args)?, 2.months());
 
     let args = DateDifference::new(d1)
         .smallest(Unit::Month)
         .mode(RoundMode::HalfExpand);
-    assert_eq!(d2.until(args)?, -1.month());
+    span_eq!(d2.until(args)?, -1.month());
 
     let cases = [
         ("2019-03-01", "2019-01-29", 1, 1),
@@ -104,7 +104,7 @@ fn rounding_relative() -> Result {
     for (end, start, months, days) in cases {
         let (start, end): (Date, Date) = (start.parse()?, end.parse()?);
         let span = start.until((Unit::Month, end))?;
-        assert_eq!(span, Span::new().months(months).days(days));
+        span_eq!(span, Span::new().months(months).days(days));
     }
     Ok(())
 }
@@ -119,25 +119,25 @@ fn roundingincrement() -> Result {
         .smallest(Unit::Year)
         .mode(RoundMode::HalfExpand)
         .increment(4);
-    assert_eq!(d1.until(args)?, 4.years());
+    span_eq!(d1.until(args)?, 4.years());
 
     let args = DateDifference::new(d2)
         .smallest(Unit::Month)
         .mode(RoundMode::HalfExpand)
         .increment(10);
-    assert_eq!(d1.until(args)?, 30.months());
+    span_eq!(d1.until(args)?, 30.months());
 
     let args = DateDifference::new(d2)
         .smallest(Unit::Week)
         .mode(RoundMode::HalfExpand)
         .increment(12);
-    assert_eq!(d1.until(args)?, 144.weeks());
+    span_eq!(d1.until(args)?, 144.weeks());
 
     let args = DateDifference::new(d2)
         .smallest(Unit::Day)
         .mode(RoundMode::HalfExpand)
         .increment(100);
-    assert_eq!(d1.until(args)?, 1000.days());
+    span_eq!(d1.until(args)?, 1000.days());
 
     Ok(())
 }
@@ -153,31 +153,31 @@ fn roundingmode_ceil() -> Result {
 
     let args =
         DateDifference::new(d2).smallest(Unit::Year).mode(RoundMode::Ceil);
-    assert_eq!(d1.until(args)?, 3.years());
+    span_eq!(d1.until(args)?, 3.years());
     let args =
         DateDifference::new(d1).smallest(Unit::Year).mode(RoundMode::Ceil);
-    assert_eq!(d2.until(args)?, -2.years());
+    span_eq!(d2.until(args)?, -2.years());
 
     let args =
         DateDifference::new(d2).smallest(Unit::Month).mode(RoundMode::Ceil);
-    assert_eq!(d1.until(args)?, 32.months());
+    span_eq!(d1.until(args)?, 32.months());
     let args =
         DateDifference::new(d1).smallest(Unit::Month).mode(RoundMode::Ceil);
-    assert_eq!(d2.until(args)?, -31.months());
+    span_eq!(d2.until(args)?, -31.months());
 
     let args =
         DateDifference::new(d2).smallest(Unit::Week).mode(RoundMode::Ceil);
-    assert_eq!(d1.until(args)?, 139.weeks());
+    span_eq!(d1.until(args)?, 139.weeks());
     let args =
         DateDifference::new(d1).smallest(Unit::Week).mode(RoundMode::Ceil);
-    assert_eq!(d2.until(args)?, -139.weeks());
+    span_eq!(d2.until(args)?, -139.weeks());
 
     let args =
         DateDifference::new(d2).smallest(Unit::Day).mode(RoundMode::Ceil);
-    assert_eq!(d1.until(args)?, 973.days());
+    span_eq!(d1.until(args)?, 973.days());
     let args =
         DateDifference::new(d1).smallest(Unit::Day).mode(RoundMode::Ceil);
-    assert_eq!(d2.until(args)?, -973.days());
+    span_eq!(d2.until(args)?, -973.days());
 
     Ok(())
 }
@@ -191,17 +191,17 @@ fn smallestunit_higher_units() -> Result {
     let args = DateDifference::new(d2)
         .smallest(Unit::Year)
         .mode(RoundMode::HalfExpand);
-    assert_eq!(d1.until(args)?, 3.years());
+    span_eq!(d1.until(args)?, 3.years());
 
     let args = DateDifference::new(d2)
         .smallest(Unit::Month)
         .mode(RoundMode::HalfExpand);
-    assert_eq!(d1.until(args)?, 32.months());
+    span_eq!(d1.until(args)?, 32.months());
 
     let args = DateDifference::new(d2)
         .smallest(Unit::Week)
         .mode(RoundMode::HalfExpand);
-    assert_eq!(d1.until(args)?, 139.weeks());
+    span_eq!(d1.until(args)?, 139.weeks());
 
     Ok(())
 }
@@ -212,8 +212,8 @@ fn weeks_months() -> Result {
     let d1 = date(1969, 7, 24);
     let d2 = date(1969, 9, 4);
 
-    assert_eq!(d1.until((Unit::Week, d2))?, 6.weeks());
-    assert_eq!(d1.until((Unit::Month, d2))?, 1.month().days(11));
+    span_eq!(d1.until((Unit::Week, d2))?, 6.weeks());
+    span_eq!(d1.until((Unit::Month, d2))?, 1.month().days(11));
 
     Ok(())
 }
@@ -224,26 +224,26 @@ fn wrapping_at_end_of_month() -> Result {
     // Span between end of longer month to end of following shorter month.
     let end = date(1970, 2, 28);
     for largest in [Unit::Year, Unit::Month] {
-        assert_eq!(date(1970, 1, 28).until((largest, end))?, 1.month());
-        assert_eq!(date(1970, 1, 29).until((largest, end))?, 30.days());
-        assert_eq!(date(1970, 1, 30).until((largest, end))?, 29.days());
-        assert_eq!(date(1970, 1, 31).until((largest, end))?, 28.days());
+        span_eq!(date(1970, 1, 28).until((largest, end))?, 1.month());
+        span_eq!(date(1970, 1, 29).until((largest, end))?, 30.days());
+        span_eq!(date(1970, 1, 30).until((largest, end))?, 29.days());
+        span_eq!(date(1970, 1, 31).until((largest, end))?, 28.days());
     }
 
     // Span between end of leap-year January to end of leap-year February.
     let end = date(1972, 2, 29);
     for largest in [Unit::Year, Unit::Month] {
-        assert_eq!(date(1972, 1, 29).until((largest, end))?, 1.month());
-        assert_eq!(date(1972, 1, 30).until((largest, end))?, 30.days());
-        assert_eq!(date(1972, 1, 31).until((largest, end))?, 29.days());
+        span_eq!(date(1972, 1, 29).until((largest, end))?, 1.month());
+        span_eq!(date(1972, 1, 30).until((largest, end))?, 30.days());
+        span_eq!(date(1972, 1, 31).until((largest, end))?, 29.days());
     }
 
     // Span between end of longer month to end of not-immediately-following
     // shorter month.
     let end = date(1970, 11, 30);
     for largest in [Unit::Year, Unit::Month] {
-        assert_eq!(date(1970, 8, 30).until((largest, end))?, 3.months());
-        assert_eq!(
+        span_eq!(date(1970, 8, 30).until((largest, end))?, 3.months());
+        span_eq!(
             date(1970, 8, 31).until((largest, end))?,
             2.months().days(30),
         );
@@ -252,27 +252,27 @@ fn wrapping_at_end_of_month() -> Result {
     // Span between end of longer month in one year to shorter month in
     // later year.
     let end = date(1973, 4, 30);
-    assert_eq!(date(1970, 12, 30).until((Unit::Month, end))?, 28.months());
-    assert_eq!(
+    span_eq!(date(1970, 12, 30).until((Unit::Month, end))?, 28.months());
+    span_eq!(
         date(1970, 12, 30).until((Unit::Year, end))?,
         2.years().months(4),
     );
-    assert_eq!(
+    span_eq!(
         date(1970, 12, 31).until((Unit::Month, end))?,
         27.months().days(30),
     );
-    assert_eq!(
+    span_eq!(
         date(1970, 12, 31).until((Unit::Year, end))?,
         2.years().months(3).days(30),
     );
 
     // Span where months passes through a month that's the same length or
     // shorter than either the start or end month
-    assert_eq!(
+    span_eq!(
         date(1970, 1, 29).until((Unit::Month, date(1970, 3, 28)))?,
         1.month().days(28),
     );
-    assert_eq!(
+    span_eq!(
         date(1970, 1, 31).until((Unit::Year, date(1971, 5, 30)))?,
         1.year().months(3).days(30),
     );

--- a/tests/tc39_262/civil/datetime/until.rs
+++ b/tests/tc39_262/civil/datetime/until.rs
@@ -10,11 +10,11 @@ use crate::tc39_262::Result;
 fn balance_negative_duration() -> Result {
     let dt1 = date(2000, 5, 2).at(9, 0, 0, 0);
     let dt2 = date(2000, 5, 5).at(10, 0, 0, 0);
-    assert_eq!(dt2.until((Unit::Day, dt1))?, -3.days().hours(1));
+    span_eq!(dt2.until((Unit::Day, dt1))?, -3.days().hours(1));
 
     let dt1 = date(2000, 5, 2).at(10, 0, 0, 0);
     let dt2 = date(2000, 5, 5).at(9, 0, 0, 0);
-    assert_eq!(dt2.until((Unit::Day, dt1))?, -2.days().hours(23));
+    span_eq!(dt2.until((Unit::Day, dt1))?, -2.days().hours(23));
 
     Ok(())
 }
@@ -24,7 +24,7 @@ fn balance_negative_duration() -> Result {
 fn balance_negative_time_units() {
     let dt = date(1996, 5, 2).at(1, 1, 1, 001_001_001);
 
-    assert_eq!(
+    span_eq!(
         dt - date(1996, 5, 2).at(0, 0, 0, 000_000_002),
         1.hour()
             .minutes(1)
@@ -33,7 +33,7 @@ fn balance_negative_time_units() {
             .microseconds(0)
             .nanoseconds(999),
     );
-    assert_eq!(
+    span_eq!(
         dt - date(1996, 5, 2).at(0, 0, 0, 000_002_000),
         1.hour()
             .minutes(1)
@@ -42,7 +42,7 @@ fn balance_negative_time_units() {
             .microseconds(999)
             .nanoseconds(1),
     );
-    assert_eq!(
+    span_eq!(
         dt - date(1996, 5, 2).at(0, 0, 0, 002_000_000),
         1.hour()
             .minutes(1)
@@ -51,7 +51,7 @@ fn balance_negative_time_units() {
             .microseconds(1)
             .nanoseconds(1),
     );
-    assert_eq!(
+    span_eq!(
         dt - date(1996, 5, 2).at(0, 0, 2, 0),
         1.hour()
             .minutes(0)
@@ -60,7 +60,7 @@ fn balance_negative_time_units() {
             .microseconds(1)
             .nanoseconds(1),
     );
-    assert_eq!(
+    span_eq!(
         dt - date(1996, 5, 2).at(0, 2, 0, 0),
         0.hour()
             .minutes(59)
@@ -69,7 +69,7 @@ fn balance_negative_time_units() {
             .microseconds(1)
             .nanoseconds(1),
     );
-    assert_eq!(
+    span_eq!(
         dt - date(1996, 5, 2).at(2, 0, 0, 0),
         -0.hour()
             .minutes(58)
@@ -107,7 +107,7 @@ fn balance() -> Result {
 fn inverse() -> Result {
     let dt1 = date(1976, 11, 18).at(15, 23, 30, 123_456_789);
     let dt2 = date(2016, 3, 3).at(18, 0, 0, 0);
-    assert_eq!(dt1.until(dt2)?, dt2.since(dt1)?);
+    span_eq!(dt1.until(dt2)?, dt2.since(dt1)?);
     Ok(())
 }
 
@@ -150,8 +150,8 @@ fn no_unncessary_units() -> Result {
     let dt1 = DateTime::from(date(2021, 2, 28));
     let dt2 = DateTime::from(date(2022, 2, 28));
 
-    assert_eq!(dt1.until((Unit::Month, dt2))?, 12.months());
-    assert_eq!(dt1.until((Unit::Year, dt2))?, 1.year());
+    span_eq!(dt1.until((Unit::Month, dt2))?, 12.months());
+    span_eq!(dt1.until((Unit::Year, dt2))?, 1.year());
 
     Ok(())
 }
@@ -166,7 +166,7 @@ fn round_cross_unit_boundary() -> Result {
         .largest(Unit::Year)
         .smallest(Unit::Month)
         .mode(RoundMode::Expand);
-    assert_eq!(dt1.until(args)?, 2.years());
+    span_eq!(dt1.until(args)?, 2.years());
 
     // Time units.
     let dt1 = date(2000, 5, 2).at(0, 0, 0, 0);
@@ -175,7 +175,7 @@ fn round_cross_unit_boundary() -> Result {
         .largest(Unit::Hour)
         .smallest(Unit::Minute)
         .mode(RoundMode::Expand);
-    assert_eq!(dt1.until(args)?, 2.hours());
+    span_eq!(dt1.until(args)?, 2.hours());
 
     // Both.
     let dt1 = date(1970, 1, 1).at(0, 0, 0, 0);
@@ -184,7 +184,7 @@ fn round_cross_unit_boundary() -> Result {
         .largest(Unit::Year)
         .smallest(Unit::Microsecond)
         .mode(RoundMode::Expand);
-    assert_eq!(dt1.until(args)?, 2.years());
+    span_eq!(dt1.until(args)?, 2.years());
 
     Ok(())
 }
@@ -195,7 +195,7 @@ fn round_negative_duration() -> Result {
     let dt1 = date(2000, 5, 2).at(12, 0, 0, 0);
     let dt2 = date(2000, 5, 5).at(0, 0, 0, 0);
     let args = DateTimeDifference::new(dt1).smallest(Unit::Day).increment(2);
-    assert_eq!(dt2.until(args)?, -2.days());
+    span_eq!(dt2.until(args)?, -2.days());
     Ok(())
 }
 
@@ -208,12 +208,12 @@ fn round_relative_to_receiver() -> Result {
     let args = DateTimeDifference::new(dt2)
         .smallest(Unit::Year)
         .mode(RoundMode::HalfExpand);
-    assert_eq!(dt1.until(args)?, 2.years());
+    span_eq!(dt1.until(args)?, 2.years());
 
     let args = DateTimeDifference::new(dt1)
         .smallest(Unit::Year)
         .mode(RoundMode::HalfExpand);
-    assert_eq!(dt2.until(args)?, -1.years());
+    span_eq!(dt2.until(args)?, -1.years());
 
     Ok(())
 }
@@ -228,25 +228,25 @@ fn roundingincrement_basic() -> Result {
         .smallest(Unit::Hour)
         .mode(RoundMode::HalfExpand)
         .increment(3);
-    assert_eq!(dt1.until(args)?, 973.days().hours(3));
+    span_eq!(dt1.until(args)?, 973.days().hours(3));
 
     let args = DateTimeDifference::new(dt2)
         .smallest(Unit::Minute)
         .mode(RoundMode::HalfExpand)
         .increment(30);
-    assert_eq!(dt1.until(args)?, 973.days().hours(4).minutes(30));
+    span_eq!(dt1.until(args)?, 973.days().hours(4).minutes(30));
 
     let args = DateTimeDifference::new(dt2)
         .smallest(Unit::Second)
         .mode(RoundMode::HalfExpand)
         .increment(15);
-    assert_eq!(dt1.until(args)?, 973.days().hours(4).minutes(17).seconds(0));
+    span_eq!(dt1.until(args)?, 973.days().hours(4).minutes(17).seconds(0));
 
     let args = DateTimeDifference::new(dt2)
         .smallest(Unit::Millisecond)
         .mode(RoundMode::HalfExpand)
         .increment(10);
-    assert_eq!(
+    span_eq!(
         dt1.until(args)?,
         973.days().hours(4).minutes(17).seconds(4).milliseconds(860)
     );
@@ -255,7 +255,7 @@ fn roundingincrement_basic() -> Result {
         .smallest(Unit::Microsecond)
         .mode(RoundMode::HalfExpand)
         .increment(10);
-    assert_eq!(
+    span_eq!(
         dt1.until(args)?,
         973.days()
             .hours(4)
@@ -269,7 +269,7 @@ fn roundingincrement_basic() -> Result {
         .smallest(Unit::Nanosecond)
         .mode(RoundMode::HalfExpand)
         .increment(10);
-    assert_eq!(
+    span_eq!(
         dt1.until(args)?,
         973.days()
             .hours(4)
@@ -362,57 +362,51 @@ fn roundingmode_ceil() -> Result {
         DateTimeDifference::new(dt).smallest(smallest).mode(RoundMode::Ceil)
     };
 
-    assert_eq!(dt1.until(mkargs(Unit::Year, dt2))?, 3.years());
-    assert_eq!(dt1.until(mkargs(Unit::Month, dt2))?, 32.months());
-    assert_eq!(dt1.until(mkargs(Unit::Week, dt2))?, 140.weeks());
-    assert_eq!(dt1.until(mkargs(Unit::Day, dt2))?, 974.days());
+    span_eq!(dt1.until(mkargs(Unit::Year, dt2))?, 3.years());
+    span_eq!(dt1.until(mkargs(Unit::Month, dt2))?, 32.months());
+    span_eq!(dt1.until(mkargs(Unit::Week, dt2))?, 140.weeks());
+    span_eq!(dt1.until(mkargs(Unit::Day, dt2))?, 974.days());
     let mut span = 973.days();
-    assert_eq!(dt1.until(mkargs(Unit::Hour, dt2))?, span.hours(5));
+    span_eq!(dt1.until(mkargs(Unit::Hour, dt2))?, span.hours(5));
     span = span.hours(4);
-    assert_eq!(dt1.until(mkargs(Unit::Minute, dt2))?, span.minutes(18));
+    span_eq!(dt1.until(mkargs(Unit::Minute, dt2))?, span.minutes(18));
     span = span.minutes(17);
-    assert_eq!(dt1.until(mkargs(Unit::Second, dt2))?, span.seconds(5));
+    span_eq!(dt1.until(mkargs(Unit::Second, dt2))?, span.seconds(5));
     span = span.seconds(4);
-    assert_eq!(
+    span_eq!(
         dt1.until(mkargs(Unit::Millisecond, dt2))?,
         span.milliseconds(865)
     );
     span = span.milliseconds(864);
-    assert_eq!(
+    span_eq!(
         dt1.until(mkargs(Unit::Microsecond, dt2))?,
         span.microseconds(198)
     );
     span = span.microseconds(197);
-    assert_eq!(
-        dt1.until(mkargs(Unit::Nanosecond, dt2))?,
-        span.nanoseconds(500)
-    );
+    span_eq!(dt1.until(mkargs(Unit::Nanosecond, dt2))?, span.nanoseconds(500));
 
-    assert_eq!(dt2.until(mkargs(Unit::Year, dt1))?, -2.years());
-    assert_eq!(dt2.until(mkargs(Unit::Month, dt1))?, -31.months());
-    assert_eq!(dt2.until(mkargs(Unit::Week, dt1))?, -139.weeks());
-    assert_eq!(dt2.until(mkargs(Unit::Day, dt1))?, -973.days());
+    span_eq!(dt2.until(mkargs(Unit::Year, dt1))?, -2.years());
+    span_eq!(dt2.until(mkargs(Unit::Month, dt1))?, -31.months());
+    span_eq!(dt2.until(mkargs(Unit::Week, dt1))?, -139.weeks());
+    span_eq!(dt2.until(mkargs(Unit::Day, dt1))?, -973.days());
     let mut span = -973.days();
-    assert_eq!(dt2.until(mkargs(Unit::Hour, dt1))?, span.hours(4));
+    span_eq!(dt2.until(mkargs(Unit::Hour, dt1))?, span.hours(4));
     span = span.hours(4);
-    assert_eq!(dt2.until(mkargs(Unit::Minute, dt1))?, span.minutes(17));
+    span_eq!(dt2.until(mkargs(Unit::Minute, dt1))?, span.minutes(17));
     span = span.minutes(17);
-    assert_eq!(dt2.until(mkargs(Unit::Second, dt1))?, span.seconds(4));
+    span_eq!(dt2.until(mkargs(Unit::Second, dt1))?, span.seconds(4));
     span = span.seconds(4);
-    assert_eq!(
+    span_eq!(
         dt2.until(mkargs(Unit::Millisecond, dt1))?,
         span.milliseconds(864)
     );
     span = span.milliseconds(864);
-    assert_eq!(
+    span_eq!(
         dt2.until(mkargs(Unit::Microsecond, dt1))?,
         span.microseconds(197)
     );
     span = span.microseconds(197);
-    assert_eq!(
-        dt2.until(mkargs(Unit::Nanosecond, dt1))?,
-        span.nanoseconds(500)
-    );
+    span_eq!(dt2.until(mkargs(Unit::Nanosecond, dt1))?, span.nanoseconds(500));
 
     Ok(())
 }
@@ -423,15 +417,15 @@ fn subseconds() -> Result {
     let dt1 = date(2020, 2, 1).at(0, 0, 0, 0);
     let dt2 = date(2020, 2, 2).at(0, 0, 0, 250_250_250);
 
-    assert_eq!(
+    span_eq!(
         dt1.until((Unit::Millisecond, dt2))?,
         86400_250.milliseconds().microseconds(250).nanoseconds(250)
     );
-    assert_eq!(
+    span_eq!(
         dt1.until((Unit::Microsecond, dt2))?,
         86400_250_250i64.microseconds().nanoseconds(250)
     );
-    assert_eq!(
+    span_eq!(
         dt1.until((Unit::Nanosecond, dt2))?,
         86400_250_250_250i64.nanoseconds()
     );
@@ -445,22 +439,22 @@ fn units_changed() -> Result {
     let dt1 = date(2020, 2, 1).at(0, 0, 0, 0);
     let dt2 = date(2021, 2, 1).at(0, 0, 0, 0);
 
-    assert_eq!(dt1.until((Unit::Year, dt2))?, 1.year());
-    assert_eq!(dt1.until((Unit::Month, dt2))?, 12.months());
-    assert_eq!(dt1.until((Unit::Week, dt2))?, 52.weeks().days(2));
-    assert_eq!(dt1.until((Unit::Day, dt2))?, 366.days());
-    assert_eq!(dt1.until((Unit::Hour, dt2))?, 8784.hours());
-    assert_eq!(dt1.until((Unit::Minute, dt2))?, 527040.minutes());
-    assert_eq!(dt1.until((Unit::Second, dt2))?, 31_622_400.seconds());
-    assert_eq!(
+    span_eq!(dt1.until((Unit::Year, dt2))?, 1.year());
+    span_eq!(dt1.until((Unit::Month, dt2))?, 12.months());
+    span_eq!(dt1.until((Unit::Week, dt2))?, 52.weeks().days(2));
+    span_eq!(dt1.until((Unit::Day, dt2))?, 366.days());
+    span_eq!(dt1.until((Unit::Hour, dt2))?, 8784.hours());
+    span_eq!(dt1.until((Unit::Minute, dt2))?, 527040.minutes());
+    span_eq!(dt1.until((Unit::Second, dt2))?, 31_622_400.seconds());
+    span_eq!(
         dt1.until((Unit::Millisecond, dt2))?,
         31_622_400_000i64.milliseconds()
     );
-    assert_eq!(
+    span_eq!(
         dt1.until((Unit::Microsecond, dt2))?,
         31_622_400_000_000i64.microseconds()
     );
-    assert_eq!(
+    span_eq!(
         dt1.until((Unit::Nanosecond, dt2))?,
         31_622_400_000_000_000i64.nanoseconds()
     );
@@ -487,26 +481,26 @@ fn wrapping_at_end_of_month() -> Result {
     // Span between end of longer month to end of following shorter month.
     let end = mkdt(1970, 2, 28);
     for largest in [Unit::Year, Unit::Month] {
-        assert_eq!(mkdt(1970, 1, 28).until((largest, end))?, 1.month());
-        assert_eq!(mkdt(1970, 1, 29).until((largest, end))?, 30.days());
-        assert_eq!(mkdt(1970, 1, 30).until((largest, end))?, 29.days());
-        assert_eq!(mkdt(1970, 1, 31).until((largest, end))?, 28.days());
+        span_eq!(mkdt(1970, 1, 28).until((largest, end))?, 1.month());
+        span_eq!(mkdt(1970, 1, 29).until((largest, end))?, 30.days());
+        span_eq!(mkdt(1970, 1, 30).until((largest, end))?, 29.days());
+        span_eq!(mkdt(1970, 1, 31).until((largest, end))?, 28.days());
     }
 
     // Span between end of leap-year January to end of leap-year February.
     let end = mkdt(1972, 2, 29);
     for largest in [Unit::Year, Unit::Month] {
-        assert_eq!(mkdt(1972, 1, 29).until((largest, end))?, 1.month());
-        assert_eq!(mkdt(1972, 1, 30).until((largest, end))?, 30.days());
-        assert_eq!(mkdt(1972, 1, 31).until((largest, end))?, 29.days());
+        span_eq!(mkdt(1972, 1, 29).until((largest, end))?, 1.month());
+        span_eq!(mkdt(1972, 1, 30).until((largest, end))?, 30.days());
+        span_eq!(mkdt(1972, 1, 31).until((largest, end))?, 29.days());
     }
 
     // Span between end of longer month to end of not-immediately-following
     // shorter month.
     let end = mkdt(1970, 11, 30);
     for largest in [Unit::Year, Unit::Month] {
-        assert_eq!(mkdt(1970, 8, 30).until((largest, end))?, 3.months());
-        assert_eq!(
+        span_eq!(mkdt(1970, 8, 30).until((largest, end))?, 3.months());
+        span_eq!(
             mkdt(1970, 8, 31).until((largest, end))?,
             2.months().days(30)
         );
@@ -515,27 +509,27 @@ fn wrapping_at_end_of_month() -> Result {
     // Span between end of longer month in one year to shorter month in
     // later year.
     let end = mkdt(1973, 4, 30);
-    assert_eq!(mkdt(1970, 12, 30).until((Unit::Month, end))?, 28.months());
-    assert_eq!(
+    span_eq!(mkdt(1970, 12, 30).until((Unit::Month, end))?, 28.months());
+    span_eq!(
         mkdt(1970, 12, 30).until((Unit::Year, end))?,
         2.years().months(4)
     );
-    assert_eq!(
+    span_eq!(
         mkdt(1970, 12, 31).until((Unit::Month, end))?,
         27.months().days(30),
     );
-    assert_eq!(
+    span_eq!(
         mkdt(1970, 12, 31).until((Unit::Year, end))?,
         2.years().months(3).days(30),
     );
 
     // Span where months passes through a month that's the same length or
     // shorter than either the start or end month.
-    assert_eq!(
+    span_eq!(
         mkdt(1970, 1, 29).until((Unit::Month, mkdt(1970, 3, 28)))?,
         1.month().days(28)
     );
-    assert_eq!(
+    span_eq!(
         mkdt(1970, 1, 31).until((Unit::Year, mkdt(1971, 5, 30)))?,
         1.year().months(3).days(30)
     );
@@ -547,7 +541,7 @@ fn wrapping_at_end_of_month() -> Result {
     // See: https://github.com/tc39/proposal-temporal/issues/2820
     let dt1 = date(2023, 2, 28).at(3, 0, 0, 0);
     let dt2 = date(2023, 4, 1).at(2, 0, 0, 0);
-    assert_eq!(dt1.until((Unit::Year, dt2))?, 1.month().days(3).hours(23));
+    span_eq!(dt1.until((Unit::Year, dt2))?, 1.month().days(3).hours(23));
 
     // Test that 1-day backoff to maintain date/time sign compatibility
     // backs-off from correct end while moving *forwards* in time and does not
@@ -556,7 +550,7 @@ fn wrapping_at_end_of_month() -> Result {
     // See: https://github.com/tc39/proposal-temporal/issues/2820
     let dt1 = date(2023, 3, 1).at(2, 0, 0, 0);
     let dt2 = date(2023, 1, 1).at(3, 0, 0, 0);
-    assert_eq!(dt1.until((Unit::Year, dt2))?, -1.month().days(30).hours(23));
+    span_eq!(dt1.until((Unit::Year, dt2))?, -1.month().days(30).hours(23));
 
     Ok(())
 }

--- a/tests/tc39_262/civil/time/until.rs
+++ b/tests/tc39_262/civil/time/until.rs
@@ -17,7 +17,7 @@ fn argument_cast() -> Result {
         .milliseconds(876)
         .microseconds(543)
         .nanoseconds(211);
-    assert_eq!(t1.until(t2)?, span);
+    span_eq!(t1.until(t2)?, span);
     Ok(())
 }
 
@@ -123,7 +123,7 @@ fn result_sub_second() -> Result {
     let t1 = time(10, 23, 15, 0);
     let t2 = time(17, 15, 57, 250_250_250);
 
-    assert_eq!(
+    span_eq!(
         t1.until((Unit::Millisecond, t2))?,
         24762250.milliseconds().microseconds(250).nanoseconds(250),
     );
@@ -135,7 +135,7 @@ fn result_sub_second() -> Result {
         "PT24762.25025025S",
     );
 
-    assert_eq!(
+    span_eq!(
         t1.until((Unit::Microsecond, t2))?,
         2_4762_250_250i64.microseconds().nanoseconds(250)
     );
@@ -144,7 +144,7 @@ fn result_sub_second() -> Result {
         "PT24762.25025025S",
     );
 
-    assert_eq!(
+    span_eq!(
         t1.until((Unit::Nanosecond, t2))?,
         2_4762_250_250_250i64.nanoseconds(),
     );
@@ -167,7 +167,7 @@ fn round_cross_unit_boundary() -> Result {
             .largest(Unit::Hour)
             .mode(RoundMode::Expand),
     )?;
-    assert_eq!(span, 2.hours());
+    span_eq!(span, 2.hours());
     Ok(())
 }
 
@@ -178,13 +178,13 @@ fn roundingincrement_hours() -> Result {
     let t2 = time(13, 47, 57, 988_655_322);
     let args = TimeDifference::new(t2).smallest(Unit::Hour);
 
-    assert_eq!(t1.until(args.increment(1))?, 10.hours());
-    assert_eq!(t1.until(args.increment(2))?, 10.hours());
-    assert_eq!(t1.until(args.increment(3))?, 9.hours());
-    assert_eq!(t1.until(args.increment(4))?, 8.hours());
-    assert_eq!(t1.until(args.increment(6))?, 6.hours());
-    assert_eq!(t1.until(args.increment(8))?, 8.hours());
-    assert_eq!(t1.until(args.increment(12))?, 0.hours());
+    span_eq!(t1.until(args.increment(1))?, 10.hours());
+    span_eq!(t1.until(args.increment(2))?, 10.hours());
+    span_eq!(t1.until(args.increment(3))?, 9.hours());
+    span_eq!(t1.until(args.increment(4))?, 8.hours());
+    span_eq!(t1.until(args.increment(6))?, 6.hours());
+    span_eq!(t1.until(args.increment(8))?, 8.hours());
+    span_eq!(t1.until(args.increment(12))?, 0.hours());
 
     Ok(())
 }
@@ -227,21 +227,21 @@ fn roundingincrement_microseconds() -> Result {
     let args = TimeDifference::new(t2).smallest(Unit::Microsecond);
 
     let span = 10.hours().minutes(35).seconds(23).milliseconds(865);
-    assert_eq!(t1.until(args.increment(1))?, span.microseconds(198));
-    assert_eq!(t1.until(args.increment(2))?, span.microseconds(198));
-    assert_eq!(t1.until(args.increment(4))?, span.microseconds(196));
-    assert_eq!(t1.until(args.increment(5))?, span.microseconds(195));
-    assert_eq!(t1.until(args.increment(8))?, span.microseconds(192));
-    assert_eq!(t1.until(args.increment(10))?, span.microseconds(190));
-    assert_eq!(t1.until(args.increment(20))?, span.microseconds(180));
-    assert_eq!(t1.until(args.increment(25))?, span.microseconds(175));
-    assert_eq!(t1.until(args.increment(40))?, span.microseconds(160));
-    assert_eq!(t1.until(args.increment(50))?, span.microseconds(150));
-    assert_eq!(t1.until(args.increment(100))?, span.microseconds(100));
-    assert_eq!(t1.until(args.increment(125))?, span.microseconds(125));
-    assert_eq!(t1.until(args.increment(200))?, span.microseconds(0));
-    assert_eq!(t1.until(args.increment(250))?, span.microseconds(0));
-    assert_eq!(t1.until(args.increment(500))?, span.microseconds(0));
+    span_eq!(t1.until(args.increment(1))?, span.microseconds(198));
+    span_eq!(t1.until(args.increment(2))?, span.microseconds(198));
+    span_eq!(t1.until(args.increment(4))?, span.microseconds(196));
+    span_eq!(t1.until(args.increment(5))?, span.microseconds(195));
+    span_eq!(t1.until(args.increment(8))?, span.microseconds(192));
+    span_eq!(t1.until(args.increment(10))?, span.microseconds(190));
+    span_eq!(t1.until(args.increment(20))?, span.microseconds(180));
+    span_eq!(t1.until(args.increment(25))?, span.microseconds(175));
+    span_eq!(t1.until(args.increment(40))?, span.microseconds(160));
+    span_eq!(t1.until(args.increment(50))?, span.microseconds(150));
+    span_eq!(t1.until(args.increment(100))?, span.microseconds(100));
+    span_eq!(t1.until(args.increment(125))?, span.microseconds(125));
+    span_eq!(t1.until(args.increment(200))?, span.microseconds(0));
+    span_eq!(t1.until(args.increment(250))?, span.microseconds(0));
+    span_eq!(t1.until(args.increment(500))?, span.microseconds(0));
 
     Ok(())
 }
@@ -254,21 +254,21 @@ fn roundingincrement_milliseconds() -> Result {
     let args = TimeDifference::new(t2).smallest(Unit::Millisecond);
 
     let span = 10.hours().minutes(35).seconds(23);
-    assert_eq!(t1.until(args.increment(1))?, span.milliseconds(865));
-    assert_eq!(t1.until(args.increment(2))?, span.milliseconds(864));
-    assert_eq!(t1.until(args.increment(4))?, span.milliseconds(864));
-    assert_eq!(t1.until(args.increment(5))?, span.milliseconds(865));
-    assert_eq!(t1.until(args.increment(8))?, span.milliseconds(864));
-    assert_eq!(t1.until(args.increment(10))?, span.milliseconds(860));
-    assert_eq!(t1.until(args.increment(20))?, span.milliseconds(860));
-    assert_eq!(t1.until(args.increment(25))?, span.milliseconds(850));
-    assert_eq!(t1.until(args.increment(40))?, span.milliseconds(840));
-    assert_eq!(t1.until(args.increment(50))?, span.milliseconds(850));
-    assert_eq!(t1.until(args.increment(100))?, span.milliseconds(800));
-    assert_eq!(t1.until(args.increment(125))?, span.milliseconds(750));
-    assert_eq!(t1.until(args.increment(200))?, span.milliseconds(800));
-    assert_eq!(t1.until(args.increment(250))?, span.milliseconds(750));
-    assert_eq!(t1.until(args.increment(500))?, span.milliseconds(500));
+    span_eq!(t1.until(args.increment(1))?, span.milliseconds(865));
+    span_eq!(t1.until(args.increment(2))?, span.milliseconds(864));
+    span_eq!(t1.until(args.increment(4))?, span.milliseconds(864));
+    span_eq!(t1.until(args.increment(5))?, span.milliseconds(865));
+    span_eq!(t1.until(args.increment(8))?, span.milliseconds(864));
+    span_eq!(t1.until(args.increment(10))?, span.milliseconds(860));
+    span_eq!(t1.until(args.increment(20))?, span.milliseconds(860));
+    span_eq!(t1.until(args.increment(25))?, span.milliseconds(850));
+    span_eq!(t1.until(args.increment(40))?, span.milliseconds(840));
+    span_eq!(t1.until(args.increment(50))?, span.milliseconds(850));
+    span_eq!(t1.until(args.increment(100))?, span.milliseconds(800));
+    span_eq!(t1.until(args.increment(125))?, span.milliseconds(750));
+    span_eq!(t1.until(args.increment(200))?, span.milliseconds(800));
+    span_eq!(t1.until(args.increment(250))?, span.milliseconds(750));
+    span_eq!(t1.until(args.increment(500))?, span.milliseconds(500));
 
     Ok(())
 }
@@ -281,17 +281,17 @@ fn roundingincrement_minutes() -> Result {
     let args = TimeDifference::new(t2).smallest(Unit::Minute);
 
     let span = 10.hours();
-    assert_eq!(t1.until(args.increment(1))?, span.minutes(35));
-    assert_eq!(t1.until(args.increment(2))?, span.minutes(34));
-    assert_eq!(t1.until(args.increment(3))?, span.minutes(33));
-    assert_eq!(t1.until(args.increment(4))?, span.minutes(32));
-    assert_eq!(t1.until(args.increment(5))?, span.minutes(35));
-    assert_eq!(t1.until(args.increment(6))?, span.minutes(30));
-    assert_eq!(t1.until(args.increment(10))?, span.minutes(30));
-    assert_eq!(t1.until(args.increment(12))?, span.minutes(24));
-    assert_eq!(t1.until(args.increment(15))?, span.minutes(30));
-    assert_eq!(t1.until(args.increment(20))?, span.minutes(20));
-    assert_eq!(t1.until(args.increment(30))?, span.minutes(30));
+    span_eq!(t1.until(args.increment(1))?, span.minutes(35));
+    span_eq!(t1.until(args.increment(2))?, span.minutes(34));
+    span_eq!(t1.until(args.increment(3))?, span.minutes(33));
+    span_eq!(t1.until(args.increment(4))?, span.minutes(32));
+    span_eq!(t1.until(args.increment(5))?, span.minutes(35));
+    span_eq!(t1.until(args.increment(6))?, span.minutes(30));
+    span_eq!(t1.until(args.increment(10))?, span.minutes(30));
+    span_eq!(t1.until(args.increment(12))?, span.minutes(24));
+    span_eq!(t1.until(args.increment(15))?, span.minutes(30));
+    span_eq!(t1.until(args.increment(20))?, span.minutes(20));
+    span_eq!(t1.until(args.increment(30))?, span.minutes(30));
 
     Ok(())
 }
@@ -305,21 +305,21 @@ fn roundingincrement_nanoseconds() -> Result {
 
     let span =
         10.hours().minutes(35).seconds(23).milliseconds(865).microseconds(198);
-    assert_eq!(t1.until(args.increment(1))?, span.nanoseconds(533));
-    assert_eq!(t1.until(args.increment(2))?, span.nanoseconds(532));
-    assert_eq!(t1.until(args.increment(4))?, span.nanoseconds(532));
-    assert_eq!(t1.until(args.increment(5))?, span.nanoseconds(530));
-    assert_eq!(t1.until(args.increment(8))?, span.nanoseconds(528));
-    assert_eq!(t1.until(args.increment(10))?, span.nanoseconds(530));
-    assert_eq!(t1.until(args.increment(20))?, span.nanoseconds(520));
-    assert_eq!(t1.until(args.increment(25))?, span.nanoseconds(525));
-    assert_eq!(t1.until(args.increment(40))?, span.nanoseconds(520));
-    assert_eq!(t1.until(args.increment(50))?, span.nanoseconds(500));
-    assert_eq!(t1.until(args.increment(100))?, span.nanoseconds(500));
-    assert_eq!(t1.until(args.increment(125))?, span.nanoseconds(500));
-    assert_eq!(t1.until(args.increment(200))?, span.nanoseconds(400));
-    assert_eq!(t1.until(args.increment(250))?, span.nanoseconds(500));
-    assert_eq!(t1.until(args.increment(500))?, span.nanoseconds(500));
+    span_eq!(t1.until(args.increment(1))?, span.nanoseconds(533));
+    span_eq!(t1.until(args.increment(2))?, span.nanoseconds(532));
+    span_eq!(t1.until(args.increment(4))?, span.nanoseconds(532));
+    span_eq!(t1.until(args.increment(5))?, span.nanoseconds(530));
+    span_eq!(t1.until(args.increment(8))?, span.nanoseconds(528));
+    span_eq!(t1.until(args.increment(10))?, span.nanoseconds(530));
+    span_eq!(t1.until(args.increment(20))?, span.nanoseconds(520));
+    span_eq!(t1.until(args.increment(25))?, span.nanoseconds(525));
+    span_eq!(t1.until(args.increment(40))?, span.nanoseconds(520));
+    span_eq!(t1.until(args.increment(50))?, span.nanoseconds(500));
+    span_eq!(t1.until(args.increment(100))?, span.nanoseconds(500));
+    span_eq!(t1.until(args.increment(125))?, span.nanoseconds(500));
+    span_eq!(t1.until(args.increment(200))?, span.nanoseconds(400));
+    span_eq!(t1.until(args.increment(250))?, span.nanoseconds(500));
+    span_eq!(t1.until(args.increment(500))?, span.nanoseconds(500));
 
     Ok(())
 }
@@ -332,17 +332,17 @@ fn roundingincrement_seconds() -> Result {
     let args = TimeDifference::new(t2).smallest(Unit::Second);
 
     let span = 10.hours().minutes(35);
-    assert_eq!(t1.until(args.increment(1))?, span.seconds(23));
-    assert_eq!(t1.until(args.increment(2))?, span.seconds(22));
-    assert_eq!(t1.until(args.increment(3))?, span.seconds(21));
-    assert_eq!(t1.until(args.increment(4))?, span.seconds(20));
-    assert_eq!(t1.until(args.increment(5))?, span.seconds(20));
-    assert_eq!(t1.until(args.increment(6))?, span.seconds(18));
-    assert_eq!(t1.until(args.increment(10))?, span.seconds(20));
-    assert_eq!(t1.until(args.increment(12))?, span.seconds(12));
-    assert_eq!(t1.until(args.increment(15))?, span.seconds(15));
-    assert_eq!(t1.until(args.increment(20))?, span.seconds(20));
-    assert_eq!(t1.until(args.increment(30))?, span.seconds(0));
+    span_eq!(t1.until(args.increment(1))?, span.seconds(23));
+    span_eq!(t1.until(args.increment(2))?, span.seconds(22));
+    span_eq!(t1.until(args.increment(3))?, span.seconds(21));
+    span_eq!(t1.until(args.increment(4))?, span.seconds(20));
+    span_eq!(t1.until(args.increment(5))?, span.seconds(20));
+    span_eq!(t1.until(args.increment(6))?, span.seconds(18));
+    span_eq!(t1.until(args.increment(10))?, span.seconds(20));
+    span_eq!(t1.until(args.increment(12))?, span.seconds(12));
+    span_eq!(t1.until(args.increment(15))?, span.seconds(15));
+    span_eq!(t1.until(args.increment(20))?, span.seconds(20));
+    span_eq!(t1.until(args.increment(30))?, span.seconds(0));
 
     Ok(())
 }
@@ -358,45 +358,45 @@ fn roundingmode_ceil() -> Result {
     let t2 = time(12, 39, 40, 987_654_289);
 
     let args = TimeDifference::new(t2).mode(RoundMode::Ceil);
-    assert_eq!(t1.until(args.smallest(Unit::Hour))?, 5.hours());
+    span_eq!(t1.until(args.smallest(Unit::Hour))?, 5.hours());
     let span = 4.hours();
-    assert_eq!(t1.until(args.smallest(Unit::Minute))?, span.minutes(18));
+    span_eq!(t1.until(args.smallest(Unit::Minute))?, span.minutes(18));
     let span = span.minutes(17);
-    assert_eq!(t1.until(args.smallest(Unit::Second))?, span.seconds(5));
+    span_eq!(t1.until(args.smallest(Unit::Second))?, span.seconds(5));
     let span = span.seconds(4);
-    assert_eq!(
+    span_eq!(
         t1.until(args.smallest(Unit::Millisecond))?,
         span.milliseconds(865)
     );
     let span = span.milliseconds(864);
-    assert_eq!(
+    span_eq!(
         t1.until(args.smallest(Unit::Microsecond))?,
         span.microseconds(198)
     );
     let span = span.microseconds(197);
-    assert_eq!(
+    span_eq!(
         t1.until(args.smallest(Unit::Nanosecond))?,
         span.nanoseconds(500)
     );
 
     let args = TimeDifference::new(t1).mode(RoundMode::Ceil);
-    assert_eq!(t2.until(args.smallest(Unit::Hour))?, -4.hours());
+    span_eq!(t2.until(args.smallest(Unit::Hour))?, -4.hours());
     let span = -4.hours();
-    assert_eq!(t2.until(args.smallest(Unit::Minute))?, span.minutes(17));
+    span_eq!(t2.until(args.smallest(Unit::Minute))?, span.minutes(17));
     let span = span.minutes(17);
-    assert_eq!(t2.until(args.smallest(Unit::Second))?, span.seconds(4));
+    span_eq!(t2.until(args.smallest(Unit::Second))?, span.seconds(4));
     let span = span.seconds(4);
-    assert_eq!(
+    span_eq!(
         t2.until(args.smallest(Unit::Millisecond))?,
         span.milliseconds(864)
     );
     let span = span.milliseconds(864);
-    assert_eq!(
+    span_eq!(
         t2.until(args.smallest(Unit::Microsecond))?,
         span.microseconds(197)
     );
     let span = span.microseconds(197);
-    assert_eq!(
+    span_eq!(
         t2.until(args.smallest(Unit::Nanosecond))?,
         span.nanoseconds(500)
     );

--- a/tests/tc39_262/mod.rs
+++ b/tests/tc39_262/mod.rs
@@ -1,9 +1,19 @@
-mod civil;
-mod span;
-
 /// A type alias we use for tests.
 ///
 /// I normally don't like using Results in unit tests, but... I had to write
 /// *so* many tests when porting from TC39's 262 test suite that the `?` mark
 /// was just easier to use.
 type Result = std::result::Result<(), jiff::Error>;
+
+/// A macro helper, only used in tests, for comparing spans for equality.
+macro_rules! span_eq {
+    ($span1:expr, $span2:expr $(,)?) => {{
+        assert_eq!($span1.fieldwise(), $span2.fieldwise());
+    }};
+    ($span1:expr, $span2:expr, $($tt:tt)*) => {{
+        assert_eq!($span1.fieldwise(), $span2.fieldwise(), $($tt)*);
+    }};
+}
+
+mod civil;
+mod span;

--- a/tests/tc39_262/span/add.rs
+++ b/tests/tc39_262/span/add.rs
@@ -162,29 +162,29 @@ fn no_calendar_units() -> Result {
     let blank = Span::new();
     insta::assert_snapshot!(
         1.year().checked_add(blank).unwrap_err(),
-        @"using largest unit (which is 'year') in given span requires that a relative reference time be given, but none was provided",
+        @"using unit 'year' in a span or configuration requires that a relative reference time be given, but none was provided",
     );
     insta::assert_snapshot!(
         1.month().checked_add(blank).unwrap_err(),
-        @"using largest unit (which is 'month') in given span requires that a relative reference time be given, but none was provided",
+        @"using unit 'month' in a span or configuration requires that a relative reference time be given, but none was provided",
     );
     insta::assert_snapshot!(
         1.week().checked_add(blank).unwrap_err(),
-        @"using largest unit (which is 'week') in given span requires that a relative reference time be given, but none was provided",
+        @"using unit 'week' in a span or configuration requires that a relative reference time be given, but none was provided",
     );
 
     let ok = 1.day();
     insta::assert_snapshot!(
         ok.checked_add(1.year()).unwrap_err(),
-        @"using largest unit (which is 'year') in given span requires that a relative reference time be given, but none was provided",
+        @"using unit 'year' in a span or configuration requires that a relative reference time be given, but none was provided",
     );
     insta::assert_snapshot!(
         ok.checked_add(1.month()).unwrap_err(),
-        @"using largest unit (which is 'month') in given span requires that a relative reference time be given, but none was provided",
+        @"using unit 'month' in a span or configuration requires that a relative reference time be given, but none was provided",
     );
     insta::assert_snapshot!(
         ok.checked_add(1.month()).unwrap_err(),
-        @"using largest unit (which is 'month') in given span requires that a relative reference time be given, but none was provided",
+        @"using unit 'month' in a span or configuration requires that a relative reference time be given, but none was provided",
     );
 
     Ok(())

--- a/tests/tc39_262/span/add.rs
+++ b/tests/tc39_262/span/add.rs
@@ -11,7 +11,7 @@ fn balance_negative_result() -> Result {
     let sp1 = -60.hours();
     let sp2 = -1.day();
     let result = sp1.checked_add(sp2)?;
-    assert_eq!(result, -3.days().hours(12));
+    span_eq!(result, -3.days().hours(12));
 
     Ok(())
 }
@@ -28,7 +28,7 @@ fn balance_negative_time_units() -> Result {
         .nanoseconds(1);
 
     let result = sp.checked_add(-2.nanoseconds())?;
-    assert_eq!(
+    span_eq!(
         result,
         1.hour()
             .minutes(1)
@@ -39,7 +39,7 @@ fn balance_negative_time_units() -> Result {
     );
 
     let result = sp.checked_add(-2.microseconds())?;
-    assert_eq!(
+    span_eq!(
         result,
         1.hour()
             .minutes(1)
@@ -50,7 +50,7 @@ fn balance_negative_time_units() -> Result {
     );
 
     let result = sp.checked_add(-2.milliseconds())?;
-    assert_eq!(
+    span_eq!(
         result,
         1.hour()
             .minutes(1)
@@ -61,7 +61,7 @@ fn balance_negative_time_units() -> Result {
     );
 
     let result = sp.checked_add(-2.seconds())?;
-    assert_eq!(
+    span_eq!(
         result,
         1.hour()
             .minutes(0)
@@ -72,7 +72,7 @@ fn balance_negative_time_units() -> Result {
     );
 
     let result = sp.checked_add(-2.minutes())?;
-    assert_eq!(
+    span_eq!(
         result,
         0.hours()
             .minutes(59)
@@ -83,7 +83,7 @@ fn balance_negative_time_units() -> Result {
     );
 
     let result = sp.checked_add(-2.hours())?;
-    assert_eq!(
+    span_eq!(
         result,
         -58.minutes()
             .seconds(58)
@@ -100,21 +100,21 @@ fn balance_negative_time_units() -> Result {
 fn basic() -> Result {
     let sp = 1.day().minutes(5);
     let result = sp.checked_add(2.days().minutes(5))?;
-    assert_eq!(result, 3.days().minutes(10));
+    span_eq!(result, 3.days().minutes(10));
     let result = sp.checked_add(12.hours().seconds(30))?;
-    assert_eq!(result, 1.day().hours(12).minutes(5).seconds(30));
+    span_eq!(result, 1.day().hours(12).minutes(5).seconds(30));
 
     let sp = 3.days().minutes(10);
     let result = sp.checked_add(-2.days().minutes(5))?;
-    assert_eq!(result, 1.day().minutes(5));
+    span_eq!(result, 1.day().minutes(5));
 
     let sp = 1.day().hours(12).minutes(5).seconds(30);
     let result = sp.checked_add(-12.hours().seconds(30))?;
-    assert_eq!(result, 1.day().minutes(5));
+    span_eq!(result, 1.day().minutes(5));
 
     let sp = "P50DT50H50M50.500500500S".parse::<Span>()?;
     let result = sp.checked_add(sp)?;
-    assert_eq!(
+    span_eq!(
         result,
         104.days()
             .hours(5)
@@ -126,11 +126,11 @@ fn basic() -> Result {
 
     let sp = -1.hour().seconds(60);
     let result = sp.checked_add(122.minutes())?;
-    assert_eq!(result, 1.hour().minutes(1));
+    span_eq!(result, 1.hour().minutes(1));
 
     let sp = -1.hour().seconds(3_721);
     let result = sp.checked_add(61.minutes().nanoseconds(3722000000001i64))?;
-    assert_eq!(result, 1.minute().seconds(1).nanoseconds(1));
+    span_eq!(result, 1.minute().seconds(1).nanoseconds(1));
 
     Ok(())
 }
@@ -151,7 +151,7 @@ fn nanoseconds_is_number_max_safe_integer() -> Result {
         .milliseconds(((nanos / 1_000_000) % 1_000) as i64)
         .microseconds(((nanos / 1_000) % 1_000) as i64)
         .nanoseconds((nanos % 1_000) as i64);
-    assert_eq!(result, expected);
+    span_eq!(result, expected);
 
     Ok(())
 }

--- a/tests/tc39_262/span/round.rs
+++ b/tests/tc39_262/span/round.rs
@@ -27,7 +27,7 @@ fn mk<const N: usize>(units: [i64; N]) -> Span {
 fn balance_negative_result() -> Result {
     let span1 = -60.hours();
     let span2 = span1.round(SpanRound::new().largest(Unit::Day))?;
-    assert_eq!(span2, -2.days().hours(12));
+    span_eq!(span2, -2.days().hours(12));
     Ok(())
 }
 
@@ -37,7 +37,7 @@ fn balance_subseconds() -> Result {
     let span1 =
         999.milliseconds().microseconds(999_999).nanoseconds(999_999_999);
     let span2 = span1.round(SpanRound::new().largest(Unit::Second))?;
-    assert_eq!(
+    span_eq!(
         span2,
         2.seconds().milliseconds(998).microseconds(998).nanoseconds(999)
     );
@@ -45,7 +45,7 @@ fn balance_subseconds() -> Result {
     let span1 =
         -999.milliseconds().microseconds(999_999).nanoseconds(999_999_999);
     let span2 = span1.round(SpanRound::new().largest(Unit::Second))?;
-    assert_eq!(
+    span_eq!(
         span2,
         -2.seconds().milliseconds(998).microseconds(998).nanoseconds(999)
     );
@@ -67,39 +67,39 @@ fn calendar_possibly_required() -> Result {
         sp.round(Unit::Hour).unwrap_err(),
         @"using largest unit (which is 'year') in given span requires that a relative reference time be given, but none was provided",
     );
-    assert_eq!(sp.round(relative_years)?, 1.year());
-    assert_eq!(sp.round(relative_months)?, 12.months());
-    assert_eq!(sp.round(relative_weeks)?, 52.weeks().days(1));
-    assert_eq!(sp.round(relative_days)?, 365.days());
+    span_eq!(sp.round(relative_years)?, 1.year());
+    span_eq!(sp.round(relative_months)?, 12.months());
+    span_eq!(sp.round(relative_weeks)?, 52.weeks().days(1));
+    span_eq!(sp.round(relative_days)?, 365.days());
 
     let sp = 12.months();
     insta::assert_snapshot!(
         sp.round(Unit::Hour).unwrap_err(),
         @"using largest unit (which is 'month') in given span requires that a relative reference time be given, but none was provided",
     );
-    assert_eq!(sp.round(relative_years)?, 1.year());
-    assert_eq!(sp.round(relative_months)?, 12.months());
-    assert_eq!(sp.round(relative_weeks)?, 52.weeks().days(1));
-    assert_eq!(sp.round(relative_days)?, 365.days());
+    span_eq!(sp.round(relative_years)?, 1.year());
+    span_eq!(sp.round(relative_months)?, 12.months());
+    span_eq!(sp.round(relative_weeks)?, 52.weeks().days(1));
+    span_eq!(sp.round(relative_days)?, 365.days());
 
     let sp = 5.weeks();
     insta::assert_snapshot!(
         sp.round(Unit::Hour).unwrap_err(),
         @"using largest unit (which is 'week') in given span requires that a relative reference time be given, but none was provided",
     );
-    assert_eq!(sp.round(relative_years)?, 1.month().days(4));
-    assert_eq!(sp.round(relative_months)?, 1.month().days(4));
-    assert_eq!(sp.round(relative_weeks)?, 5.weeks());
-    assert_eq!(sp.round(relative_days)?, 35.days());
+    span_eq!(sp.round(relative_years)?, 1.month().days(4));
+    span_eq!(sp.round(relative_months)?, 1.month().days(4));
+    span_eq!(sp.round(relative_weeks)?, 5.weeks());
+    span_eq!(sp.round(relative_days)?, 35.days());
 
     let sp = 42.days();
-    assert_eq!(sp.round(relative_years)?, 1.month().days(11));
-    assert_eq!(sp.round(relative_months)?, 1.month().days(11));
-    assert_eq!(sp.round(relative_weeks)?, 6.weeks());
-    assert_eq!(sp.round(relative_days)?, 42.days());
+    span_eq!(sp.round(relative_years)?, 1.month().days(11));
+    span_eq!(sp.round(relative_months)?, 1.month().days(11));
+    span_eq!(sp.round(relative_weeks)?, 6.weeks());
+    span_eq!(sp.round(relative_days)?, 42.days());
     // We don't need a relative datetime for rounding days.
     // In this case, we assume civil day (always 24 hours).
-    assert_eq!(sp.round(Unit::Hour)?, 42.days());
+    span_eq!(sp.round(Unit::Hour)?, 42.days());
 
     Ok(())
 }
@@ -117,7 +117,7 @@ fn dst_balancing_result() -> Result {
         "1999-10-29T01-07[America/Los_Angeles]".parse::<jiff::Zoned>()?;
     let result =
         sp.round(SpanRound::new().largest(Unit::Year).relative(&zdt))?;
-    assert_eq!(result, 1.year().hours(24));
+    span_eq!(result, 1.year().hours(24));
 
     // Added my own test here using a shorter duration since we use an
     // actual time zone for testing, where as Temporal uses a "dummy" time
@@ -129,7 +129,7 @@ fn dst_balancing_result() -> Result {
         "2000-09-29T01-07[America/Los_Angeles]".parse::<jiff::Zoned>()?;
     let result =
         sp.round(SpanRound::new().largest(Unit::Year).relative(&zdt))?;
-    assert_eq!(result, 1.month().hours(24));
+    span_eq!(result, 1.month().hours(24));
 
     // Try one month earlier, and we balance up to 1 day.
     let sp = 1.month().hours(24);
@@ -137,7 +137,7 @@ fn dst_balancing_result() -> Result {
         "2000-08-29T01-07[America/Los_Angeles]".parse::<jiff::Zoned>()?;
     let result =
         sp.round(SpanRound::new().largest(Unit::Year).relative(&zdt))?;
-    assert_eq!(result, 1.month().days(1));
+    span_eq!(result, 1.month().days(1));
 
     let sp = 24.hours().nanoseconds(5);
     let zdt =
@@ -150,7 +150,7 @@ fn dst_balancing_result() -> Result {
             .increment(30)
             .relative(&zdt),
     )?;
-    assert_eq!(result, 24.hours().minutes(30));
+    span_eq!(result, 24.hours().minutes(30));
 
     Ok(())
 }
@@ -168,35 +168,35 @@ fn dst_rounding_result() -> Result {
         "2000-02-18T02-08[America/Los_Angeles]".parse::<jiff::Zoned>()?;
     let result =
         sp.round(SpanRound::new().smallest(Unit::Month).relative(&zdt))?;
-    assert_eq!(result, 2.months());
+    span_eq!(result, 2.months());
 
     let sp = 1.month().days(15).minutes(30);
     let zdt =
         "2000-03-02T02-08[America/Los_Angeles]".parse::<jiff::Zoned>()?;
     let result =
         sp.round(SpanRound::new().smallest(Unit::Month).relative(&zdt))?;
-    assert_eq!(result, 2.months());
+    span_eq!(result, 2.months());
     let result = sp.round(
         SpanRound::new()
             .smallest(Unit::Month)
             .mode(RoundMode::HalfTrunc)
             .relative(&zdt),
     )?;
-    assert_eq!(result, 1.month());
+    span_eq!(result, 1.month());
 
     let sp = 11.hours().minutes(30);
     let zdt =
         "2000-04-02T00:00:00[America/Los_Angeles]".parse::<jiff::Zoned>()?;
     let result =
         sp.round(SpanRound::new().smallest(Unit::Day).relative(&zdt))?;
-    assert_eq!(result, 1.day());
+    span_eq!(result, 1.day());
     let result = sp.round(
         SpanRound::new()
             .smallest(Unit::Day)
             .mode(RoundMode::HalfTrunc)
             .relative(&zdt),
     )?;
-    assert_eq!(result, 0.days());
+    span_eq!(result, 0.days());
 
     Ok(())
 }
@@ -231,15 +231,15 @@ fn february_leap_year() -> Result {
 
     let sp = 3.years().months(11).days(27);
     let result = sp.round(options)?;
-    assert_eq!(result, 3.years().months(11).days(27));
+    span_eq!(result, 3.years().months(11).days(27));
 
     let sp = 3.years().months(11).days(28);
     let result = sp.round(options)?;
-    assert_eq!(result, 3.years().months(11).days(28));
+    span_eq!(result, 3.years().months(11).days(28));
 
     let sp = 3.years().months(11).days(29);
     let result = sp.round(options)?;
-    assert_eq!(result, 4.years());
+    span_eq!(result, 4.years());
 
     Ok(())
 }
@@ -252,25 +252,25 @@ fn largestunit_correct_rebalancing() -> Result {
     let options = SpanRound::new().largest(Unit::Month).relative(d);
 
     let sp = Span::new().days(days);
-    assert_eq!(sp.round(options)?, 3.months().days(11));
+    span_eq!(sp.round(options)?, 3.months().days(11));
 
     let sp = Span::new().hours(days * 24);
-    assert_eq!(sp.round(options)?, 3.months().days(11));
+    span_eq!(sp.round(options)?, 3.months().days(11));
 
     let sp = Span::new().minutes(days * 24 * 60);
-    assert_eq!(sp.round(options)?, 3.months().days(11));
+    span_eq!(sp.round(options)?, 3.months().days(11));
 
     let sp = Span::new().seconds(days * 24 * 60 * 60);
-    assert_eq!(sp.round(options)?, 3.months().days(11));
+    span_eq!(sp.round(options)?, 3.months().days(11));
 
     let sp = Span::new().milliseconds(days * 24 * 60 * 60 * 1_000);
-    assert_eq!(sp.round(options)?, 3.months().days(11));
+    span_eq!(sp.round(options)?, 3.months().days(11));
 
     let sp = Span::new().microseconds(days * 24 * 60 * 60 * 1_000_000);
-    assert_eq!(sp.round(options)?, 3.months().days(11));
+    span_eq!(sp.round(options)?, 3.months().days(11));
 
     let sp = Span::new().nanoseconds(days * 24 * 60 * 60 * 1_000_000_000);
-    assert_eq!(sp.round(options)?, 3.months().days(11));
+    span_eq!(sp.round(options)?, 3.months().days(11));
 
     Ok(())
 }
@@ -415,8 +415,9 @@ fn largestunit_smallestunit_combinations_relative() -> Result {
                         .smallest(smallest)
                         .relative(relative),
                 )?;
-                assert_eq!(
-                    result, expected,
+                span_eq!(
+                    result,
+                    expected,
                     "largest unit {largest:?}, \
                      smallest unit {smallest:?}, \
                      and relative to {relative:?}",
@@ -509,8 +510,9 @@ fn largestunit_smallestunit_combinations() -> Result {
         for &(smallest, expected) in entry.iter() {
             let result = sp
                 .round(SpanRound::new().largest(largest).smallest(smallest))?;
-            assert_eq!(
-                result, expected,
+            span_eq!(
+                result,
+                expected,
                 "largest unit {largest:?}, smallest unit {smallest:?}",
             );
         }
@@ -526,33 +528,33 @@ fn largestunit_smallestunit_default() -> Result {
 
     let almost_year = 364.days();
     let options = SpanRound::new().smallest(Unit::Year).relative(d);
-    assert_eq!(almost_year.round(options)?, 1.year());
+    span_eq!(almost_year.round(options)?, 1.year());
 
     let almost_month = 27.days();
     let options = SpanRound::new().smallest(Unit::Month).relative(d);
-    assert_eq!(almost_month.round(options)?, 1.month());
+    span_eq!(almost_month.round(options)?, 1.month());
 
     let almost_week = 6.days();
     let options = SpanRound::new().smallest(Unit::Week).relative(d);
-    assert_eq!(almost_week.round(options)?, 1.week());
+    span_eq!(almost_week.round(options)?, 1.week());
 
     let almost_day = 86_399.seconds();
-    assert_eq!(almost_day.round(Unit::Day)?, 1.day());
+    span_eq!(almost_day.round(Unit::Day)?, 1.day());
 
     let almost_hour = 3599.seconds();
-    assert_eq!(almost_hour.round(Unit::Hour)?, 1.hour());
+    span_eq!(almost_hour.round(Unit::Hour)?, 1.hour());
 
     let almost_minute = 59.seconds();
-    assert_eq!(almost_minute.round(Unit::Minute)?, 1.minute());
+    span_eq!(almost_minute.round(Unit::Minute)?, 1.minute());
 
     let almost_second = 999_999_999.nanoseconds();
-    assert_eq!(almost_second.round(Unit::Second)?, 1.second());
+    span_eq!(almost_second.round(Unit::Second)?, 1.second());
 
     let almost_millisecond = 999_999.nanoseconds();
-    assert_eq!(almost_millisecond.round(Unit::Millisecond)?, 1.millisecond());
+    span_eq!(almost_millisecond.round(Unit::Millisecond)?, 1.millisecond());
 
     let almost_microsecond = 999.nanoseconds();
-    assert_eq!(almost_microsecond.round(Unit::Microsecond)?, 1.microsecond());
+    span_eq!(almost_microsecond.round(Unit::Microsecond)?, 1.microsecond());
 
     Ok(())
 }
@@ -590,11 +592,11 @@ fn largestunit_smallestunit_mismatch() -> Result {
 fn largestunit_undefined() -> Result {
     let sp = "PT1h120m1.123456789s".parse::<Span>()?;
     let result = sp.round(Unit::Nanosecond)?;
-    assert_eq!(result, "PT3h1.123456789s".parse()?);
+    span_eq!(result, "PT3h1.123456789s".parse::<Span>()?);
 
     let sp = "PT120m1.123456789s".parse::<Span>()?;
     let result = sp.round(Unit::Nanosecond)?;
-    assert_eq!(result, "PT120m1.123456789s".parse()?);
+    span_eq!(result, "PT120m1.123456789s".parse::<Span>()?);
 
     Ok(())
 }
@@ -638,12 +640,12 @@ fn precision_exact_in_round_duration() -> Result {
     let sp = 100_000.hours().nanoseconds(5);
     let result =
         sp.round(SpanRound::new().smallest(Unit::Hour).mode(RoundMode::Ceil))?;
-    assert_eq!(result, 100_001.hours());
+    span_eq!(result, 100_001.hours());
 
     let sp = 1_000.days().nanoseconds(5);
     let result =
         sp.round(SpanRound::new().smallest(Unit::Day).mode(RoundMode::Ceil))?;
-    assert_eq!(result, 1001.days());
+    span_eq!(result, 1001.days());
 
     Ok(())
 }
@@ -651,7 +653,7 @@ fn precision_exact_in_round_duration() -> Result {
 /// Source: https://github.com/tc39/test262/blob/29c6f7028a683b8259140e7d6352ae0ca6448a85/test/built-ins/Temporal/Duration/prototype/round/relativeto-undefined-throw-on-calendar-units.js
 #[test]
 fn relativeto_undefined_throw_on_calendar_units() -> Result {
-    assert_eq!(1.day().round(SpanRound::new().largest(Unit::Day))?, 1.day());
+    span_eq!(1.day().round(SpanRound::new().largest(Unit::Day))?, 1.day());
     insta::assert_snapshot!(
         1.week().round(SpanRound::new().largest(Unit::Day)).unwrap_err(),
         @"using largest unit (which is 'week') in given span requires that a relative reference time be given, but none was provided",
@@ -689,7 +691,7 @@ fn relativeto_zoneddatetime_negative_epochnanoseconds() -> Result {
     let sp = 1.day();
     let result =
         sp.round(SpanRound::new().largest(Unit::Day).relative(&zdt))?;
-    assert_eq!(result, 1.day());
+    span_eq!(result, 1.day());
     Ok(())
 }
 
@@ -715,37 +717,37 @@ fn round_cross_unit_bondary() -> Result {
     let result = sp.round(
         SpanRound::new().smallest(Unit::Month).mode(mode).relative(d),
     )?;
-    assert_eq!(result, 2.years());
+    span_eq!(result, 2.years());
 
     let sp = -1.year().months(11).days(24);
     let result = sp.round(
         SpanRound::new().smallest(Unit::Month).mode(mode).relative(d),
     )?;
-    assert_eq!(result, -2.years());
+    span_eq!(result, -2.years());
 
     let sp = 1.hour().minutes(59).seconds(59).milliseconds(900);
     let result = sp.round(
         SpanRound::new().smallest(Unit::Second).mode(mode).relative(d),
     )?;
-    assert_eq!(result, 2.hours());
+    span_eq!(result, 2.hours());
 
     let sp = -1.hour().minutes(59).seconds(59).milliseconds(900);
     let result = sp.round(
         SpanRound::new().smallest(Unit::Second).mode(mode).relative(d),
     )?;
-    assert_eq!(result, -2.hours());
+    span_eq!(result, -2.hours());
 
     let sp = 11.months().days(24);
     let result = sp.round(
         SpanRound::new().smallest(Unit::Month).mode(mode).relative(d),
     )?;
-    assert_eq!(result, 12.months());
+    span_eq!(result, 12.months());
 
     let sp = -11.months().days(24);
     let result = sp.round(
         SpanRound::new().smallest(Unit::Month).mode(mode).relative(d),
     )?;
-    assert_eq!(result, -12.months());
+    span_eq!(result, -12.months());
 
     Ok(())
 }
@@ -755,7 +757,7 @@ fn round_cross_unit_bondary() -> Result {
 fn round_negative_result() -> Result {
     let sp = -60.hours();
     let result = sp.round(Unit::Day)?;
-    assert_eq!(result, -3.days());
+    span_eq!(result, -3.days());
 
     Ok(())
 }
@@ -770,10 +772,10 @@ fn roundingincrement_non_integer() -> Result {
         .relative(date(2000, 1, 1));
 
     let result = sp.round(options.increment(2))?;
-    assert_eq!(result, 2.days());
+    span_eq!(result, 2.days());
 
     let result = sp.round(options.increment(1_000_000))?;
-    assert_eq!(result, 1_000_000.days());
+    span_eq!(result, 1_000_000.days());
 
     Ok(())
 }
@@ -818,12 +820,12 @@ fn roundingmode_ceil() -> Result {
     ];
     for &(smallest, positive, negative) in expected {
         let options = options.smallest(smallest);
-        assert_eq!(
+        span_eq!(
             sp.round(options.relative(fwd))?,
             positive,
             "{sp} rounds to {positive} for smallest unit {smallest:?}",
         );
-        assert_eq!(
+        span_eq!(
             sp.negate().round(options.relative(bck))?,
             negative,
             "-{sp} rounds to {negative} for smallest unit {smallest:?}",
@@ -873,12 +875,12 @@ fn roundingmode_expand() -> Result {
     ];
     for &(smallest, positive, negative) in expected {
         let options = options.smallest(smallest);
-        assert_eq!(
+        span_eq!(
             sp.round(options.relative(fwd))?,
             positive,
             "{sp} rounds to {positive} for smallest unit {smallest:?}",
         );
-        assert_eq!(
+        span_eq!(
             sp.negate().round(options.relative(bck))?,
             negative,
             "-{sp} rounds to {negative} for smallest unit {smallest:?}",
@@ -928,12 +930,12 @@ fn roundingmode_floor() -> Result {
     ];
     for &(smallest, positive, negative) in expected {
         let options = options.smallest(smallest);
-        assert_eq!(
+        span_eq!(
             sp.round(options.relative(fwd))?,
             positive,
             "{sp} rounds to {positive} for smallest unit {smallest:?}",
         );
-        assert_eq!(
+        span_eq!(
             sp.negate().round(options.relative(bck))?,
             negative,
             "-{sp} rounds to {negative} for smallest unit {smallest:?}",
@@ -983,12 +985,12 @@ fn roundingmode_halfceil() -> Result {
     ];
     for &(smallest, positive, negative) in expected {
         let options = options.smallest(smallest);
-        assert_eq!(
+        span_eq!(
             sp.round(options.relative(fwd))?,
             positive,
             "{sp} rounds to {positive} for smallest unit {smallest:?}",
         );
-        assert_eq!(
+        span_eq!(
             sp.negate().round(options.relative(bck))?,
             negative,
             "-{sp} rounds to {negative} for smallest unit {smallest:?}",
@@ -1038,12 +1040,12 @@ fn roundingmode_halfeven() -> Result {
     ];
     for &(smallest, positive, negative) in expected {
         let options = options.smallest(smallest);
-        assert_eq!(
+        span_eq!(
             sp.round(options.relative(fwd))?,
             positive,
             "{sp} rounds to {positive} for smallest unit {smallest:?}",
         );
-        assert_eq!(
+        span_eq!(
             sp.negate().round(options.relative(bck))?,
             negative,
             "-{sp} rounds to {negative} for smallest unit {smallest:?}",
@@ -1093,12 +1095,12 @@ fn roundingmode_halfexpand() -> Result {
     ];
     for &(smallest, positive, negative) in expected {
         let options = options.smallest(smallest);
-        assert_eq!(
+        span_eq!(
             sp.round(options.relative(fwd))?,
             positive,
             "{sp} rounds to {positive} for smallest unit {smallest:?}",
         );
-        assert_eq!(
+        span_eq!(
             sp.negate().round(options.relative(bck))?,
             negative,
             "-{sp} rounds to {negative} for smallest unit {smallest:?}",
@@ -1148,12 +1150,12 @@ fn roundingmode_halffloor() -> Result {
     ];
     for &(smallest, positive, negative) in expected {
         let options = options.smallest(smallest);
-        assert_eq!(
+        span_eq!(
             sp.round(options.relative(fwd))?,
             positive,
             "{sp} rounds to {positive} for smallest unit {smallest:?}",
         );
-        assert_eq!(
+        span_eq!(
             sp.negate().round(options.relative(bck))?,
             negative,
             "-{sp} rounds to {negative} for smallest unit {smallest:?}",
@@ -1203,12 +1205,12 @@ fn roundingmode_halftrunc() -> Result {
     ];
     for &(smallest, positive, negative) in expected {
         let options = options.smallest(smallest);
-        assert_eq!(
+        span_eq!(
             sp.round(options.relative(fwd))?,
             positive,
             "{sp} rounds to {positive} for smallest unit {smallest:?}",
         );
-        assert_eq!(
+        span_eq!(
             sp.negate().round(options.relative(bck))?,
             negative,
             "-{sp} rounds to {negative} for smallest unit {smallest:?}",
@@ -1258,12 +1260,12 @@ fn roundingmode_trunc() -> Result {
     ];
     for &(smallest, positive, negative) in expected {
         let options = options.smallest(smallest);
-        assert_eq!(
+        span_eq!(
             sp.round(options.relative(fwd))?,
             positive,
             "{sp} rounds to {positive} for smallest unit {smallest:?}",
         );
-        assert_eq!(
+        span_eq!(
             sp.negate().round(options.relative(bck))?,
             negative,
             "-{sp} rounds to {negative} for smallest unit {smallest:?}",
@@ -1313,7 +1315,7 @@ fn smallestunit() -> Result {
         ),
     ];
     for &(smallest, expected) in tests {
-        assert_eq!(
+        span_eq!(
             sp.round(smallest)?,
             expected,
             "rounding {sp} to {smallest:?}"

--- a/tests/tc39_262/span/total.rs
+++ b/tests/tc39_262/span/total.rs
@@ -38,21 +38,21 @@ fn calendar_possibly_required() -> Result {
 
     insta::assert_snapshot!(
         year.total(Unit::Day).unwrap_err(),
-        @"using unit 'year' requires that a relative reference time be given, but none was provided",
+        @"using unit 'year' in a span or configuration requires that a relative reference time be given, but none was provided",
     );
     let result = year.total((Unit::Day, d))?;
     assert_eq!(result, 730_120.0);
 
     insta::assert_snapshot!(
         month.total(Unit::Day).unwrap_err(),
-        @"using unit 'month' requires that a relative reference time be given, but none was provided",
+        @"using unit 'month' in a span or configuration requires that a relative reference time be given, but none was provided",
     );
     let result = month.total((Unit::Day, d))?;
     assert_eq!(result, 1_492.0);
 
     insta::assert_snapshot!(
         week.total(Unit::Day).unwrap_err(),
-        @"using unit 'week' requires that a relative reference time be given, but none was provided",
+        @"using unit 'week' in a span or configuration requires that a relative reference time be given, but none was provided",
     );
     let result = week.total((Unit::Day, d))?;
     assert_eq!(result, 7.0);


### PR DESCRIPTION
In brief, we:

* Deprecate `intz` methods in favor of `in_tz`.
* Deprecate the `Eq` and `PartialEq` trait implementations on `Span` in
  favor of calling `span.fieldwise()` to get a `SpanFieldwise` that implements
  `Eq` and `PartialEq`.
* Deprecate any silent assumtions in the `Span` APIs that days are always 24
  hours. Instead, callers must either provide a relative reference time or
  provide the new special `SpanRelativeTo::days_are_24_hours()` marker.
* Deprecate `%V` in favor of `%Q` for IANA time zone identifiers in `strftime`
  and `strptime` APIs.
* Add a whole bunch of conversion specifiers to bring Jiff's `strftime` and
  `strptime` in near-parity with GNU's implementation. We leave out locale
  specific specifiers (because Jiff doesn't do locale, use `icu` for that)
  and `%V` for ISO 8601 week numbers. We'll add `%V` for this in `jiff 0.2`
  since it's a breaking change. (Hence the aforementioned deprecation.)

See the commit messages and their linked issues for more details.
