### PR TITLE
dev-dependencies: remove dependency on serde-yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG
 
+0.1.28 (2025-01-27)
+===================
+This is a small release that just removes the dev-dependency on `serde_yml`.
+It has been replaced with the deprecated `serde_yaml`. See
+[this post about `serde_yml` shenanigans](https://x.com/davidtolnay/status/1883906113428676938)
+for why this was done. Note that this was only a dev-dependency and thus doesn't
+impact folks using Jiff.
+
+Bug fixes:
+
+* [#225](https://github.com/BurntSushi/jiff/pull/225):
+Remove dependency on `serde_yml` in favor of `serde_yaml`.
+
+
 0.1.27 (2025-01-25)
 ===================
 This is a small release with a bug fix for precision loss in some cases when

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ jiff = { path = "./", default-features = false, features = ["serde"] }
 quickcheck = { version = "1.0.3", default-features = false }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
-serde_yml = "0.0.12"
+serde_yaml = "0.9.34"
 tabwriter = "1.4.0"
 time = { version = "0.3.36", features = ["local-offset", "macros", "parsing"] }
 tzfile = "0.1.3"

--- a/src/civil/date.rs
+++ b/src/civil/date.rs
@@ -4052,17 +4052,17 @@ mod tests {
     fn civil_date_deserialize_yaml() {
         let expected = date(2024, 10, 31);
 
-        let deserialized: Date = serde_yml::from_str("2024-10-31").unwrap();
+        let deserialized: Date = serde_yaml::from_str("2024-10-31").unwrap();
 
         assert_eq!(deserialized, expected);
 
         let deserialized: Date =
-            serde_yml::from_slice("2024-10-31".as_bytes()).unwrap();
+            serde_yaml::from_slice("2024-10-31".as_bytes()).unwrap();
 
         assert_eq!(deserialized, expected);
 
         let cursor = Cursor::new(b"2024-10-31");
-        let deserialized: Date = serde_yml::from_reader(cursor).unwrap();
+        let deserialized: Date = serde_yaml::from_reader(cursor).unwrap();
 
         assert_eq!(deserialized, expected);
     }

--- a/src/civil/datetime.rs
+++ b/src/civil/datetime.rs
@@ -4403,18 +4403,18 @@ mod tests {
         let expected = datetime(2024, 10, 31, 16, 33, 53, 123456789);
 
         let deserialized: DateTime =
-            serde_yml::from_str("2024-10-31 16:33:53.123456789").unwrap();
+            serde_yaml::from_str("2024-10-31 16:33:53.123456789").unwrap();
 
         assert_eq!(deserialized, expected);
 
         let deserialized: DateTime =
-            serde_yml::from_slice("2024-10-31 16:33:53.123456789".as_bytes())
+            serde_yaml::from_slice("2024-10-31 16:33:53.123456789".as_bytes())
                 .unwrap();
 
         assert_eq!(deserialized, expected);
 
         let cursor = Cursor::new(b"2024-10-31 16:33:53.123456789");
-        let deserialized: DateTime = serde_yml::from_reader(cursor).unwrap();
+        let deserialized: DateTime = serde_yaml::from_reader(cursor).unwrap();
 
         assert_eq!(deserialized, expected);
     }

--- a/src/civil/time.rs
+++ b/src/civil/time.rs
@@ -3392,17 +3392,17 @@ mod tests {
         let expected = time(16, 35, 4, 987654321);
 
         let deserialized: Time =
-            serde_yml::from_str("16:35:04.987654321").unwrap();
+            serde_yaml::from_str("16:35:04.987654321").unwrap();
 
         assert_eq!(deserialized, expected);
 
         let deserialized: Time =
-            serde_yml::from_slice("16:35:04.987654321".as_bytes()).unwrap();
+            serde_yaml::from_slice("16:35:04.987654321".as_bytes()).unwrap();
 
         assert_eq!(deserialized, expected);
 
         let cursor = Cursor::new(b"16:35:04.987654321");
-        let deserialized: Time = serde_yml::from_reader(cursor).unwrap();
+        let deserialized: Time = serde_yaml::from_reader(cursor).unwrap();
 
         assert_eq!(deserialized, expected);
     }

--- a/src/signed_duration.rs
+++ b/src/signed_duration.rs
@@ -2619,18 +2619,18 @@ mod tests {
         let expected = SignedDuration::from_secs(123456789);
 
         let deserialized: SignedDuration =
-            serde_yml::from_str("PT34293h33m9s").unwrap();
+            serde_yaml::from_str("PT34293h33m9s").unwrap();
 
         assert_eq!(deserialized, expected);
 
         let deserialized: SignedDuration =
-            serde_yml::from_slice("PT34293h33m9s".as_bytes()).unwrap();
+            serde_yaml::from_slice("PT34293h33m9s".as_bytes()).unwrap();
 
         assert_eq!(deserialized, expected);
 
         let cursor = Cursor::new(b"PT34293h33m9s");
         let deserialized: SignedDuration =
-            serde_yml::from_reader(cursor).unwrap();
+            serde_yaml::from_reader(cursor).unwrap();
 
         assert_eq!(deserialized, expected);
     }

--- a/src/span.rs
+++ b/src/span.rs
@@ -7041,17 +7041,17 @@ mod tests {
             .seconds(7);
 
         let deserialized: Span =
-            serde_yml::from_str("P1y2m3w4dT5h6m7s").unwrap();
+            serde_yaml::from_str("P1y2m3w4dT5h6m7s").unwrap();
 
         span_eq!(deserialized, expected);
 
         let deserialized: Span =
-            serde_yml::from_slice("P1y2m3w4dT5h6m7s".as_bytes()).unwrap();
+            serde_yaml::from_slice("P1y2m3w4dT5h6m7s".as_bytes()).unwrap();
 
         span_eq!(deserialized, expected);
 
         let cursor = Cursor::new(b"P1y2m3w4dT5h6m7s");
-        let deserialized: Span = serde_yml::from_reader(cursor).unwrap();
+        let deserialized: Span = serde_yaml::from_reader(cursor).unwrap();
 
         span_eq!(deserialized, expected);
     }

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -3749,12 +3749,12 @@ mod tests {
             .timestamp();
 
         let deserialized: Timestamp =
-            serde_yml::from_str("2024-10-31T16:33:53.123456789+00:00")
+            serde_yaml::from_str("2024-10-31T16:33:53.123456789+00:00")
                 .unwrap();
 
         assert_eq!(deserialized, expected);
 
-        let deserialized: Timestamp = serde_yml::from_slice(
+        let deserialized: Timestamp = serde_yaml::from_slice(
             "2024-10-31T16:33:53.123456789+00:00".as_bytes(),
         )
         .unwrap();
@@ -3762,7 +3762,7 @@ mod tests {
         assert_eq!(deserialized, expected);
 
         let cursor = Cursor::new(b"2024-10-31T16:33:53.123456789+00:00");
-        let deserialized: Timestamp = serde_yml::from_reader(cursor).unwrap();
+        let deserialized: Timestamp = serde_yaml::from_reader(cursor).unwrap();
 
         assert_eq!(deserialized, expected);
     }

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -5406,12 +5406,12 @@ mod tests {
             .unwrap();
 
         let deserialized: Zoned =
-            serde_yml::from_str("2024-10-31T16:33:53.123456789+00:00[UTC]")
+            serde_yaml::from_str("2024-10-31T16:33:53.123456789+00:00[UTC]")
                 .unwrap();
 
         assert_eq!(deserialized, expected);
 
-        let deserialized: Zoned = serde_yml::from_slice(
+        let deserialized: Zoned = serde_yaml::from_slice(
             "2024-10-31T16:33:53.123456789+00:00[UTC]".as_bytes(),
         )
         .unwrap();
@@ -5419,7 +5419,7 @@ mod tests {
         assert_eq!(deserialized, expected);
 
         let cursor = Cursor::new(b"2024-10-31T16:33:53.123456789+00:00[UTC]");
-        let deserialized: Zoned = serde_yml::from_reader(cursor).unwrap();
+        let deserialized: Zoned = serde_yaml::from_reader(cursor).unwrap();
 
         assert_eq!(deserialized, expected);
     }


### PR DESCRIPTION
... and replace it with serde-yaml. This is non-ideal since serde-yaml
is deprecated, but I'll take that over the shenanigans going on with
serde-yml (that I was unaware of, since this was a dev-dependency).

Ref https://x.com/davidtolnay/status/1883906113428676938
