### PR TITLE
Add crate for integration with the AWS SDK for Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
   "crates/jiff-icu",
   "crates/jiff-sqlx",
   "crates/jiff-static",
+  "crates/jiff-aws",
   "crates/jiff-tzdb",
   "crates/jiff-tzdb-platform",
   "examples/*",

--- a/crates/jiff-aws/COPYING
+++ b/crates/jiff-aws/COPYING
@@ -1,0 +1,3 @@
+This project is dual-licensed under the Unlicense and MIT licenses.
+
+You may use this code under the terms of either license.

--- a/crates/jiff-aws/Cargo.toml
+++ b/crates/jiff-aws/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "jiff-aws"
+version = "0.1.0"  #:version
+authors = ["Andrew Gallant <jamslam@gmail.com>"]
+license = "Unlicense OR MIT"
+homepage = "https://github.com/BurntSushi/jiff/tree/master/crates/jiff-aws"
+repository = "https://github.com/BurntSushi/jiff"
+documentation = "https://docs.rs/jiff-aws"
+description = "Integration for Jiff with The AWS SDK for Rust"
+categories = ["date-and-time"]
+keywords = ["date", "time", "jiff", "aws", "zone"]
+workspace = "../.."
+edition = "2021"
+rust-version = "1.70"
+include = ["/src/*.rs", "/*.dat", "COPYING", "LICENSE-MIT", "UNLICENSE"]
+
+[lib]
+name = "jiff_aws"
+bench = false
+path = "src/lib.rs"
+
+[features]
+default = ["std"]
+std = ["alloc", "jiff/std"]
+alloc = ["jiff/alloc"]
+
+[dependencies]
+aws-smithy-types = "1.2"
+jiff = { version = "0.2.0", path = "../..", default-features = false }
+
+[dev-dependencies]
+jiff = { version = "0.2.0", path = "../..", default-features = true }

--- a/crates/jiff-aws/LICENSE-MIT
+++ b/crates/jiff-aws/LICENSE-MIT
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Andrew Gallant
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/crates/jiff-aws/README.md
+++ b/crates/jiff-aws/README.md
@@ -1,0 +1,6 @@
+jiff-aws
+=========
+This crate provides traits and methods to [`jiff`] that implement some basic
+conversion methods to/from the datetime types used in 
+the [AWS SDK for Rust](https://aws.amazon.com/sdk-for-rust/).
+

--- a/crates/jiff-aws/UNLICENSE
+++ b/crates/jiff-aws/UNLICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>

--- a/crates/jiff-aws/src/lib.rs
+++ b/crates/jiff-aws/src/lib.rs
@@ -1,0 +1,163 @@
+/*!
+This crate provides type convertion for [Jiff](jiff) and
+Aws Smithy Type [DateTime] used
+in the [AWS SDK for Rust](https://aws.amazon.com/sdk-for-rust/).
+
+```
+use jiff_aws::ConvertAwsDateTime;
+use jiff_aws::ConvertJiffTypes;
+use jiff::Timestamp;
+use jiff::Zoned;
+use aws_smithy_types::DateTime;
+
+let datetime = DateTime::from_secs_and_nanos(1627680004,123000000);
+let timestamp: Timestamp = datetime.try_into_timestamp().unwrap();
+assert_eq!( "2021-07-30T21:20:04.123Z".parse::<Timestamp>().unwrap(), timestamp);
+
+let timestamp = Timestamp::try_from_aws(datetime).unwrap();
+assert_eq!( "2021-07-30T21:20:04.123Z".parse::<Timestamp>().unwrap(), timestamp);
+
+let zoned = datetime.try_into_zoned().unwrap();
+assert_eq!( "2021-07-30T21:20:04.123+00:00[UTC]".parse::<Zoned>().unwrap(), zoned);
+
+let zoned = Zoned::try_from_aws(datetime).unwrap();
+assert_eq!( "2021-07-30T21:20:04.123+00:00[UTC]".parse::<Zoned>().unwrap(), zoned);
+
+let other: DateTime = timestamp.into_aws_datetime();
+assert_eq!(datetime, other);
+
+let other = DateTime::from_timestamp(timestamp);
+assert_eq!(datetime, other);
+
+let other: DateTime = zoned.clone().into_aws_datetime();
+assert_eq!(datetime, other);
+
+let other = DateTime::from_zoned(zoned);
+assert_eq!(datetime, other);
+
+```
+*/
+
+use aws_smithy_types::DateTime;
+use jiff::{tz::TimeZone, Timestamp, Zoned};
+pub use traits::{ConvertAwsDateTime, ConvertJiffTypes};
+mod traits;
+
+impl ConvertAwsDateTime for Timestamp {
+    type Error = jiff::Error;
+
+    fn into_aws_datetime(self) -> DateTime {
+        DateTime::from_timestamp(self)
+    }
+
+    fn try_from_aws(value: DateTime) -> Result<Self, Self::Error> {
+        jiff::Timestamp::new(value.secs(), value.subsec_nanos() as i32)
+    }
+}
+
+impl ConvertAwsDateTime for Zoned {
+    type Error = jiff::Error;
+
+    fn into_aws_datetime(self) -> DateTime {
+        DateTime::from_zoned(self)
+    }
+
+    fn try_from_aws(value: DateTime) -> Result<Self, Self::Error> {
+        let timestamp =
+            jiff::Timestamp::new(value.secs(), value.subsec_nanos() as i32)?;
+        Ok(timestamp.to_zoned(TimeZone::UTC))
+    }
+}
+
+impl ConvertJiffTypes for DateTime {
+    type Error = jiff::Error;
+
+    fn from_timestamp(timestamp: Timestamp) -> Self {
+        let (seconds, nanos) = if timestamp.subsec_nanosecond() < 0 {
+            (
+                timestamp.as_second() - 1,
+                (1_000_000_000 + timestamp.subsec_nanosecond()) as u32,
+            )
+        } else {
+            (timestamp.as_second(), timestamp.subsec_nanosecond() as u32)
+        };
+
+        DateTime::from_secs_and_nanos(seconds, nanos)
+    }
+
+    fn from_zoned(zoned: Zoned) -> Self {
+        let timestamp = zoned.timestamp();
+        Self::from_timestamp(timestamp)
+    }
+
+    fn try_into_zoned(self) -> Result<Zoned, Self::Error> {
+        Zoned::try_from_aws(self)
+    }
+
+    fn try_into_timestamp(self) -> Result<Timestamp, Self::Error> {
+        Timestamp::try_from_aws(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{traits::ConvertJiffTypes, ConvertAwsDateTime};
+    use aws_smithy_types::DateTime;
+    use jiff::{Timestamp, ToSpan};
+
+    #[test]
+    fn epoch() -> Result<(), jiff::Error> {
+        //Epoch
+        let ts = Timestamp::UNIX_EPOCH;
+        let dt = ts.into_aws_datetime();
+        assert_eq!(DateTime::from_secs_and_nanos(0, 0), dt);
+
+        //Roundtrip Epoch
+        let ts2 = dt.try_into_timestamp()?;
+        assert_eq!(Timestamp::UNIX_EPOCH, ts2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn epoch_minus_one_nano() -> Result<(), jiff::Error> {
+        // Epoch -1 nanosecond
+        let ts = Timestamp::UNIX_EPOCH - 1.nanosecond();
+        let dt = ts.into_aws_datetime();
+        assert_eq!(DateTime::from_secs_and_nanos(-1, 999_999_999), dt);
+
+        // Roundtrip -1 nanosecond
+        let ts2 = dt.try_into_timestamp()?;
+        assert_eq!(Timestamp::UNIX_EPOCH - 1.nanosecond(), ts2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn epoch_minus_one_sec() -> Result<(), jiff::Error> {
+        // Epoch -1 second
+        let ts = Timestamp::UNIX_EPOCH - 1.second();
+        let dt = ts.into_aws_datetime();
+        assert_eq!(DateTime::from_secs_and_nanos(-1, 0), dt);
+
+        // Roundtrip epoch -1 second
+        let ts2 = dt.try_into_timestamp()?;
+        assert_eq!(Timestamp::UNIX_EPOCH - 1.second(), ts2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn epoch_plus_1_sec_1_nano() -> Result<(), jiff::Error> {
+        // Epoch + 1 second and 1 nanosecond
+        let ts = Timestamp::UNIX_EPOCH + 1.second() + 1.nanosecond();
+        let dt = ts.into_aws_datetime();
+        assert_eq!(DateTime::from_secs_and_nanos(1, 1), dt);
+
+        // Roundtrip epoch + 1 second and 1 nanosecond
+        let ts2 = dt.try_into_timestamp()?;
+        assert_eq!(Timestamp::UNIX_EPOCH + 1.second() + 1.nanosecond(), ts2);
+
+        Ok(())
+    }
+}

--- a/crates/jiff-aws/src/traits.rs
+++ b/crates/jiff-aws/src/traits.rs
@@ -1,0 +1,27 @@
+use aws_smithy_types::DateTime;
+use jiff::{Timestamp, Zoned};
+
+/// A trait for adding methods to convert types into the [Jiff](jiff) types
+/// [Timestamp](jiff::Timestamp) and [Zoned](jiff::Zoned)
+pub trait ConvertJiffTypes: Sized {
+    type Error;
+    /// Infallibly creates a value of type `Self` from a Jiff [`Timestamp`](jiff::Timestamp)
+    fn from_timestamp(value: Timestamp) -> Self;
+    /// Infallibly creates a value of type `Self` from a Jiff [`Zoned`](jiff::Zoned)
+    fn from_zoned(value: Zoned) -> Self;
+    /// Fallibly creates a Jiff [`Zoned`](jiff::Zoned) (in TimeZone UTC) from `Self`
+    fn try_into_zoned(self) -> Result<Zoned, Self::Error>;
+    /// Fallibly creates a Jiff [`Timestamp`](jiff::Timestamp) from `Self`
+    fn try_into_timestamp(self) -> Result<Timestamp, Self::Error>;
+}
+
+/// A trait for adding methods to convert types into the aws smithy type [DateTime](aws_smithy_types::DateTime)
+pub trait ConvertAwsDateTime: Sized {
+    type Error;
+    /// Infallibly converts a value of type `Self` to a value of type Aws Smithy
+    /// [`DateTime`](aws_smithy_types::DateTime).
+    fn into_aws_datetime(self) -> DateTime;
+
+    /// Fallibly converts a value of Aws Smithy type [`DateTime`](aws_smithy_types::DateTime) to a value of type `Self`.
+    fn try_from_aws(value: DateTime) -> Result<Self, Self::Error>;
+}


### PR DESCRIPTION
I have implemented some basic conversion from the AWS Smithy type `DateTime`  into/from `Timestamp` and `Zoned`. 