### PR TITLE
prepare for `jiff 0.2` release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,7 @@ insta = "1.39.0"
 # We force `serde` to be enabled in dev mode so that the docs render and test
 # correctly. This is highly suspicious.
 jiff = { path = "./", default-features = false, features = ["serde"] }
+jiff-icu = { path = "./crates/jiff-icu" }
 quickcheck = { version = "1.0.3", default-features = false }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"

--- a/crates/jiff-diesel/Cargo.toml
+++ b/crates/jiff-diesel/Cargo.toml
@@ -6,13 +6,13 @@ license = "Unlicense OR MIT"
 homepage = "https://github.com/BurntSushi/jiff/tree/master/crates/jiff-diesel"
 repository = "https://github.com/BurntSushi/jiff"
 documentation = "https://docs.rs/jiff-diesel"
-description = "Integration for Jiff in Diesel."
+description = "Integration for Jiff with Diesel."
 categories = ["date-and-time"]
 keywords = ["date", "time", "jiff", "diesel", "zone"]
 workspace = "../.."
 edition = "2021"
 rust-version = "1.70"
-include = ["/*.rs", "COPYING", "LICENSE-MIT", "UNLICENSE"]
+include = ["/src/*.rs", "COPYING", "LICENSE-MIT", "UNLICENSE"]
 
 [lib]
 name = "jiff_diesel"
@@ -26,8 +26,8 @@ postgres = ["diesel/postgres_backend"]
 sqlite = ["diesel/sqlite"]
 
 [dependencies]
-jiff = { path = "../..", default-features = false, features = ["std"] }
+jiff = { version = "0.1.29", path = "../..", default-features = false, features = ["std"] }
 diesel = { version = "2.0.0", default-features = false }
 
 [dev-dependencies]
-jiff = { path = "../..", default-features = true }
+jiff = { version = "0.1.29", path = "../..", default-features = true }

--- a/crates/jiff-diesel/README.md
+++ b/crates/jiff-diesel/README.md
@@ -1,7 +1,11 @@
-jiff-icu
-========
-WIP
+jiff-diesel
+===========
+This crate provides wrapper types for [`jiff`] that implement the necessary
+traits for integration with [`diesel`].
+
+[`diesel`]: https://docs.rs/diesel
+[`jiff`]: https://docs.rs/jiff/0.2
 
 ### Documentation
 
-https://docs.rs/jiff-icu
+https://docs.rs/jiff-diesel

--- a/crates/jiff-icu/Cargo.toml
+++ b/crates/jiff-icu/Cargo.toml
@@ -6,13 +6,13 @@ license = "Unlicense OR MIT"
 homepage = "https://github.com/BurntSushi/jiff/tree/master/crates/jiff-icu"
 repository = "https://github.com/BurntSushi/jiff"
 documentation = "https://docs.rs/jiff-icu"
-description = "Conversion routines for Jiff and ICU4X."
+description = "Conversion routines between Jiff and ICU4X."
 categories = ["date-and-time"]
 keywords = ["date", "time", "temporal", "zone", "icu"]
 workspace = "../.."
 edition = "2021"
 rust-version = "1.70"
-include = ["/*.rs", "/*.dat", "COPYING", "LICENSE-MIT", "UNLICENSE"]
+include = ["/src/*.rs", "/*.dat", "COPYING", "LICENSE-MIT", "UNLICENSE"]
 
 [lib]
 name = "jiff_icu"
@@ -25,9 +25,9 @@ std = ["alloc", "icu_calendar/std", "jiff/std"]
 alloc = ["jiff/alloc"]
 
 [dependencies]
-jiff = { path = "../..", default-features = false }
+jiff = { version = "0.1.29", path = "../..", default-features = false }
 icu_calendar = { version = "1.5.2", default-features = false }
 
 [dev-dependencies]
-jiff = { path = "../..", default-features = true }
+jiff = { version = "0.1.29", path = "../..", default-features = true }
 icu = { version = "1.5.0", features = ["std"] }

--- a/crates/jiff-icu/README.md
+++ b/crates/jiff-icu/README.md
@@ -1,6 +1,12 @@
 jiff-icu
 ========
-WIP
+A crate for converting between the datetime types found in [`icu`] and
+[`jiff`]. This can, for example, be used to augment uses of Jiff with
+functionality it doesn't support. For example, non-Gregorian calendars and
+datetime localization.
+
+[`icu`]: https://docs.rs/icu/1/
+[`jiff`]: https://docs.rs/jiff/0.2
 
 ### Documentation
 

--- a/crates/jiff-sqlx/Cargo.toml
+++ b/crates/jiff-sqlx/Cargo.toml
@@ -6,13 +6,13 @@ license = "Unlicense OR MIT"
 homepage = "https://github.com/BurntSushi/jiff/tree/master/crates/jiff-sqlx"
 repository = "https://github.com/BurntSushi/jiff"
 documentation = "https://docs.rs/jiff-sqlx"
-description = "Integration for Jiff in SQLx."
+description = "Integration for Jiff with SQLx."
 categories = ["date-and-time"]
 keywords = ["date", "time", "jiff", "sqlx", "zone"]
 workspace = "../.."
 edition = "2021"
 rust-version = "1.70"
-include = ["/*.rs", "/*.dat", "COPYING", "LICENSE-MIT", "UNLICENSE"]
+include = ["/src/*.rs", "/*.dat", "COPYING", "LICENSE-MIT", "UNLICENSE"]
 
 [lib]
 name = "jiff_sqlx"
@@ -25,10 +25,10 @@ postgres = ["dep:sqlx-postgres"]
 sqlite = ["dep:sqlx-sqlite"]
 
 [dependencies]
-jiff = { path = "../..", default-features = false }
+jiff = { version = "0.1.29", path = "../..", default-features = false }
 sqlx-core = { version = "0.8.0", default-features = false }
 sqlx-postgres = { version = "0.8.0", default-features = false, optional = true }
 sqlx-sqlite = { version = "0.8.0", default-features = false, optional = true }
 
 [dev-dependencies]
-jiff = { path = "../..", default-features = true }
+jiff = { version = "0.1.29", path = "../..", default-features = true }

--- a/crates/jiff-sqlx/README.md
+++ b/crates/jiff-sqlx/README.md
@@ -1,7 +1,11 @@
-jiff-icu
-========
-WIP
+jiff-sqlx
+=========
+This crate provides wrapper types for [`jiff`] that implement the necessary
+traits for integration with [`sqlx`].
+
+[`diesel`]: https://docs.rs/sqlx
+[`jiff`]: https://docs.rs/jiff/0.2
 
 ### Documentation
 
-https://docs.rs/jiff-icu
+https://docs.rs/jiff-sqlx

--- a/src/fmt/friendly/mod.rs
+++ b/src/fmt/friendly/mod.rs
@@ -512,11 +512,11 @@ intuitive things you'd expect to work will work.
 # Internationalization
 
 Currently, only US English unit designator labels are supported. In general,
-Jiff resists trying to solve the internationalization problem in favor of
-punting it to a crate like [`icu`](https://docs.rs/icu). Jiff _could_ adopt
-unit designator labels for other languages, but it's not totally clear whether
-that's the right path to follow given the complexity of internationalization.
-If you'd like to discuss it, please
+Jiff resists trying to solve the internationalization problem in favor
+of punting it to another crate, such as [`icu`] via [`jiff-icu`]. Jiff
+_could_ adopt unit designator labels for other languages, but it's not
+totally clear whether that's the right path to follow given the complexity
+of internationalization. If you'd like to discuss it, please
 [file an issue](https://github.com/BurntSushi/jiff/issues).
 
 # Grammar
@@ -688,6 +688,8 @@ should support a "reasonable" range of values.
 
 [`humantime`]: https://docs.rs/humantime
 [`humantime-serde`]: https://docs.rs/humantime-serde
+[`icu`]: https://docs.rs/icu
+[`jiff-icu`]: https://docs.rs/jiff-icu
 */
 
 pub use self::{

--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -5,6 +5,164 @@ Note that for most use cases, you should be using the corresponding
 [`Display`](std::fmt::Display) or [`FromStr`](std::str::FromStr) trait
 implementations for printing and parsing respectively. The APIs in this module
 provide more configurable support for printing and parsing.
+
+# Tables of examples
+
+The tables below attempt to show some examples of datetime and duration
+formatting, along with names and links to relevant routines and types. The
+point of these tables is to give a general overview of the formatting and
+parsing functionality in these sub-modules.
+
+## Support for `FromStr` and `Display`
+
+This table lists the formats supported by the [`FromStr`] and [`Display`]
+trait implementations on the datetime and duration types in Jiff.
+
+In all of these cases, the trait implementations are mere conveniences for
+functionality provided by the [`temporal`] sub-module (and, in a couple cases,
+the [`friendly`] sub-module). The sub-modules provide lower level control
+(such as parsing from `&[u8]`) and more configuration (such as controlling the
+disambiguation strategy used when parsing zoned datetime [RFC-9557] strings).
+
+| Example | Format | Links |
+| ------- | ------ | ----- |
+| `2025-08-20T17:35:00Z` | [RFC-3339] | [`Timestamp`] |
+| `2025-08-20T17:35:00-05` | [RFC-3339] | [`FromStr`] impl and<br>[`Timestamp::display_with_offset`] |
+| `2025-08-20T17:35:00+02[Poland]` | [RFC-9557] | [`Zoned`] |
+| `2025-08-20T17:35:00+02:00[+02:00]` | [RFC-9557] | [`Zoned`] |
+| `2025-08-20T17:35:00` | [ISO-8601] | [`civil::DateTime`] |
+| `2025-08-20` | [ISO-8601] | [`civil::Date`] |
+| `17:35:00` | [ISO-8601] | [`civil::Time`] |
+| `P1Y2M3W4DT5H6M7S` | [ISO-8601], [Temporal] | [`Span`] |
+| `PT1H2M3S` | [ISO-8601] | [`SignedDuration`], [`Span`] |
+| `PT1H2M3.123456789S` | [ISO-8601] | [`SignedDuration`], [`Span`] |
+| `1d 2h 3m 5s` | [`friendly`] | [`FromStr`] impl and alternative [`Display`]<br>via `{:#}` for [`SignedDuration`], [`Span`] |
+
+Note that for datetimes like `2025-08-20T17:35:00`, the following variants are
+also accepted:
+
+```text
+2025-08-20 17:35:00
+2025-08-20T17:35:00.123456789
+2025-08-20T17:35
+2025-08-20T17
+```
+
+This applies to RFC 3339 and RFC 9557 timestamps as well.
+
+Also, for ISO 8601 durations, the unit designator labels are matched
+case insensitively. For example, `PT1h2m3s` is recognized by Jiff.
+
+## The "friendly" duration format
+
+This table lists a few examples of the [`friendly`] duration format. Briefly,
+it is a bespoke format for Jiff, but is meant to match similar bespoke formats
+used elsewhere and be easier to read than the standard ISO 8601 duration
+format.
+
+All examples below can be parsed via a [`Span`]'s [`FromStr`] trait
+implementation. All examples with units no bigger than hours can be parsed via
+a [`SignedDuration`]'s [`FromStr`] trait implementation. This table otherwise
+shows the options for printing durations in the format shown.
+
+| Example | Print configuration |
+| ------- | ------------------- |
+| `1year 2months` | [`Designator::Verbose`] via [`SpanPrinter::designator`] |
+| `1yr 2mos` | [`Designator::Short`] via [`SpanPrinter::designator`] |
+| `1y 2mo` | [`Designator::Compact`] via [`SpanPrinter::designator`] (default) |
+| `1h2m3s` | [`Spacing::None`] via [`SpanPrinter::spacing`] |
+| `1h 2m 3s` | [`Spacing::BetweenUnits`] via [`SpanPrinter::spacing`] (default) |
+| `1 h 2 m 3 s` | [`Spacing::BetweenUnitsAndDesignators`] via [`SpanPrinter::spacing`] |
+| `2d 3h ago` | [`Direction::Auto`] via [`SpanPrinter::direction`] (default) |
+| `-2d 3h` | [`Direction::Sign`] via [`SpanPrinter::direction`] |
+| `+2d 3h` | [`Direction::ForceSign`] via [`SpanPrinter::direction`] |
+| `2d 3h ago` | [`Direction::Suffix`] via [`SpanPrinter::direction`] |
+| `9.123456789s` | [`FractionalUnit::Second`] via [`SpanPrinter::fractional`] |
+| `1y, 2mo` | [`SpanPrinter::comma_after_designator`] |
+| `15d 02:59:15.123` | [`SpanPrinter::hours_minutes_seconds`] |
+
+## Bespoke datetime formats via `strptime` and `strftime`
+
+Every datetime type has bespoke formatting routines defined on it. For
+example, [`Zoned::strptime`] and [`civil::Date::strftime`]. Additionally, the
+[`strtime`] sub-module also provides convenience routines, [`strtime::format`]
+and [`strtime::parse`], where the former is generic over any datetime type in
+Jiff and the latter provides a [`BrokenDownTime`] for granular parsing.
+
+| Example | Format string |
+| ------- | ------------- |
+| `2025-05-20` | `%Y-%m-%d` |
+| `2025-05-20` | `%F` |
+| `2025-W21-2` | `%G-W%V-%w` |
+| `05/20/25` | `%m/%d/%y` |
+| `Monday, February 10, 2025 at 9:01pm -0500` | `%A, %B %d, %Y at %-I:%M%P %z` |
+| `Monday, February 10, 2025 at 9:01pm EST` | `%A, %B %d, %Y at %-I:%M%P %Z` |
+| `Monday, February 10, 2025 at 9:01pm America/New_York` | `%A, %B %d, %Y at %-I:%M%P %Q` |
+
+The specific conversion specifiers supported are documented in the [`strtime`]
+sub-module. While precise POSIX compatibility is not guaranteed, the conversion
+specifiers are generally meant to match prevailing implementations. (Although
+there are many such implementations and they each tend to have their own quirks
+and features.)
+
+## RFC 2822 parsing and printing
+
+[RFC-2822] support is provided by the [`rfc2822`] sub-module.
+
+| Example | Links |
+| ------- | ----- |
+| `Thu, 29 Feb 2024 05:34 -0500` | [`rfc2822::parse`] and [`rfc2822::to_string`] |
+| `Thu, 01 Jan 1970 00:00:01 GMT` | [`DateTimePrinter::timestamp_to_rfc9110_string`] |
+
+[Temporal]: https://tc39.es/proposal-temporal/#sec-temporal-iso8601grammar
+[ISO-8601]: https://www.iso.org/iso-8601-date-and-time-format.html
+[RFC-3339]: https://www.rfc-editor.org/rfc/rfc3339
+[RFC-9557]: https://www.rfc-editor.org/rfc/rfc9557.html
+[ISO-8601]: https://www.iso.org/iso-8601-date-and-time-format.html
+[RFC-2822]: https://datatracker.ietf.org/doc/html/rfc2822
+[RFC-9110]: https://datatracker.ietf.org/doc/html/rfc9110#section-5.6.7-15
+[`Display`]: std::fmt::Display
+[`FromStr`]: std::str::FromStr
+[`friendly`]: crate::fmt::friendly
+[`temporal`]: crate::fmt::temporal
+[`rfc2822`]: crate::fmt::rfc2822
+[`strtime`]: crate::fmt::strtime
+[`civil::DateTime`]: crate::civil::DateTime
+[`civil::Date`]: crate::civil::Date
+[`civil::Date::strftime`]: crate::civil::Date::strftime
+[`civil::Time`]: crate::civil::Time
+[`SignedDuration`]: crate::SignedDuration
+[`Span`]: crate::Span
+[`Timestamp`]: crate::Timestamp
+[`Timestamp::display_with_offset`]: crate::Timestamp::display_with_offset
+[`Zoned`]: crate::Zoned
+[`Zoned::strptime`]: crate::Zoned::strptime
+
+[`Designator::Verbose`]: crate::fmt::friendly::Designator::Verbose
+[`Designator::Short`]: crate::fmt::friendly::Designator::Short
+[`Designator::Compact`]: crate::fmt::friendly::Designator::Compact
+[`Spacing::None`]: crate::fmt::friendly::Spacing::None
+[`Spacing::BetweenUnits`]: crate::fmt::friendly::Spacing::BetweenUnits
+[`Spacing::BetweenUnitsAndDesignators`]: crate::fmt::friendly::Spacing::BetweenUnitsAndDesignators
+[`Direction::Auto`]: crate::fmt::friendly::Direction::Auto
+[`Direction::Sign`]: crate::fmt::friendly::Direction::Sign
+[`Direction::ForceSign`]: crate::fmt::friendly::Direction::ForceSign
+[`Direction::Suffix`]: crate::fmt::friendly::Direction::Suffix
+[`FractionalUnit::Second`]: crate::fmt::friendly::FractionalUnit::Second
+[`SpanPrinter::designator`]: crate::fmt::friendly::SpanPrinter::designator
+[`SpanPrinter::spacing`]: crate::fmt::friendly::SpanPrinter::spacing
+[`SpanPrinter::direction`]: crate::fmt::friendly::SpanPrinter::direction
+[`SpanPrinter::fractional`]: crate::fmt::friendly::SpanPrinter::fractional
+[`SpanPrinter::comma_after_designator`]: crate::fmt::friendly::SpanPrinter::comma_after_designator
+[`SpanPrinter::hours_minutes_seconds`]: crate::fmt::friendly::SpanPrinter::hours_minutes_seconds
+
+[`BrokenDownTime`]: crate::fmt::strtime::BrokenDownTime
+[`strtime::parse`]: crate::fmt::strtime::parse
+[`strtime::format`]: crate::fmt::strtime::format
+
+[`rfc2822::parse`]: crate::fmt::rfc2822::parse
+[`rfc2822::to_string`]: crate::fmt::rfc2822::to_string
+[`DateTimePrinter::timestamp_to_rfc9110_string`]: crate::fmt::rfc2822::DateTimePrinter::timestamp_to_rfc9110_string
 */
 
 use crate::{

--- a/src/fmt/strtime/mod.rs
+++ b/src/fmt/strtime/mod.rs
@@ -249,12 +249,13 @@ The following things are currently unsupported:
 * Parsing or formatting fractional seconds in the time time zone offset.
 * Locale oriented conversion specifiers, such as `%c`, `%r` and `%+`, are not
   supported by Jiff. For locale oriented datetime formatting, please use the
-  [`icu`] crate.
+  [`icu`] crate via [`jiff-icu`].
 
 [`strftime`]: https://pubs.opengroup.org/onlinepubs/009695399/functions/strftime.html
 [`strptime`]: https://pubs.opengroup.org/onlinepubs/009695399/functions/strptime.html
 [ISO 8601 week-based]: https://en.wikipedia.org/wiki/ISO_week_date
 [`icu`]: https://docs.rs/icu
+[`jiff-icu`]: https://docs.rs/jiff-icu
 */
 
 use crate::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,8 +118,8 @@ maximum datetime values.][cppchrono]
 * [Jiff aims to have reasonable performance and may not be capable of doing the
 fastest possible thing.][perf]
 
-At present, it is recommended to use the [`icu`] crate for localization and
-non-Gregorian use cases.
+At present, it is recommended to use the [`icu`] crate via [`jiff-icu`] for
+localization and non-Gregorian use cases.
 
 [Leap seconds]: https://github.com/BurntSushi/jiff/issues/7
 [Calendars other than Gregorian]: https://github.com/BurntSushi/jiff/issues/6
@@ -127,6 +127,7 @@ non-Gregorian use cases.
 [cppchrono]: https://github.com/BurntSushi/jiff/issues/3
 [perf]: https://github.com/BurntSushi/jiff/issues/17
 [`icu`]: https://docs.rs/icu
+[`jiff-icu`]: https://docs.rs/jiff-icu
 
 Please file an issue if you can think of more (substantial) things to add to
 the above list.

--- a/src/tz/mod.rs
+++ b/src/tz/mod.rs
@@ -3281,7 +3281,7 @@ impl AmbiguousZoned {
 ///
 /// The main use case for daylight saving time status or time zone
 /// abbreviations is for formatting datetimes in an end user's locale. If you
-/// want this, consider using the [`icu`] crate.
+/// want this, consider using the [`icu`] crate via [`jiff-icu`].
 ///
 /// The lifetime parameter `'t` corresponds to the lifetime of the `TimeZone`
 /// that this info was extracted from.
@@ -3319,6 +3319,7 @@ impl AmbiguousZoned {
 /// ```
 ///
 /// [`icu`]: https://docs.rs/icu
+/// [`jiff-icu`]: https://docs.rs/jiff-icu
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct TimeZoneOffsetInfo<'t> {
     offset: Offset,


### PR DESCRIPTION
This is doing some final touch-ups to prepare for the `jiff 0.2`
release. Most of these touch-ups are (and will be) docs related I
think.
