### PR TITLE
shared: fix implementation of `IDate::yesterday`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG
 
+0.2.3 (2025-03-07)
+==================
+This is a small release that fixes a bug in the handling of POSIX time zones
+in some cases. Specifically, the implementation of `Date::yesterday` was wrong
+when the date was the first of the month. This was a regression introduced in
+`0.2.2` and was not present in older releases. More test coverage has been
+added.
+
+Bug fixes:
+
+* [#290](https://github.com/BurntSushi/jiff/issues/290):
+Fix bug in implementation of `Date::yesterday`.
+
+
 0.2.2 (2025-03-06)
 ==================
 This release of Jiff includes a new opt-in proc macro for embedding a

--- a/src/shared/util/itime.rs
+++ b/src/shared/util/itime.rs
@@ -440,7 +440,7 @@ impl IDate {
                 return Ok(IDate { year, month: 12, day: 31 });
             }
             let month = self.month - 1;
-            let day = days_in_month(self.year, self.month);
+            let day = days_in_month(self.year, month);
             return Ok(IDate { month, day, ..self });
         }
         Ok(IDate { day: self.day - 1, ..self })
@@ -878,5 +878,41 @@ mod tests {
 
         assert_eq!(days_in_month(1900, 2), 28);
         assert_eq!(days_in_month(2000, 2), 29);
+    }
+
+    #[test]
+    fn yesterday() {
+        let d1 = IDate { year: 2025, month: 4, day: 7 };
+        let d2 = d1.yesterday().unwrap();
+        assert_eq!(d2, IDate { year: 2025, month: 4, day: 6 });
+
+        let d1 = IDate { year: 2025, month: 4, day: 1 };
+        let d2 = d1.yesterday().unwrap();
+        assert_eq!(d2, IDate { year: 2025, month: 3, day: 31 });
+
+        let d1 = IDate { year: 2025, month: 1, day: 1 };
+        let d2 = d1.yesterday().unwrap();
+        assert_eq!(d2, IDate { year: 2024, month: 12, day: 31 });
+
+        let d1 = IDate { year: -9999, month: 1, day: 1 };
+        assert_eq!(d1.yesterday().ok(), None);
+    }
+
+    #[test]
+    fn tomorrow() {
+        let d1 = IDate { year: 2025, month: 4, day: 7 };
+        let d2 = d1.tomorrow().unwrap();
+        assert_eq!(d2, IDate { year: 2025, month: 4, day: 8 });
+
+        let d1 = IDate { year: 2025, month: 3, day: 31 };
+        let d2 = d1.tomorrow().unwrap();
+        assert_eq!(d2, IDate { year: 2025, month: 4, day: 1 });
+
+        let d1 = IDate { year: 2025, month: 12, day: 31 };
+        let d2 = d1.tomorrow().unwrap();
+        assert_eq!(d2, IDate { year: 2026, month: 1, day: 1 });
+
+        let d1 = IDate { year: 9999, month: 12, day: 31 };
+        assert_eq!(d1.tomorrow().ok(), None);
     }
 }

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -5599,4 +5599,18 @@ mod tests {
         );
         assert_eq!(zdt1, &zdt2 - span, "should be reversible");
     }
+
+    // See: https://github.com/BurntSushi/jiff/issues/290
+    #[test]
+    fn zoned_roundtrip_regression() {
+        if crate::tz::db().is_definitively_empty() {
+            return;
+        }
+
+        let zdt: Zoned =
+            "2063-03-31T10:00:00+11:00[Australia/Sydney]".parse().unwrap();
+        assert_eq!(zdt.offset(), super::Offset::constant(11));
+        let roundtrip = zdt.time_zone().to_zoned(zdt.datetime()).unwrap();
+        assert_eq!(zdt, roundtrip);
+    }
 }


### PR DESCRIPTION
Basically, it was wrong when the date was the first day of the month.
This only impacts `jiff 0.2.2`. The bug wasn't present in previous
releases.

This was a transcription error during one of my refactors and it looks
like there unfortunately wasn't test coverage for it. Test coverage has
been added in this PR.

Fixes #290
