### PR TITLE
ci: check that `jiff-cli generate` doesn't produce diffs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,3 +372,50 @@ jobs:
     - name: Check formatting
       run: |
         cargo fmt --all -- --check
+
+  # Check that some `jiff-cli generate` commands don't produce a diff.
+  #
+  # This is useful for ensuring that, e.g., changes to `src/shared` are
+  # propagated to `crates/jiff-static/shared`.
+  generated:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+    - name: Install jiff-cli
+      run: cargo install -f --path crates/jiff-cli
+    - name: Generate code shared between jiff and jiff-static
+      run: |
+        jiff-cli generate shared
+        if ! git diff --exit-code; then
+          echo 'Please run `jiff-cli generated shared`'
+          exit 1
+        fi
+    - name: Generate crc32 code
+      run: |
+        jiff-cli generate crc32
+        if ! git diff --exit-code; then
+          echo 'Please run `jiff-cli generated crc32`'
+          exit 1
+        fi
+    - name: Generate unit designator match expression
+      run: |
+        jiff-cli generate unit-designator-match
+        if ! git diff --exit-code; then
+          echo 'Please run `jiff-cli generated unit-designator-match`'
+          exit 1
+        fi
+    - name: Generate mapping from Windows zones to IANA time zone identifiers
+      run: |
+        curl -LO 'https://raw.githubusercontent.com/unicode-org/cldr/main/common/supplemental/windowsZones.xml'
+        jiff-cli generate windows-zones windowsZones.xml
+        if ! git diff --exit-code; then
+          echo 'In a separate PR, please download windowsZones.xml'
+          echo 'from github.com/unicode-org/cldr and run'
+          echo '`jiff-cli generated windows-zones`'
+          exit 1
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,10 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  # This runs tests under a number of different feature combinations. Jiff has
+  # too many features to do the full powerset, but we capture a number of
+  # configurations here.
+  testfull:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -62,10 +65,6 @@ jobs:
       run: sed -i.bak 's/^edition = "2021"$/edition = "2024"/' Cargo.toml
     - name: Bump rust-version to Rust 1.85
       run: sed -i.bak 's/^rust-version = "1\.70"$/rust-version = "1.85"/' Cargo.toml
-    - run: cargo build --verbose
-    - run: cargo doc --features serde,static --verbose
-    - run: cargo test --verbose --lib --profile testrelease
-    - run: cargo test --verbose --test integration --profile testrelease
     - run: ./test
 
   # Test for Windows. We test fewer configurations here because it just
@@ -321,6 +320,44 @@ jobs:
       run: |
         cd crates/jiff-wasm
         wasm-pack test --node
+
+  # Run tests with `testrelease` profile.
+  #
+  # This is useful because Jiff's ranged integers internally track min/max
+  # values in debug mode, but don't in release mode. So there may occasionally
+  # be a discrepancy that is worth testing here.
+  testrelease:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+    # In Rust 2024, doc tests are (mostly) all compiled into a single
+    # executable and then run once. This is a lot faster for Jiff, which has
+    # 1000+ doc tests. Since we run doc tests in this job, we just bump to Rust
+    # 2024 to take advantage of this.
+    - name: Switch to Rust 2024
+      run: sed -i.bak 's/^edition = "2021"$/edition = "2024"/' Cargo.toml
+    - name: Bump rust-version to Rust 1.85
+      run: sed -i.bak 's/^rust-version = "1\.70"$/rust-version = "1.85"/' Cargo.toml
+    - name: Run tests under release mode
+      run: cargo test --verbose --all --profile testrelease
+
+  # Test that documentation gets built.
+  testdoc:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+    - name: Build docs with all features enabled
+      run: cargo doc --verbose --all-features
 
   # Run benchmarks as tests.
   testbench:

--- a/crates/jiff-static/shared/tzif.rs
+++ b/crates/jiff-static/shared/tzif.rs
@@ -584,14 +584,14 @@ impl TzifOwned {
             let its = ITimestamp { second: timestamp, nanosecond: 0 };
             let ioff = IOffset { second: offset };
             let dt = its.to_datetime(ioff);
-            TzifDateTime {
-                year: dt.date.year,
-                month: dt.date.month,
-                day: dt.date.day,
-                hour: dt.time.hour,
-                minute: dt.time.minute,
-                second: dt.time.second,
-            }
+            TzifDateTime::new(
+                dt.date.year,
+                dt.date.month,
+                dt.date.day,
+                dt.time.hour,
+                dt.time.minute,
+                dt.time.second,
+            )
         }
 
         let trans = &mut self.transitions;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -684,7 +684,12 @@ For more, see the [`fmt::serde`] sub-module. (This requires enabling Jiff's
 // Lots of rustdoc links break when disabling default features because docs
 // aren't written conditionally.
 #![cfg_attr(
-    all(feature = "std", feature = "serde", feature = "tzdb-zoneinfo"),
+    all(
+        feature = "std",
+        feature = "serde",
+        feature = "static",
+        feature = "tzdb-zoneinfo"
+    ),
     deny(rustdoc::broken_intra_doc_links)
 )]
 // These are just too annoying to squash otherwise.


### PR DESCRIPTION
This should help ensure that generated code doesn't get stale.

This is especially pertinent with the new `src/shared` module, which has
to be copied over to `crates/jiff-static/shared` any time a change is
made. Not all changes result in breakage (theoretical or otherwise), so
it's easy to forget to do.
