### PR TITLE
jiff-diesel: Update examples to use Insertable and Selectable derivations.

### DIFF
--- a/examples/diesel-mysql/main.rs
+++ b/examples/diesel-mysql/main.rs
@@ -1,9 +1,31 @@
 use diesel::{
-    connection::Connection, mysql::MysqlConnection, query_dsl::RunQueryDsl,
-    sql_query, sql_types, QueryableByName,
+    connection::Connection, mysql::MysqlConnection, sql_query, sql_types,
+    QueryableByName, RunQueryDsl,
 };
 use jiff::civil;
 use jiff_diesel::ToDiesel;
+
+mod schema {
+    diesel::table! {
+        datetimes {
+            id -> Integer, // Diesel tables require an ID column.
+            ts -> Datetime,
+            dt -> Timestamp,
+            d -> Date,
+            t -> Time,
+        }
+    }
+
+    diesel::table! {
+        nullable_datetimes {
+            id -> Integer, // Diesel tables require an ID column.
+            ts -> Nullable<Datetime>,
+            dt -> Nullable<Timestamp>,
+            d -> Nullable<Date>,
+            t -> Nullable<Time>,
+        }
+    }
+}
 
 fn main() -> anyhow::Result<()> {
     // To set this up, I ran
@@ -18,7 +40,33 @@ fn main() -> anyhow::Result<()> {
         "mysql://demo:password@localhost/jiff_diesel_example",
     )?;
 
+    sql_query(
+        "CREATE TEMPORARY TABLE IF NOT EXISTS datetimes (
+            id integer primary key,
+            ts datetime not null,
+            dt timestamp not null,
+            d date not null,
+            t time(6) not null
+        )",
+    )
+    .execute(&mut conn)
+    .unwrap();
+
+    sql_query(
+        "CREATE TEMPORARY TABLE IF NOT EXISTS nullable_datetimes (
+            id integer primary key,
+            ts datetime,
+            dt timestamp,
+            d date,
+            t time(6)
+        )",
+    )
+    .execute(&mut conn)
+    .unwrap();
+
     example_datetime_roundtrip(&mut conn)?;
+    example_nullable_datetime_roundtrip(&mut conn)?;
+    example_datetime_sql_query_roundtrip(&mut conn)?;
 
     Ok(())
 }
@@ -27,27 +75,155 @@ fn main() -> anyhow::Result<()> {
 fn example_datetime_roundtrip(
     conn: &mut MysqlConnection,
 ) -> anyhow::Result<()> {
-    diesel::table! {
-        datetimes {
-            id -> Integer, // Diesel tables require an ID column.
-            ts -> Datetime,
-            dt -> Timestamp,
-            d -> Date,
-            t -> Time
-        }
-    }
+    use diesel::prelude::*;
 
-    #[derive(Debug, PartialEq, QueryableByName)]
-    #[diesel(table_name = datetimes)]
+    #[derive(
+        Clone, Copy, Debug, PartialEq, Queryable, Insertable, Selectable,
+    )]
+    #[diesel(table_name = schema::datetimes)]
     #[diesel(check_for_backend(diesel::mysql::Mysql))]
     struct Row {
-        #[diesel(deserialize_as = jiff_diesel::Timestamp)]
+        id: i32,
+        #[diesel(
+            serialize_as = jiff_diesel::Timestamp,
+            deserialize_as = jiff_diesel::Timestamp
+        )]
         ts: jiff::Timestamp,
-        #[diesel(deserialize_as = jiff_diesel::DateTime)]
+        #[diesel(
+            serialize_as = jiff_diesel::DateTime,
+            deserialize_as = jiff_diesel::DateTime
+        )]
         dt: jiff::civil::DateTime,
-        #[diesel(deserialize_as = jiff_diesel::Date)]
+        #[diesel(
+            serialize_as = jiff_diesel::Date,
+            deserialize_as = jiff_diesel::Date
+        )]
         d: jiff::civil::Date,
-        #[diesel(deserialize_as = jiff_diesel::Time)]
+        #[diesel(
+            serialize_as = jiff_diesel::Time,
+            deserialize_as = jiff_diesel::Time
+        )]
+        t: jiff::civil::Time,
+    }
+
+    let given = Row {
+        id: 0,
+        ts: "1970-01-01T00:00:00Z".parse()?,
+        dt: civil::date(2025, 7, 20).at(0, 0, 0, 0),
+        d: civil::date(1999, 1, 8),
+        t: civil::time(23, 59, 59, 999_999_000),
+    };
+
+    let _ = diesel::insert_into(schema::datetimes::table)
+        .values(given)
+        .execute(conn)?;
+
+    let got = schema::datetimes::table
+        .select(Row::as_select())
+        .filter(schema::datetimes::id.eq(given.id))
+        .first(conn)?;
+
+    assert_eq!(given, got);
+
+    Ok(())
+}
+
+/// Performs a round-trip with all of Jiff's nullable datetime types.
+fn example_nullable_datetime_roundtrip(
+    conn: &mut MysqlConnection,
+) -> anyhow::Result<()> {
+    use diesel::prelude::*;
+
+    #[derive(
+        Clone, Copy, Debug, PartialEq, Queryable, Insertable, Selectable,
+    )]
+    #[diesel(table_name = schema::nullable_datetimes)]
+    #[diesel(check_for_backend(diesel::mysql::Mysql))]
+    struct Row {
+        id: i32,
+        #[diesel(
+            serialize_as = jiff_diesel::NullableTimestamp,
+            deserialize_as = jiff_diesel::NullableTimestamp
+        )]
+        ts: Option<jiff::Timestamp>,
+        #[diesel(
+            serialize_as = jiff_diesel::NullableDateTime,
+            deserialize_as = jiff_diesel::NullableDateTime
+        )]
+        dt: Option<jiff::civil::DateTime>,
+        #[diesel(
+            serialize_as = jiff_diesel::NullableDate,
+            deserialize_as = jiff_diesel::NullableDate
+        )]
+        d: Option<jiff::civil::Date>,
+        #[diesel(
+            serialize_as = jiff_diesel::NullableTime,
+            deserialize_as = jiff_diesel::NullableTime
+        )]
+        t: Option<jiff::civil::Time>,
+    }
+
+    let given = Row {
+        id: 1,
+        ts: Some("1970-01-01T00:00:00Z".parse()?),
+        dt: Some(civil::date(2025, 7, 20).at(0, 0, 0, 0)),
+        d: Some(civil::date(1999, 1, 8)),
+        t: Some(civil::time(23, 59, 59, 999_999_000)),
+    };
+
+    let _ = diesel::insert_into(schema::nullable_datetimes::table)
+        .values(given)
+        .execute(conn)?;
+
+    let got = schema::nullable_datetimes::table
+        .select(Row::as_select())
+        .filter(schema::nullable_datetimes::id.eq(given.id))
+        .first(conn)?;
+
+    assert_eq!(given, got);
+
+    let given = Row { id: 2, ts: None, dt: None, d: None, t: None };
+
+    let _ = diesel::insert_into(schema::nullable_datetimes::table)
+        .values(given)
+        .execute(conn)?;
+
+    let got = schema::nullable_datetimes::table
+        .select(Row::as_select())
+        .filter(schema::nullable_datetimes::id.eq(given.id))
+        .first(conn)?;
+
+    assert_eq!(given, got);
+
+    Ok(())
+}
+
+fn example_datetime_sql_query_roundtrip(
+    conn: &mut MysqlConnection,
+) -> anyhow::Result<()> {
+    #[derive(Clone, Copy, Debug, PartialEq, QueryableByName)]
+    #[diesel(table_name = schema::datetimes)]
+    #[diesel(check_for_backend(diesel::mysql::Mysql))]
+    struct Row {
+        #[diesel(
+            serialize_as = jiff_diesel::Timestamp,
+            deserialize_as = jiff_diesel::Timestamp
+        )]
+        ts: jiff::Timestamp,
+        #[diesel(
+            serialize_as = jiff_diesel::DateTime,
+            deserialize_as = jiff_diesel::DateTime
+        )]
+        dt: jiff::civil::DateTime,
+        #[diesel(
+            serialize_as = jiff_diesel::Date,
+            deserialize_as = jiff_diesel::Date
+        )]
+        d: jiff::civil::Date,
+        #[diesel(
+            serialize_as = jiff_diesel::Time,
+            deserialize_as = jiff_diesel::Time
+        )]
         t: jiff::civil::Time,
     }
 

--- a/examples/diesel-postgres/main.rs
+++ b/examples/diesel-postgres/main.rs
@@ -1,17 +1,66 @@
 use diesel::{
     connection::Connection, dsl::sql, pg::PgConnection,
-    query_dsl::RunQueryDsl, select, sql_query, sql_types, QueryableByName,
+    query_dsl::RunQueryDsl, select, sql_query, sql_types, Insertable,
+    QueryableByName,
 };
 use jiff::civil;
 use jiff_diesel::ToDiesel;
+
+mod schema {
+    diesel::table! {
+        datetimes {
+            id -> Integer, // Diesel tables require an ID column.
+            ts -> Timestamptz,
+            dt -> Timestamp,
+            d -> Date,
+            t -> Time,
+        }
+    }
+
+    diesel::table! {
+        nullable_datetimes {
+            id -> Integer, // Diesel tables require an ID column.
+            ts -> Nullable<Timestamptz>,
+            dt -> Nullable<Timestamp>,
+            d -> Nullable<Date>,
+            t -> Nullable<Time>,
+        }
+    }
+}
 
 fn main() -> anyhow::Result<()> {
     let mut conn = PgConnection::establish(
         "postgres://postgres:password@localhost/test",
     )?;
 
+    sql_query(
+        "CREATE TEMPORARY TABLE IF NOT EXISTS datetimes (
+            id integer primary key generated always as identity,
+            ts timestamptz not null,
+            dt timestamp not null,
+            d date not null,
+            t time not null
+        )",
+    )
+    .execute(&mut conn)
+    .unwrap();
+
+    sql_query(
+        "CREATE TEMPORARY TABLE IF NOT EXISTS nullable_datetimes (
+            id integer primary key generated always as identity,
+            ts timestamptz,
+            dt timestamp,
+            d date,
+            t time
+        )",
+    )
+    .execute(&mut conn)
+    .unwrap();
+
     example_datetime_roundtrip(&mut conn)?;
     example_nullable_datetime_roundtrip(&mut conn)?;
+    example_datetime_sql_query_roundtrip(&mut conn)?;
+    example_nullable_datetime_sql_query_roundtrip(&mut conn)?;
     example_span_decode(&mut conn)?;
     example_time_zone_setting(&mut conn)?;
 
@@ -20,27 +69,139 @@ fn main() -> anyhow::Result<()> {
 
 /// Performs a round-trip with all of Jiff's datetime types.
 fn example_datetime_roundtrip(conn: &mut PgConnection) -> anyhow::Result<()> {
-    diesel::table! {
-        datetimes {
-            id -> Integer, // Diesel tables require an ID column.
-            ts -> Timestamptz,
-            dt -> Timestamp,
-            d -> Date,
-            t -> Time
-        }
-    }
+    use diesel::prelude::*;
 
-    #[derive(Debug, PartialEq, QueryableByName)]
-    #[diesel(table_name = datetimes)]
+    #[derive(
+        Clone, Copy, Debug, PartialEq, Queryable, Insertable, Selectable,
+    )]
+    #[diesel(table_name = schema::datetimes)]
     #[diesel(check_for_backend(diesel::pg::Pg))]
     struct Row {
-        #[diesel(deserialize_as = jiff_diesel::Timestamp)]
+        #[diesel(
+            serialize_as = jiff_diesel::Timestamp,
+            deserialize_as = jiff_diesel::Timestamp
+        )]
         ts: jiff::Timestamp,
-        #[diesel(deserialize_as = jiff_diesel::DateTime)]
+        #[diesel(
+            serialize_as = jiff_diesel::DateTime,
+            deserialize_as = jiff_diesel::DateTime
+        )]
         dt: jiff::civil::DateTime,
-        #[diesel(deserialize_as = jiff_diesel::Date)]
+        #[diesel(
+            serialize_as = jiff_diesel::Date,
+            deserialize_as = jiff_diesel::Date
+        )]
         d: jiff::civil::Date,
-        #[diesel(deserialize_as = jiff_diesel::Time)]
+        #[diesel(
+            serialize_as = jiff_diesel::Time,
+            deserialize_as = jiff_diesel::Time
+        )]
+        t: jiff::civil::Time,
+    }
+
+    let given = Row {
+        ts: "1970-01-01T00:00:00Z".parse()?,
+        dt: civil::date(2025, 7, 20).at(0, 0, 0, 0),
+        d: civil::date(1999, 1, 8),
+        t: civil::time(23, 59, 59, 999_999_000),
+    };
+
+    let got = diesel::insert_into(schema::datetimes::table)
+        .values(given)
+        .returning(Row::as_returning())
+        .get_result(conn)?;
+
+    assert_eq!(given, got);
+
+    Ok(())
+}
+
+/// Performs a round-trip with all of Jiff's nullable datetime types.
+fn example_nullable_datetime_roundtrip(
+    conn: &mut PgConnection,
+) -> anyhow::Result<()> {
+    use diesel::prelude::*;
+
+    #[derive(
+        Clone, Copy, Debug, PartialEq, Queryable, Insertable, Selectable,
+    )]
+    #[diesel(table_name = schema::nullable_datetimes)]
+    #[diesel(check_for_backend(diesel::pg::Pg))]
+    struct Row {
+        #[diesel(
+            serialize_as = jiff_diesel::NullableTimestamp,
+            deserialize_as = jiff_diesel::NullableTimestamp
+        )]
+        ts: Option<jiff::Timestamp>,
+        #[diesel(
+            serialize_as = jiff_diesel::NullableDateTime,
+            deserialize_as = jiff_diesel::NullableDateTime
+        )]
+        dt: Option<jiff::civil::DateTime>,
+        #[diesel(
+            serialize_as = jiff_diesel::NullableDate,
+            deserialize_as = jiff_diesel::NullableDate
+        )]
+        d: Option<jiff::civil::Date>,
+        #[diesel(
+            serialize_as = jiff_diesel::NullableTime,
+            deserialize_as = jiff_diesel::NullableTime
+        )]
+        t: Option<jiff::civil::Time>,
+    }
+
+    let given = Row {
+        ts: Some("1970-01-01T00:00:00Z".parse()?),
+        dt: Some(civil::date(2025, 7, 20).at(0, 0, 0, 0)),
+        d: Some(civil::date(1999, 1, 8)),
+        t: Some(civil::time(23, 59, 59, 999_999_000)),
+    };
+
+    let got = diesel::insert_into(schema::nullable_datetimes::table)
+        .values([given])
+        .returning(Row::as_returning())
+        .get_result(conn)?;
+
+    assert_eq!(given, got);
+
+    let given = Row { ts: None, dt: None, d: None, t: None };
+
+    let got = diesel::insert_into(schema::nullable_datetimes::table)
+        .values(given)
+        .returning(Row::as_returning())
+        .get_result(conn)?;
+
+    assert_eq!(given, got);
+
+    Ok(())
+}
+
+fn example_datetime_sql_query_roundtrip(
+    conn: &mut PgConnection,
+) -> anyhow::Result<()> {
+    #[derive(Clone, Copy, Debug, PartialEq, QueryableByName)]
+    #[diesel(table_name = schema::datetimes)]
+    #[diesel(check_for_backend(diesel::pg::Pg))]
+    struct Row {
+        #[diesel(
+            serialize_as = jiff_diesel::Timestamp,
+            deserialize_as = jiff_diesel::Timestamp
+        )]
+        ts: jiff::Timestamp,
+        #[diesel(
+            serialize_as = jiff_diesel::DateTime,
+            deserialize_as = jiff_diesel::DateTime
+        )]
+        dt: jiff::civil::DateTime,
+        #[diesel(
+            serialize_as = jiff_diesel::Date,
+            deserialize_as = jiff_diesel::Date
+        )]
+        d: jiff::civil::Date,
+        #[diesel(
+            serialize_as = jiff_diesel::Time,
+            deserialize_as = jiff_diesel::Time
+        )]
         t: jiff::civil::Time,
     }
 
@@ -70,31 +231,32 @@ fn example_datetime_roundtrip(conn: &mut PgConnection) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Performs a round-trip with all of Jiff's datetime types.
-fn example_nullable_datetime_roundtrip(
+fn example_nullable_datetime_sql_query_roundtrip(
     conn: &mut PgConnection,
 ) -> anyhow::Result<()> {
-    diesel::table! {
-        nullable_datetimes {
-            id -> Integer, // Diesel tables require an ID column.
-            ts -> Nullable<Timestamptz>,
-            dt -> Nullable<Timestamp>,
-            d -> Nullable<Date>,
-            t -> Nullable<Time>
-        }
-    }
-
-    #[derive(Debug, PartialEq, QueryableByName)]
-    #[diesel(table_name = nullable_datetimes)]
+    #[derive(Clone, Copy, Debug, PartialEq, QueryableByName)]
+    #[diesel(table_name = schema::nullable_datetimes)]
     #[diesel(check_for_backend(diesel::pg::Pg))]
     struct Row {
-        #[diesel(deserialize_as = jiff_diesel::NullableTimestamp)]
+        #[diesel(
+            serialize_as = jiff_diesel::NullableTimestamp,
+            deserialize_as = jiff_diesel::NullableTimestamp
+        )]
         ts: Option<jiff::Timestamp>,
-        #[diesel(deserialize_as = jiff_diesel::NullableDateTime)]
+        #[diesel(
+            serialize_as = jiff_diesel::NullableDateTime,
+            deserialize_as = jiff_diesel::NullableDateTime
+        )]
         dt: Option<jiff::civil::DateTime>,
-        #[diesel(deserialize_as = jiff_diesel::NullableDate)]
+        #[diesel(
+            serialize_as = jiff_diesel::NullableDate,
+            deserialize_as = jiff_diesel::NullableDate
+        )]
         d: Option<jiff::civil::Date>,
-        #[diesel(deserialize_as = jiff_diesel::NullableTime)]
+        #[diesel(
+            serialize_as = jiff_diesel::NullableTime,
+            deserialize_as = jiff_diesel::NullableTime
+        )]
         t: Option<jiff::civil::Time>,
     }
 
@@ -124,24 +286,6 @@ fn example_nullable_datetime_roundtrip(
     .bind::<sql_types::Nullable<sql_types::Time>, _>(&given.t.to_diesel())
     .get_result(conn)?;
     assert_eq!(given, got);
-
-    let given_null = Row { ts: None, dt: None, d: None, t: None };
-
-    let got_null = sql_query("select $1 as ts, $2 as dt, $3 as d, $4 as t")
-        .bind::<sql_types::Nullable<sql_types::Timestamptz>, _>(
-            &given_null.ts.to_diesel(),
-        )
-        .bind::<sql_types::Nullable<sql_types::Timestamp>, _>(
-            &given_null.dt.to_diesel(),
-        )
-        .bind::<sql_types::Nullable<sql_types::Date>, _>(
-            &given_null.d.to_diesel(),
-        )
-        .bind::<sql_types::Nullable<sql_types::Time>, _>(
-            &given_null.t.to_diesel(),
-        )
-        .get_result(conn)?;
-    assert_eq!(given_null, got_null);
 
     Ok(())
 }

--- a/examples/diesel-sqlite/Cargo.toml
+++ b/examples/diesel-sqlite/Cargo.toml
@@ -10,7 +10,10 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.95"
-diesel = { version = "2.2.0", features = ["sqlite"] }
+diesel = { version = "2.2.0", features = [
+    "returning_clauses_for_sqlite_3_35",
+    "sqlite",
+] }
 jiff = { path = "../.." }
 jiff-diesel = { path = "../../crates/jiff-diesel", features = ["sqlite"] }
 tempfile = "3.16.0"


### PR DESCRIPTION
This moves the majority of examples to use the `Insertable` and `Selectable` derivations from the query struct. This follows idiomatic Diesel usage. It also tests actual database round-tripping via database stores, includes testing of the `AsExpression` implementations.

The downside of this is that tables need to exist; I have created temporary tables in this PR for this purpose (which are dropped when the session is closed).

It also moves the database schema definition to a separate module, to match standard usage in diesel.

These tests require that #253 is merged, otherwise it's impossible to derive `Insertable` for nullable jiff types.