### PR TITLE
jiff-diesel: Update diesel examples to use QueryableByName and sql_query.

### DIFF
--- a/examples/diesel-mysql/main.rs
+++ b/examples/diesel-mysql/main.rs
@@ -1,6 +1,6 @@
 use diesel::{
-    connection::Connection, dsl::sql, mysql::MysqlConnection,
-    query_dsl::RunQueryDsl, select, sql_types, ExpressionMethods,
+    connection::Connection, mysql::MysqlConnection, query_dsl::RunQueryDsl,
+    sql_query, sql_types, QueryableByName,
 };
 use jiff::civil;
 use jiff_diesel::ToDiesel;
@@ -18,72 +18,55 @@ fn main() -> anyhow::Result<()> {
         "mysql://demo:password@localhost/jiff_diesel_example",
     )?;
 
-    example_datetime_decode(&mut conn)?;
-    example_datetime_encode(&mut conn)?;
+    example_datetime_roundtrip(&mut conn)?;
 
     Ok(())
 }
 
-/// Performs a decoding with all of Jiff's datetime types.
-fn example_datetime_decode(conn: &mut MysqlConnection) -> anyhow::Result<()> {
-    // Decoding jiff::Timestamp
-    let query = select(sql::<sql_types::Datetime>("'1970-01-01 00:00:00Z'"));
-    let got: jiff_diesel::Timestamp = query.get_result(conn)?;
-    let expected =
-        "1970-01-01T00:00:00Z".parse::<jiff::Timestamp>()?.to_diesel();
-    assert_eq!(expected, got);
+/// Performs a round-trip with all of Jiff's datetime types.
+fn example_datetime_roundtrip(
+    conn: &mut MysqlConnection,
+) -> anyhow::Result<()> {
+    diesel::table! {
+        jiffs {
+            id -> Integer, // Diesel tables require an ID column.
+            ts -> Datetime,
+            dt -> Timestamp,
+            d -> Date,
+            t -> Time
+        }
+    }
 
-    // Decoding jiff::civil::DateTime
-    let query = select(sql::<sql_types::Timestamp>("'2025-07-20 00:00:00'"));
-    let got: jiff_diesel::DateTime = query.get_result(conn)?;
-    let expected = civil::date(2025, 7, 20).at(0, 0, 0, 0).to_diesel();
-    assert_eq!(expected, got);
+    #[derive(Debug, PartialEq, QueryableByName)]
+    #[diesel(check_for_backend(diesel::mysql::Mysql))]
+    struct Jiff {
+        #[diesel(deserialize_as = jiff_diesel::Timestamp)]
+        pub ts: jiff::Timestamp,
+        #[diesel(deserialize_as = jiff_diesel::DateTime)]
+        pub dt: jiff::civil::DateTime,
+        #[diesel(deserialize_as = jiff_diesel::Date)]
+        pub d: jiff::civil::Date,
+        #[diesel(deserialize_as = jiff_diesel::Time)]
+        pub t: jiff::civil::Time,
+    }
 
-    // Decoding jiff::civil::Date
-    let query = select(sql::<sql_types::Date>("'1999-01-08'"));
-    let got: jiff_diesel::Date = query.get_result(conn)?;
-    let expected = civil::date(1999, 1, 8).to_diesel();
-    assert_eq!(expected, got);
+    let given = Jiff {
+        ts: "1970-01-01T00:00:00Z".parse()?,
+        dt: civil::date(2025, 7, 20).at(0, 0, 0, 0),
+        d: civil::date(1999, 1, 8),
+        t: civil::time(23, 59, 59, 999_999_000),
+    };
 
-    // Decoding with jiff::civil::Time
-    let query = select(sql::<sql_types::Time>("'23:59:59.999999'"));
-    let got: jiff_diesel::Time = query.get_result(conn)?;
-    let expected = civil::time(23, 59, 59, 999_999_000).to_diesel();
-    assert_eq!(expected, got);
-
-    Ok(())
-}
-
-/// Performs a encoding with all of Jiff's datetime types.
-fn example_datetime_encode(conn: &mut MysqlConnection) -> anyhow::Result<()> {
-    // Encoding jiff::Timestamp
-    let ts = "1970-01-01T00:00:01Z".parse::<jiff::Timestamp>()?.to_diesel();
-    let query = select(
-        sql::<sql_types::Datetime>("CAST('1970-01-01 00:00:01' AS DATETIME)")
-            .eq(ts),
-    );
-    assert!(query.get_result::<bool>(conn)?);
-
-    // Encoding jiff::civil::DateTime
-    let dt = civil::date(2025, 7, 20).at(0, 0, 0, 0).to_diesel();
-    let query = select(
-        sql::<sql_types::Timestamp>("CAST('2025-07-20 00:00:00' AS DATETIME)")
-            .eq(dt),
-    );
-    assert!(query.get_result::<bool>(conn)?);
-
-    // Encoding jiff::civil::Date
-    let date = civil::date(1999, 1, 8).to_diesel();
-    let query =
-        select(sql::<sql_types::Date>("CAST('1999-01-08' AS DATE)").eq(date));
-    assert!(query.get_result::<bool>(conn)?);
-
-    // Encoding jiff::civil::Time
-    let time = civil::time(23, 59, 59, 999_999_000).to_diesel();
-    let query = select(
-        sql::<sql_types::Time>("CAST('23:59:59.999999' AS TIME(6))").eq(time),
-    );
-    assert!(query.get_result::<bool>(conn)?);
+    // We need to name the columns as Diesel's sql_query matches fields by name.
+    let got = sql_query(
+        "select CAST(? AS DATETIME) as ts, CAST(? AS DATETIME) as dt, CAST(? AS DATE) as d, CAST(? AS TIME(6)) as t",
+    )
+    .bind::<sql_types::Datetime, _>(&given.ts.to_diesel())
+    .bind::<sql_types::Timestamp, _>(&given.dt.to_diesel())
+    .bind::<sql_types::Date, _>(&given.d.to_diesel())
+    .bind::<sql_types::Time, _>(&given.t.to_diesel())
+    .get_result(conn)?;
+    assert_eq!(given, got);
 
     Ok(())
 }

--- a/examples/diesel-postgres/main.rs
+++ b/examples/diesel-postgres/main.rs
@@ -20,7 +20,7 @@ fn main() -> anyhow::Result<()> {
 /// Performs a round-trip with all of Jiff's datetime types.
 fn example_datetime_roundtrip(conn: &mut PgConnection) -> anyhow::Result<()> {
     diesel::table! {
-        jiffs {
+        datetimes {
             id -> Integer, // Diesel tables require an ID column.
             ts -> Timestamptz,
             dt -> Timestamp,
@@ -30,19 +30,20 @@ fn example_datetime_roundtrip(conn: &mut PgConnection) -> anyhow::Result<()> {
     }
 
     #[derive(Debug, PartialEq, QueryableByName)]
+    #[diesel(table_name = datetimes)]
     #[diesel(check_for_backend(diesel::pg::Pg))]
-    struct Jiff {
+    struct Row {
         #[diesel(deserialize_as = jiff_diesel::Timestamp)]
-        pub ts: jiff::Timestamp,
+        ts: jiff::Timestamp,
         #[diesel(deserialize_as = jiff_diesel::DateTime)]
-        pub dt: jiff::civil::DateTime,
+        dt: jiff::civil::DateTime,
         #[diesel(deserialize_as = jiff_diesel::Date)]
-        pub d: jiff::civil::Date,
+        d: jiff::civil::Date,
         #[diesel(deserialize_as = jiff_diesel::Time)]
-        pub t: jiff::civil::Time,
+        t: jiff::civil::Time,
     }
 
-    let given = Jiff {
+    let given = Row {
         ts: "1970-01-01T00:00:00Z".parse()?,
         dt: civil::date(2025, 7, 20).at(0, 0, 0, 0),
         d: civil::date(1999, 1, 8),
@@ -50,12 +51,19 @@ fn example_datetime_roundtrip(conn: &mut PgConnection) -> anyhow::Result<()> {
     };
 
     // We need to name the columns as Diesel's sql_query matches fields by name.
-    let got = sql_query("select $1 as ts, $2 as dt, $3 as d, $4 as t")
-        .bind::<sql_types::Timestamptz, _>(&given.ts.to_diesel())
-        .bind::<sql_types::Timestamp, _>(&given.dt.to_diesel())
-        .bind::<sql_types::Date, _>(&given.d.to_diesel())
-        .bind::<sql_types::Time, _>(&given.t.to_diesel())
-        .get_result(conn)?;
+    let got = sql_query(
+        "select
+            $1 as ts,
+            $2 as dt,
+            $3 as d,
+            $4 as t
+        ",
+    )
+    .bind::<sql_types::Timestamptz, _>(&given.ts.to_diesel())
+    .bind::<sql_types::Timestamp, _>(&given.dt.to_diesel())
+    .bind::<sql_types::Date, _>(&given.d.to_diesel())
+    .bind::<sql_types::Time, _>(&given.t.to_diesel())
+    .get_result(conn)?;
     assert_eq!(given, got);
 
     Ok(())

--- a/examples/diesel-postgres/main.rs
+++ b/examples/diesel-postgres/main.rs
@@ -1,6 +1,6 @@
 use diesel::{
     connection::Connection, dsl::sql, pg::PgConnection,
-    query_dsl::RunQueryDsl, select, sql_query, sql_types,
+    query_dsl::RunQueryDsl, select, sql_query, sql_types, QueryableByName,
 };
 use jiff::civil;
 use jiff_diesel::ToDiesel;
@@ -19,33 +19,44 @@ fn main() -> anyhow::Result<()> {
 
 /// Performs a round-trip with all of Jiff's datetime types.
 fn example_datetime_roundtrip(conn: &mut PgConnection) -> anyhow::Result<()> {
-    // Integration with jiff::Timestamp
-    let ts = "1970-01-01T00:00:00Z".parse::<jiff::Timestamp>()?.to_diesel();
-    let query = select(sql::<sql_types::Timestamptz>(
-        "'1970-01-01 00:00:00Z'::timestamp with time zone",
-    ));
-    let got: jiff_diesel::Timestamp = query.get_result(conn)?;
-    assert_eq!(ts, got);
+    diesel::table! {
+        jiffs {
+            id -> Integer, // Diesel tables require an ID column.
+            ts -> Timestamptz,
+            dt -> Timestamp,
+            d -> Date,
+            t -> Time
+        }
+    }
 
-    // Integration with jiff::civil::DateTime
-    let dt = civil::date(2025, 7, 20).at(0, 0, 0, 0).to_diesel();
-    let query = select(sql::<sql_types::Timestamp>(
-        "'2025-07-20 00:00:00'::timestamp without time zone",
-    ));
-    let got: jiff_diesel::DateTime = query.get_result(conn)?;
-    assert_eq!(dt, got);
+    #[derive(Debug, PartialEq, QueryableByName)]
+    #[diesel(check_for_backend(diesel::pg::Pg))]
+    struct Jiff {
+        #[diesel(deserialize_as = jiff_diesel::Timestamp)]
+        pub ts: jiff::Timestamp,
+        #[diesel(deserialize_as = jiff_diesel::DateTime)]
+        pub dt: jiff::civil::DateTime,
+        #[diesel(deserialize_as = jiff_diesel::Date)]
+        pub d: jiff::civil::Date,
+        #[diesel(deserialize_as = jiff_diesel::Time)]
+        pub t: jiff::civil::Time,
+    }
 
-    // Integration with jiff::civil::Date
-    let date = civil::date(1999, 1, 8).to_diesel();
-    let query = select(sql::<sql_types::Date>("'1999-01-08'::date"));
-    let got: jiff_diesel::Date = query.get_result(conn)?;
-    assert_eq!(date, got);
+    let given = Jiff {
+        ts: "1970-01-01T00:00:00Z".parse()?,
+        dt: civil::date(2025, 7, 20).at(0, 0, 0, 0),
+        d: civil::date(1999, 1, 8),
+        t: civil::time(23, 59, 59, 999_999_000),
+    };
 
-    // Integration with jiff::civil::Time
-    let time = civil::time(23, 59, 59, 999_999_000).to_diesel();
-    let query = select(sql::<sql_types::Time>("'23:59:59.999999'::time"));
-    let got: jiff_diesel::Time = query.get_result(conn)?;
-    assert_eq!(time, got);
+    // We need to name the columns as Diesel's sql_query matches fields by name.
+    let got = sql_query("select $1 as ts, $2 as dt, $3 as d, $4 as t")
+        .bind::<sql_types::Timestamptz, _>(&given.ts.to_diesel())
+        .bind::<sql_types::Timestamp, _>(&given.dt.to_diesel())
+        .bind::<sql_types::Date, _>(&given.d.to_diesel())
+        .bind::<sql_types::Time, _>(&given.t.to_diesel())
+        .get_result(conn)?;
+    assert_eq!(given, got);
 
     Ok(())
 }

--- a/examples/diesel-sqlite/main.rs
+++ b/examples/diesel-sqlite/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use diesel::{
     connection::Connection, dsl::sql, query_dsl::RunQueryDsl, select,
-    sql_types, sqlite::SqliteConnection,
+    sql_query, sql_types, sqlite::SqliteConnection, QueryableByName,
 };
 use jiff::civil;
 use jiff_diesel::ToDiesel;
@@ -21,30 +21,44 @@ fn main() -> anyhow::Result<()> {
 fn example_datetime_roundtrip(
     conn: &mut SqliteConnection,
 ) -> anyhow::Result<()> {
-    // Integration with jiff::Timestamp
-    let ts = "1970-01-01T00:00:00Z".parse::<jiff::Timestamp>()?.to_diesel();
-    let query =
-        select(sql::<sql_types::TimestamptzSqlite>("'1970-01-01 00:00:00Z'"));
-    let got: jiff_diesel::Timestamp = query.get_result(conn)?;
-    assert_eq!(ts, got);
+    diesel::table! {
+        jiffs {
+            id -> Integer, // Diesel tables require an ID column.
+            ts -> TimestamptzSqlite,
+            dt -> Timestamp,
+            d -> Date,
+            t -> Time
+        }
+    }
 
-    // Integration with jiff::civil::DateTime
-    let dt = civil::date(2025, 7, 20).at(0, 0, 0, 0).to_diesel();
-    let query = select(sql::<sql_types::Timestamp>("'2025-07-20 00:00:00'"));
-    let got: jiff_diesel::DateTime = query.get_result(conn)?;
-    assert_eq!(dt, got);
+    #[derive(Debug, PartialEq, QueryableByName)]
+    #[diesel(check_for_backend(diesel::sqlite::Sqlite))]
+    struct Jiff {
+        #[diesel(deserialize_as = jiff_diesel::Timestamp)]
+        pub ts: jiff::Timestamp,
+        #[diesel(deserialize_as = jiff_diesel::DateTime)]
+        pub dt: jiff::civil::DateTime,
+        #[diesel(deserialize_as = jiff_diesel::Date)]
+        pub d: jiff::civil::Date,
+        #[diesel(deserialize_as = jiff_diesel::Time)]
+        pub t: jiff::civil::Time,
+    }
 
-    // Integration with jiff::civil::Date
-    let date = civil::date(1999, 1, 8).to_diesel();
-    let query = select(sql::<sql_types::Date>("'1999-01-08'"));
-    let got: jiff_diesel::Date = query.get_result(conn)?;
-    assert_eq!(date, got);
+    let given = Jiff {
+        ts: "1970-01-01T00:00:00Z".parse()?,
+        dt: civil::date(2025, 7, 20).at(0, 0, 0, 0),
+        d: civil::date(1999, 1, 8),
+        t: civil::time(23, 59, 59, 999_999_000),
+    };
 
-    // Integration with jiff::civil::Time
-    let time = civil::time(23, 59, 59, 999_999_000).to_diesel();
-    let query = select(sql::<sql_types::Time>("'23:59:59.999999'"));
-    let got: jiff_diesel::Time = query.get_result(conn)?;
-    assert_eq!(time, got);
+    // We need to name the columns as Diesel's sql_query matches fields by name.
+    let got = sql_query("select $1 as ts, $2 as dt, $3 as d, $4 as t")
+        .bind::<sql_types::TimestamptzSqlite, _>(&given.ts.to_diesel())
+        .bind::<sql_types::Timestamp, _>(&given.dt.to_diesel())
+        .bind::<sql_types::Date, _>(&given.d.to_diesel())
+        .bind::<sql_types::Time, _>(&given.t.to_diesel())
+        .get_result(conn)?;
+    assert_eq!(given, got);
 
     Ok(())
 }


### PR DESCRIPTION
Updated examples for diesel that exercise a more usual usage of the library (when manually writing SQL), and also test the `deserialize_as` annotation for the wrapper type.