### PR TITLE
jiff-diesel: Diesel error needs to implement std Error, add std feature to jiff.

### DIFF
--- a/crates/jiff-diesel/Cargo.toml
+++ b/crates/jiff-diesel/Cargo.toml
@@ -26,7 +26,7 @@ postgres = ["diesel/postgres"]
 sqlite = ["diesel/sqlite"]
 
 [dependencies]
-jiff = { path = "../..", default-features = false }
+jiff = { path = "../..", default-features = false, features = ["std"] }
 diesel = { version = "2.0.0", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
Fixes errors like:

```
error[E0277]: the trait bound `jiff::Error: std::error::Error` is not satisfied
  --> crates/jiff-diesel/src/mysql.rs:31:51
   |
31 |             dt = dt.round(jiff::Unit::Microsecond)?;
   |                                                   ^ the trait `std::error::Error` is not implemented for `jiff::Error`
   |
   = help: the trait `FromResidual<Result<Infallible, E>>` is implemented for `Result<T, F>`
   = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `From<jiff::Error>`
   = note: required for `Result<IsNull, Box<dyn std::error::Error + Send + Sync>>` to implement `FromResidual<Result<Infallible, jiff::Error>>`
```