### PR TITLE
civil: add convenience routines for ISOWeekDate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+0.1.29 (TBD)
+============
+TODO
+
+Enhancements:
+
+* [#227](https://github.com/BurntSushi/jiff/issues/227):
+The `civil::ISOWeekDate` API has been beefed up with a few convenience methods.
+
+
 0.1.28 (2025-01-27)
 ===================
 This is a small release that just removes the dev-dependency on `serde_yml`.


### PR DESCRIPTION
This PR adds the following methods to `jiff::civil::ISOWeekDate`:

* `ISOWeekDate::first_of_week`
* `ISOWeekDate::last_of_week`
* `ISOWeekDate::first_of_year`
* `ISOWeekDate::last_of_year`
* `ISOWeekDate::days_in_year`
* `ISOWeekDate::weeks_in_year`
* `ISOWeekDate::tomorrow`
* `ISOWeekDate::yesterday`

This makes it a bit easier to navigate around the calendar without
having to do this manually.

In #227, I originally proposed adding `ISOWeekDate::series` as well, but
as I implemented it, I think it turned out to be a bad idea. In
particular, `Span` is really a _Gregorian_ period of time, and applying
it to `ISOWeekDate` can be awkward. It works fine for units of weeks or
lower, but above it's weird. For months, one might excuse it since it's
"obvious" that a month will be applied on the Gregorian interpretation
of a week date since the ISO 8601 week calendar has no concept of
months. But for years... things get weird. If you ask for a series of 1
year intervals starting at `2026-W01-Monday`, then 1 year later is
actually `2026-W53-Tuesday` instead of the expected `2027-W01-Monday`.
This is because the year arithmetic is done on the Gregorian date and
`2026-W01-Monday` is `2025-12-29`. Thus, one year later is `2026-12-29`,
which is in turn `2026-W53-Tuesday`.

This is just overall begging for bugs. The only way I can see to offer a
series-like API for `ISOWeekDate` is to specifically implement ISO week
arithmetic. So, I guess we'd return an error for non-zero units of
months (thus making the `ISOWeekDate::series` API fallible) and use the
ISO week interpretation of "years" instead of the Gregorian
interpretation. But this is a fair bit of infrastructure that I'm not
sure is worth having. So I've left it out.

On the upside, it is very easy to map back and forth between `Date` and
`ISOWeekDate`. And you can still use `Date::series` for this, and things
will generally make sense as long as you stick to units of weeks or
lower. But this does at least make it clear that the series is
calculated on the Gregorian calendar and not the ISO 8601 week calendar.

Closes #227
