### PR TITLE
doc: beef up docs for methods that set sub-second units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+0.2.2 (TBD)
+===========
+TODO
+
+Bug fixes:
+
+* [#261](https://github.com/BurntSushi/jiff/issues/261):
+Improve the documentation for `ZonedWith::nanosecond` and
+`ZonedWith::subsec_nanosecond`.
+
+
 0.2.1 (2025-02-16)
 ==================
 This release includes a massive number of optimizations that significantly

--- a/src/civil/datetime.rs
+++ b/src/civil/datetime.rs
@@ -4183,6 +4183,11 @@ impl DateTimeWith {
     ///
     /// This overrides any previous millisecond settings.
     ///
+    /// Note that this only sets the millisecond component. It does
+    /// not change the microsecond or nanosecond components. To set
+    /// the fractional second component to nanosecond precision, use
+    /// [`DateTimeWith::subsec_nanosecond`].
+    ///
     /// # Errors
     ///
     /// This returns an error when [`DateTimeWith::build`] is called if the
@@ -4216,6 +4221,11 @@ impl DateTimeWith {
     /// One can access this value via [`DateTime::microsecond`].
     ///
     /// This overrides any previous microsecond settings.
+    ///
+    /// Note that this only sets the microsecond component. It does
+    /// not change the millisecond or nanosecond components. To set
+    /// the fractional second component to nanosecond precision, use
+    /// [`DateTimeWith::subsec_nanosecond`].
     ///
     /// # Errors
     ///
@@ -4251,6 +4261,11 @@ impl DateTimeWith {
     ///
     /// This overrides any previous nanosecond settings.
     ///
+    /// Note that this only sets the nanosecond component. It does
+    /// not change the millisecond or microsecond components. To set
+    /// the fractional second component to nanosecond precision, use
+    /// [`DateTimeWith::subsec_nanosecond`].
+    ///
     /// # Errors
     ///
     /// This returns an error when [`DateTimeWith::build`] is called if the
@@ -4285,6 +4300,12 @@ impl DateTimeWith {
     /// [`DateTime::subsec_nanosecond`].
     ///
     /// This overrides any previous subsecond nanosecond settings.
+    ///
+    /// Note that this sets the entire fractional second component to
+    /// nanosecond precision, and overrides any individual millisecond,
+    /// microsecond or nanosecond settings. To set individual components,
+    /// use [`DateTimeWith::millisecond`], [`DateTimeWith::microsecond`] or
+    /// [`DateTimeWith::nanosecond`].
     ///
     /// # Errors
     ///

--- a/src/civil/time.rs
+++ b/src/civil/time.rs
@@ -3093,6 +3093,11 @@ impl TimeWith {
     ///
     /// This overrides any previous millisecond settings.
     ///
+    /// Note that this only sets the millisecond component. It does
+    /// not change the microsecond or nanosecond components. To set
+    /// the fractional second component to nanosecond precision, use
+    /// [`TimeWith::subsec_nanosecond`].
+    ///
     /// # Errors
     ///
     /// This returns an error when [`TimeWith::build`] is called if the given
@@ -3122,6 +3127,11 @@ impl TimeWith {
     /// One can access this value via [`Time::microsecond`].
     ///
     /// This overrides any previous microsecond settings.
+    ///
+    /// Note that this only sets the microsecond component. It does
+    /// not change the millisecond or nanosecond components. To set
+    /// the fractional second component to nanosecond precision, use
+    /// [`TimeWith::subsec_nanosecond`].
     ///
     /// # Errors
     ///
@@ -3153,6 +3163,11 @@ impl TimeWith {
     ///
     /// This overrides any previous nanosecond settings.
     ///
+    /// Note that this only sets the nanosecond component. It does
+    /// not change the millisecond or microsecond components. To set
+    /// the fractional second component to nanosecond precision, use
+    /// [`TimeWith::subsec_nanosecond`].
+    ///
     /// # Errors
     ///
     /// This returns an error when [`TimeWith::build`] is called if the given
@@ -3183,6 +3198,12 @@ impl TimeWith {
     /// [`Time::subsec_nanosecond`].
     ///
     /// This overrides any previous subsecond nanosecond settings.
+    ///
+    /// Note that this sets the entire fractional second component to
+    /// nanosecond precision, and overrides any individual millisecond,
+    /// microsecond or nanosecond settings. To set individual components,
+    /// use [`TimeWith::millisecond`], [`TimeWith::microsecond`] or
+    /// [`TimeWith::nanosecond`].
     ///
     /// # Errors
     ///

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -4887,6 +4887,11 @@ impl ZonedWith {
     ///
     /// This overrides any previous millisecond settings.
     ///
+    /// Note that this only sets the millisecond component. It does
+    /// not change the microsecond or nanosecond components. To set
+    /// the fractional second component to nanosecond precision, use
+    /// [`ZonedWith::subsec_nanosecond`].
+    ///
     /// # Errors
     ///
     /// This returns an error when [`ZonedWith::build`] is called if the
@@ -4920,6 +4925,11 @@ impl ZonedWith {
     /// One can access this value via [`Zoned::microsecond`].
     ///
     /// This overrides any previous microsecond settings.
+    ///
+    /// Note that this only sets the microsecond component. It does
+    /// not change the millisecond or nanosecond components. To set
+    /// the fractional second component to nanosecond precision, use
+    /// [`ZonedWith::subsec_nanosecond`].
     ///
     /// # Errors
     ///
@@ -4955,6 +4965,11 @@ impl ZonedWith {
     ///
     /// This overrides any previous nanosecond settings.
     ///
+    /// Note that this only sets the nanosecond component. It does
+    /// not change the millisecond or microsecond components. To set
+    /// the fractional second component to nanosecond precision, use
+    /// [`ZonedWith::subsec_nanosecond`].
+    ///
     /// # Errors
     ///
     /// This returns an error when [`ZonedWith::build`] is called if the
@@ -4989,6 +5004,12 @@ impl ZonedWith {
     /// [`Zoned::subsec_nanosecond`].
     ///
     /// This overrides any previous subsecond nanosecond settings.
+    ///
+    /// Note that this sets the entire fractional second component to
+    /// nanosecond precision, and overrides any individual millisecond,
+    /// microsecond or nanosecond settings. To set individual components,
+    /// use [`ZonedWith::millisecond`], [`ZonedWith::microsecond`] or
+    /// [`ZonedWith::nanosecond`].
     ///
     /// # Errors
     ///


### PR DESCRIPTION
For example, there is `Time::nanosecond` and `Time::subsec_nanosecond`.
The former sets the individual nanosecond component and does not change
the millisecond or microsecond components. But the latter sets the
entire fractional second component to nanosecond precision.

Fixes #261
