### PR TITLE
tz: add support for (de)serializing `TimeZone` with Serde

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ TODO
 
 Enhancements:
 
+* [#89](https://github.com/BurntSushi/jiff/issues/89):
+Opt-in support for using Serde with `jiff::tz::TimeZone` has been added.
 * [#227](https://github.com/BurntSushi/jiff/issues/227):
 The `civil::ISOWeekDate` API has been beefed up with a few convenience methods.
 

--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -220,6 +220,13 @@ impl<W: core::fmt::Write> Write for StdFmtWrite<W> {
     }
 }
 
+impl<W: Write> core::fmt::Write for StdFmtWrite<W> {
+    #[inline]
+    fn write_str(&mut self, string: &str) -> Result<(), core::fmt::Error> {
+        self.0.write_str(string).map_err(|_| core::fmt::Error)
+    }
+}
+
 /// An extension trait to `Write` that provides crate internal routines.
 ///
 /// These routines aren't exposed because they make use of crate internal

--- a/src/fmt/rfc9557.rs
+++ b/src/fmt/rfc9557.rs
@@ -246,11 +246,6 @@ impl Parser {
         }
         input = &input[1..];
 
-        // This does a quick check for an `=` after the opening `[` but before
-        // the closing `]`. If one is found, then we know we cannot have a
-        // time zone annotation, but a more generic key-value annotation. We
-        // could do this while parsing below, but I found this to be simpler.
-
         let critical = input.starts_with(b"!");
         if critical {
             input = &input[1..];

--- a/src/tz/system/mod.rs
+++ b/src/tz/system/mod.rs
@@ -5,7 +5,7 @@ use alloc::string::ToString;
 use crate::{
     error::{err, Error, ErrorContext},
     tz::{posix::PosixTz, TimeZone, TimeZoneDatabase},
-    util::{cache::Expiration, sync::Arc},
+    util::cache::Expiration,
 };
 
 #[cfg(all(unix, not(target_os = "android")))]
@@ -197,11 +197,9 @@ fn get_env_tz(db: &TimeZoneDatabase) -> Result<Option<TimeZone>, Error> {
         Ok(PosixTz::Implementation(string)) => string.to_string(),
         Ok(PosixTz::Rule(tz)) => match tz.reasonable() {
             Ok(reasonable_posix_tz) => {
-                let kind = super::TimeZoneKind::Posix(
-                    super::TimeZonePosix::from(reasonable_posix_tz),
-                );
-                let tz = TimeZone { kind: Some(Arc::new(kind)) };
-                return Ok(Some(tz));
+                return Ok(Some(TimeZone::from_reasonable_posix_tz(
+                    reasonable_posix_tz,
+                )));
             }
             Err(_) => {
                 warn!(

--- a/src/util/escape.rs
+++ b/src/util/escape.rs
@@ -48,6 +48,7 @@ impl core::fmt::Debug for Byte {
 /// This generally works best when the bytes are presumed to be mostly UTF-8,
 /// but will work for anything. For any bytes that aren't UTF-8, they are
 /// emitted as hex escape sequences.
+#[derive(Clone, Copy)]
 pub struct Bytes<'a>(pub &'a [u8]);
 
 impl<'a> core::fmt::Display for Bytes<'a> {


### PR DESCRIPTION
And, also, add lower level routines to `jiff::fmt::temporal` for
printing and parsing a `TimeZone` without going through Serde.

For now, we don't implement `Serialize` or `Deserialize` on `TimeZone`
directly. Instead, we add `with` helpers to `jiff::fmt::serde::tz`. This
is because it's not clear if this is an appropriate "universal"
serialization for a `TimeZone`, and especially since for some (very
rare) cases, a `TimeZone` cannot be serialized succinctly. I also think
it's somewhat _odd_ that a `Deserialize` routine will do an implicit
global tzdb lookup. But it's not really clear that that is an issue in
practice, especially since we're already doing that for parsing `Zoned`
values.

Closes #89
