### PR TITLE
jiff-diesel: Derive the `Queryable` trait for diesel wrapper types.

### DIFF
--- a/crates/jiff-diesel/src/mysql.rs
+++ b/crates/jiff-diesel/src/mysql.rs
@@ -1,5 +1,5 @@
 use diesel::{
-    deserialize::{self, FromSql, Queryable},
+    deserialize::{self, FromSql},
     mysql::{
         data_types::{MysqlTime, MysqlTimestampType},
         Mysql, MysqlValue,
@@ -12,14 +12,6 @@ use jiff::{civil, tz};
 use crate::{Date, DateTime, Time, Timestamp, ToDiesel};
 
 static UTC: tz::TimeZone = tz::TimeZone::UTC;
-
-impl Queryable<sql_types::Datetime, Mysql> for Timestamp {
-    type Row = Timestamp;
-
-    fn build(row: Timestamp) -> deserialize::Result<Timestamp> {
-        Ok(row)
-    }
-}
 
 impl ToSql<sql_types::Datetime, Mysql> for Timestamp {
     fn to_sql<'b>(
@@ -75,14 +67,6 @@ impl FromSql<sql_types::Datetime, Mysql> for Timestamp {
     }
 }
 
-impl Queryable<sql_types::Timestamp, Mysql> for DateTime {
-    type Row = DateTime;
-
-    fn build(row: DateTime) -> deserialize::Result<DateTime> {
-        Ok(row)
-    }
-}
-
 impl ToSql<sql_types::Timestamp, Mysql> for DateTime {
     fn to_sql<'b>(
         &'b self,
@@ -134,14 +118,6 @@ impl FromSql<sql_types::Timestamp, Mysql> for DateTime {
     }
 }
 
-impl Queryable<sql_types::Date, Mysql> for Date {
-    type Row = Date;
-
-    fn build(row: Date) -> deserialize::Result<Date> {
-        Ok(row)
-    }
-}
-
 impl ToSql<sql_types::Date, Mysql> for Date {
     fn to_sql<'b>(
         &'b self,
@@ -177,14 +153,6 @@ impl FromSql<sql_types::Date, Mysql> for Date {
             mysql_time.day.try_into()?,
         )?;
         Ok(date.to_diesel())
-    }
-}
-
-impl Queryable<sql_types::Time, Mysql> for Time {
-    type Row = Time;
-
-    fn build(row: Time) -> deserialize::Result<Time> {
-        Ok(row)
     }
 }
 

--- a/crates/jiff-diesel/src/postgres.rs
+++ b/crates/jiff-diesel/src/postgres.rs
@@ -1,5 +1,5 @@
 use diesel::{
-    deserialize::{self, FromSql, Queryable},
+    deserialize::{self, FromSql},
     pg::{
         data_types::{PgDate, PgInterval, PgTime, PgTimestamp},
         Pg, PgValue,
@@ -24,14 +24,6 @@ static POSTGRES_EPOCH_TIMESTAMP: i64 = 946684800;
 static MIDNIGHT: civil::Time = civil::Time::midnight();
 static UTC: tz::TimeZone = tz::TimeZone::UTC;
 
-impl Queryable<sql_types::Timestamptz, Pg> for Timestamp {
-    type Row = Timestamp;
-
-    fn build(row: Timestamp) -> deserialize::Result<Timestamp> {
-        Ok(row)
-    }
-}
-
 impl ToSql<sql_types::Timestamptz, Pg> for Timestamp {
     fn to_sql<'b>(
         &'b self,
@@ -55,14 +47,6 @@ impl FromSql<sql_types::Timestamptz, Pg> for Timestamp {
         let epoch =
             jiff::Timestamp::from_second(POSTGRES_EPOCH_TIMESTAMP).unwrap();
         Ok(epoch.checked_add(micros)?.to_diesel())
-    }
-}
-
-impl Queryable<sql_types::Timestamp, Pg> for DateTime {
-    type Row = DateTime;
-
-    fn build(row: DateTime) -> deserialize::Result<DateTime> {
-        Ok(row)
     }
 }
 
@@ -96,14 +80,6 @@ impl FromSql<sql_types::Timestamp, Pg> for DateTime {
     }
 }
 
-impl Queryable<sql_types::Date, Pg> for Date {
-    type Row = Date;
-
-    fn build(row: Date) -> deserialize::Result<Date> {
-        Ok(row)
-    }
-}
-
 impl ToSql<sql_types::Date, Pg> for Date {
     fn to_sql<'b>(
         &'b self,
@@ -124,14 +100,6 @@ impl FromSql<sql_types::Date, Pg> for Date {
         let PgDate(days) = FromSql::<sql_types::Date, Pg>::from_sql(bytes)?;
         let span = jiff::Span::new().try_days(days)?;
         Ok(POSTGRES_EPOCH_DATE.checked_add(span)?.to_diesel())
-    }
-}
-
-impl Queryable<sql_types::Time, Pg> for Time {
-    type Row = Time;
-
-    fn build(row: Time) -> deserialize::Result<Time> {
-        Ok(row)
     }
 }
 
@@ -158,14 +126,6 @@ impl FromSql<sql_types::Time, Pg> for Time {
         let PgTime(micros) = FromSql::<sql_types::Time, Pg>::from_sql(bytes)?;
         let micros = jiff::SignedDuration::from_micros(micros);
         Ok(MIDNIGHT.checked_add(micros)?.to_diesel())
-    }
-}
-
-impl Queryable<sql_types::Interval, Pg> for Span {
-    type Row = Span;
-
-    fn build(row: Span) -> deserialize::Result<Span> {
-        Ok(row)
     }
 }
 

--- a/crates/jiff-diesel/src/sqlite.rs
+++ b/crates/jiff-diesel/src/sqlite.rs
@@ -1,5 +1,5 @@
 use diesel::{
-    deserialize::{self, FromSql, Queryable},
+    deserialize::{self, FromSql},
     serialize::{self, IsNull, Output, ToSql},
     sql_types,
     sqlite::{Sqlite, SqliteValue},
@@ -9,14 +9,6 @@ use jiff::fmt::temporal::DateTimeParser;
 use crate::{Date, DateTime, Time, Timestamp, ToDiesel};
 
 static PARSER: DateTimeParser = DateTimeParser::new();
-
-impl Queryable<sql_types::TimestamptzSqlite, Sqlite> for Timestamp {
-    type Row = Timestamp;
-
-    fn build(row: Timestamp) -> deserialize::Result<Timestamp> {
-        Ok(row)
-    }
-}
 
 impl ToSql<sql_types::TimestamptzSqlite, Sqlite> for Timestamp {
     fn to_sql<'b>(
@@ -53,14 +45,6 @@ impl FromSql<sql_types::TimestamptzSqlite, Sqlite> for Timestamp {
     }
 }
 
-impl Queryable<sql_types::Timestamp, Sqlite> for DateTime {
-    type Row = DateTime;
-
-    fn build(row: DateTime) -> deserialize::Result<DateTime> {
-        Ok(row)
-    }
-}
-
 impl ToSql<sql_types::Timestamp, Sqlite> for DateTime {
     fn to_sql<'b>(
         &'b self,
@@ -87,14 +71,6 @@ impl FromSql<sql_types::Timestamp, Sqlite> for DateTime {
     }
 }
 
-impl Queryable<sql_types::Date, Sqlite> for Date {
-    type Row = Date;
-
-    fn build(row: Date) -> deserialize::Result<Date> {
-        Ok(row)
-    }
-}
-
 impl ToSql<sql_types::Date, Sqlite> for Date {
     fn to_sql<'b>(
         &'b self,
@@ -116,14 +92,6 @@ impl FromSql<sql_types::Date, Sqlite> for Date {
             FromSql::<sql_types::Date, Sqlite>::from_sql(value)?;
         let date = PARSER.parse_date(text)?;
         Ok(date.to_diesel())
-    }
-}
-
-impl Queryable<sql_types::Time, Sqlite> for Time {
-    type Row = Time;
-
-    fn build(row: Time) -> deserialize::Result<Time> {
-        Ok(row)
     }
 }
 

--- a/crates/jiff-diesel/src/wrappers.rs
+++ b/crates/jiff-diesel/src/wrappers.rs
@@ -22,7 +22,17 @@ pub trait ToDiesel {
 }
 
 /// A wrapper type for [`jiff::Timestamp`].
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    PartialEq,
+    PartialOrd,
+    Ord,
+    diesel::deserialize::FromSqlRow,
+)]
 #[cfg_attr(
     any(feature = "mysql", feature = "postgres", feature = "sqlite"),
     derive(diesel::expression::AsExpression)
@@ -70,6 +80,7 @@ impl From<Timestamp> for jiff::Timestamp {
     PartialOrd,
     Ord,
     diesel::expression::AsExpression,
+    diesel::deserialize::FromSqlRow,
 )]
 #[diesel(sql_type = diesel::sql_types::Timestamp)]
 pub struct DateTime(jiff::civil::DateTime);
@@ -112,6 +123,7 @@ impl From<DateTime> for jiff::civil::DateTime {
     PartialOrd,
     Ord,
     diesel::expression::AsExpression,
+    diesel::deserialize::FromSqlRow,
 )]
 #[diesel(sql_type = diesel::sql_types::Date)]
 pub struct Date(jiff::civil::Date);
@@ -154,6 +166,7 @@ impl From<Date> for jiff::civil::Date {
     PartialOrd,
     Ord,
     diesel::expression::AsExpression,
+    diesel::deserialize::FromSqlRow,
 )]
 #[diesel(sql_type = diesel::sql_types::Time)]
 pub struct Time(jiff::civil::Time);
@@ -194,7 +207,7 @@ impl From<Time> for jiff::civil::Time {
 /// `Span` into a PostgreSQL interval requires a relative datetime.
 /// Therefore, users wanting to store a `Span` will need to explicitly use a
 /// [`diesel::pg::data_types::PgInterval`] at least at encoding time.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, diesel::deserialize::FromSqlRow)]
 pub struct Span(jiff::Span);
 
 impl Span {


### PR DESCRIPTION
This reduces the amount of boilerplate code needed for each wrapper type. In addition, the implementation is more general, allowing external implementations of `Backend` to use `Queryable`.

Example expansion:
```rust
    const _: () = {
        use diesel;
        use diesel::deserialize::{self, FromSql, Queryable};
        impl<__DB, __ST> Queryable<__ST, __DB> for Timestamp
        where
            __DB: diesel::backend::Backend,
            __ST: diesel::sql_types::SingleValue,
            Self: FromSql<__ST, __DB>,
        {
            type Row = Self;
            fn build(row: Self::Row) -> deserialize::Result<Self> {
                Ok(row)
            }
        }
    };
```