### PR TITLE
civil: deprecate `ISOWeekDate::to_date()` in favor of `date()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+0.1.26 (TBD)
+============
+TODO
+
+Deprecations:
+
+* [#210](https://github.com/BurntSushi/jiff/pull/210):
+  Deprecate `ISOWeekDate::to_date` in favor of `ISOWeekDate::date`.
+
+
 0.1.25 (2025-01-21)
 ===================
 This release contains a number of deprecations in preparation for a `jiff 0.2`

--- a/src/civil/iso_week_date.rs
+++ b/src/civil/iso_week_date.rs
@@ -305,6 +305,19 @@ impl ISOWeekDate {
     /// assert_eq!(weekdate.to_date(), date(1948, 2, 10));
     /// ```
     #[inline]
+    pub fn date(self) -> Date {
+        Date::from_iso_week_date(self)
+    }
+}
+
+/// Deprecated APIs.
+impl ISOWeekDate {
+    /// A deprecated equivalent to [`ISOWeekDate::date`].
+    ///
+    /// This method will be removed in `jiff 0.2`. This was done to make naming
+    /// more consistent throughout the crate.
+    #[deprecated(since = "0.1.26", note = "use ISOWeekDate::date instead")]
+    #[inline]
     pub fn to_date(self) -> Date {
         Date::from_iso_week_date(self)
     }


### PR DESCRIPTION
I think this helps make the naming a little more consistent.

We still have `Date::to_zoned` and `Date::to_datetime` (instead of just
`Date::zoned` and `Date::datetime`), but I think those makes sense. At
least, it feels wrong to drop the `to_` prefix there.

I honestly kind of feel like `Date::to_iso_week_date` and
`ISOWeekDate::to_date` are also right, but for `Zoned`,
`to_iso_week_date` makes less sense? And I want `Zoned` to use the same
names of methods that are available on `DateTime` and `Date`.
