### PR TITLE
tz: add `Offset::round` and fix `Africa/Monrovia` parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Enhancements:
 Opt-in support for using Serde with `jiff::tz::TimeZone` has been added.
 * [#227](https://github.com/BurntSushi/jiff/issues/227):
 The `civil::ISOWeekDate` API has been beefed up with a few convenience methods.
+* [#233](https://github.com/BurntSushi/jiff/issues/233):
+Add `tz::Offset::round` for rounding time zone offsets.
 
 
 0.1.28 (2025-01-27)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The `civil::ISOWeekDate` API has been beefed up with a few convenience methods.
 * [#233](https://github.com/BurntSushi/jiff/issues/233):
 Add `tz::Offset::round` for rounding time zone offsets.
 
+Bug fixes:
+
+* [#231](https://github.com/BurntSushi/jiff/issues/231):
+Use more flexible offset equality when parsing offsets with fractional minutes.
+
 
 0.1.28 (2025-01-27)
 ===================

--- a/src/signed_duration.rs
+++ b/src/signed_duration.rs
@@ -2086,6 +2086,12 @@ impl TryFrom<SignedDuration> for Duration {
     }
 }
 
+impl From<Offset> for SignedDuration {
+    fn from(offset: Offset) -> SignedDuration {
+        SignedDuration::from_secs(i64::from(offset.seconds()))
+    }
+}
+
 impl core::str::FromStr for SignedDuration {
     type Err = Error;
 
@@ -2384,6 +2390,11 @@ impl SignedDurationRound {
     #[inline]
     pub fn increment(self, increment: i64) -> SignedDurationRound {
         SignedDurationRound { increment, ..self }
+    }
+
+    /// Returns the `smallest` unit configuration.
+    pub(crate) fn get_smallest(&self) -> Unit {
+        self.smallest
     }
 
     /// Does the actual duration rounding.

--- a/src/tz/mod.rs
+++ b/src/tz/mod.rs
@@ -97,7 +97,7 @@ use self::posix::ReasonablePosixTimeZone;
 pub use self::db::TimeZoneNameIter;
 pub use self::{
     db::{db, TimeZoneDatabase},
-    offset::{Dst, Offset, OffsetArithmetic, OffsetConflict},
+    offset::{Dst, Offset, OffsetArithmetic, OffsetConflict, OffsetRound},
 };
 
 #[cfg(feature = "tzdb-concatenated")]

--- a/src/tz/posix.rs
+++ b/src/tz/posix.rs
@@ -801,7 +801,7 @@ impl PosixDateTimeSpec {
         let Some(date) = self.date.to_civil_date(year) else { return mkmax() };
         let mut dt = date.to_datetime(Time::MIN);
         let dur_transition = self.time().to_duration();
-        let dur_offset = offset.to_duration();
+        let dur_offset = SignedDuration::from(offset);
         dt = dt.checked_add(dur_transition).unwrap_or_else(|_| {
             if dur_transition.is_negative() {
                 mkmin()


### PR DESCRIPTION
This adds a new `Offset::round` API in order to support fixing #231.

Namely, previously, we would fail to parse zoned datetimes
like `1969-12-31T23:15:30-00:45[Africa/Monrovia]` because
`Africa/Monrovia`'s offset at the time was `-00:44:30`, which doesn't
match `-00:45:00`. This in turn caused an error because Jiff's default
behavior is to reject parsed datetimes whose offset doesn't match a
valid offset in the corresponding time zone.

However, in this case, we want to accept it. What it comes down to
is that RFC 3339 and RFC 9557 do not support fractional minutes in
the offset. (I wonder why they flubbed that one.) So in order to
be compatible with existing implementations, Jiff serializes zoned
datetimes with fractional minutes by rounding to the nearest minute.
Hence why you might see `-00:45`. But this in turn means Jiff wouldn't
be able to parse a zoned datetime that itself serialized. Which is sad.

So in learning from Temporal here, we permit offsets from tzdb that
have fractional minutes to be rounded to the nearest minute before
being compared with the parsed offset. In this case, `-00:44:30` gets
rounded to `-00:45` and thus compares equal with the parsed offset.

Note though that the offset of the parsed zoned datetime is still,
correctly, `-00:44:30`. It only becomes `-00:45` when serializing via
the Temporal datetime printer. (One can print an offset with second
precision via the `%z` or `%:z` `strftime` conversion specifiers.)

Ref https://github.com/tc39/proposal-temporal/issues/3079
Fixes #231, Closes #233
