### PR TITLE
tz: fix comment and remove superfluous `repr(align(..))`

### DIFF
--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -365,7 +365,6 @@ pub enum TzifTransitionKind {
 /// extremely cheap. This is especially useful since we do a binary search on
 /// `&[TzifDateTime]` when doing a TZ lookup for a civil datetime.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-#[repr(align(8))]
 pub struct TzifDateTime {
     bits: i64,
 }

--- a/src/tz/timezone.rs
+++ b/src/tz/timezone.rs
@@ -2022,7 +2022,7 @@ mod repr {
     /// provenance polyfill (because of MSRV). We use the lower 4 bits of a
     /// pointer to indicate which variant we have. This is sound because we
     /// require all types that we allocate for to have a minimum alignment of
-    /// 4 bytes.
+    /// 8 bytes.
     pub(super) struct Repr {
         ptr: *const u8,
     }


### PR DESCRIPTION
When I originally wrote the comment on `Repr`, I got the alignment
wrong. But I caught that mistake and fixed it before merging anything
to `master`. I just hadn't updated the comment.

The `repr(align(..))` was leftovers from experimenting with a
`TzifDateTime` that *wasn't* packed. I was trying to get `rustc` to
optimize comparisons automatically to a single integer, but couldn't get
ti to work. So I resorted to bit-packing. Since the representation is
now just an `i64`, an explicit alignment is not needed. (And it didn't
help anyway.)