### PR TITLE
timestamp: fix precision loss in arithmetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+0.1.27 (2025-01-25)
+===================
+This is a small release with a bug fix for precision loss in some cases when
+doing arithmetic on `Timestamp` or `Zoned`.
+
+Bug fixes:
+
+* [#223](https://github.com/BurntSushi/jiff/issues/223):
+Fix the check for fractional seconds before taking the fast path.
+
+
 0.1.26 (2025-01-23)
 ===================
 This is a small release with another deprecation and a new API for doing

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -5483,4 +5483,22 @@ mod tests {
             .unwrap();
         assert_eq!(zdt2.to_string(), "2024-03-10T01:30:00-05:00[US/Eastern]");
     }
+
+    #[test]
+    fn zoned_precision_loss() {
+        if crate::tz::db().is_definitively_empty() {
+            return;
+        }
+
+        let zdt1: Zoned = "2025-01-25T19:32:21.783444592+01:00[Europe/Paris]"
+            .parse()
+            .unwrap();
+        let span = 1.second();
+        let zdt2 = &zdt1 + span;
+        assert_eq!(
+            zdt2.to_string(),
+            "2025-01-25T19:32:22.783444592+01:00[Europe/Paris]"
+        );
+        assert_eq!(zdt1, &zdt2 - span, "should be reversible");
+    }
 }


### PR DESCRIPTION
When doing timestamp arithmetic, we were special casing a path where if
there weren't any fractional seconds, could skip a fair bit of math.
However, we were only checking whether the span given lacked fractional
seconds. We also need to check if the timestamp does. If either have
non-zero fractional seconds, then we can take the optimized path. This
was resulting in apparent precision loss.

Fixes #223
