### PR TITLE
rangeint: remove PartialEq and PartialOrd impls for i{8,16,32,64,128}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # CHANGELOG
 
+0.2.4 (2025-03-10)
+==================
+This is another small release that fixes a problem where Jiff could break
+builds if they relied on inference for integer comparisons. Specifically, Jiff
+uses internal trait impls to make comparing its internal ranged integers
+more convenient. But Rust the language has no concept of "internal" trait
+impls, and thus this can impact type inference. If code was written in a way
+that relies on a singular trait impl that is available, then adding Jiff to
+the project can cause it to break.
+
+This isn't arguably Jiff's fault per se, but since these trait impls were just
+about internal convenience and not essential to Jiff's design, we adopt a
+pragmatic approach and just remove them.
+
+Bug fixes:
+
+* [#293](https://github.com/BurntSushi/jiff/issues/293):
+Remove internal trait impls that can cause breaks due to inference failures.
+
+
 0.2.3 (2025-03-07)
 ==================
 This is a small release that fixes a bug in the handling of POSIX time zones

--- a/src/civil/date.rs
+++ b/src/civil/date.rs
@@ -359,8 +359,8 @@ impl Date {
                 // max value bigger than what can really occur, and then panic.
                 // So we use these caps to say, "no range integer, it truly
                 // won't exceed 9999-W52-4."
-                if year == 9999 {
-                    if week >= 52 {
+                if year == C(9999) {
+                    if week >= C(52) {
                         [week.min(C(52)), weekday.min(C(4))]
                     } else {
                         [week, weekday]
@@ -472,7 +472,7 @@ impl Date {
     #[inline]
     pub fn era_year(self) -> (i16, Era) {
         let year = self.year_ranged();
-        if year >= 1 {
+        if year >= C(1) {
             (year.get(), Era::CE)
         } else {
             // We specifically ensure our min/max bounds on `Year` always leave
@@ -1058,9 +1058,9 @@ impl Date {
         // ref: http://howardhinnant.github.io/date_algorithms.html#next_weekday
 
         let nth = t::SpanWeeks::try_new("nth weekday", nth)?;
-        if nth == 0 {
+        if nth == C(0) {
             Err(err!("nth weekday cannot be `0`"))
-        } else if nth > 0 {
+        } else if nth > C(0) {
             let nth = nth.max(C(1));
             let weekday_diff = weekday.since_ranged(self.weekday().next());
             let diff = (nth - C(1)) * C(7) + weekday_diff;
@@ -1463,9 +1463,9 @@ impl Date {
         }
         if span.units().contains_only(Unit::Day) {
             let span_days = span.get_days_ranged();
-            return if span_days == -1 {
+            return if span_days == C(-1) {
                 self.yesterday()
-            } else if span_days == 1 {
+            } else if span_days == C(1) {
                 self.tomorrow()
             } else {
                 let epoch_days = self.to_unix_epoch_day();
@@ -2112,7 +2112,7 @@ impl Date {
         day: impl RInto<Day>,
     ) -> Result<Date, Error> {
         let (year, month, day) = (year.rinto(), month.rinto(), day.rinto());
-        if day > 28 {
+        if day > C(28) {
             let max_day = days_in_month(year, month);
             if day > max_day {
                 return Err(day.to_error_with_bounds("day", 1, max_day));
@@ -2970,8 +2970,8 @@ impl DateDifference {
         let mut months =
             t::SpanMonths::rfrom(month2) - t::SpanMonths::rfrom(month1);
         let mut days = t::SpanDays::rfrom(day2) - t::SpanMonths::rfrom(day1);
-        if years != 0 || months != 0 {
-            let sign = if years != 0 {
+        if years != C(0) || months != C(0) {
+            let sign = if years != C(0) {
                 Sign::rfrom(years.signum())
             } else {
                 Sign::rfrom(months.signum())
@@ -2990,7 +2990,7 @@ impl DateDifference {
                 months = t::SpanMonths::rfrom(month2)
                     - t::SpanMonths::rfrom(month1);
                 days_in_month1 = days_in_month(year2, month2).rinto();
-                day_correct = if sign < 0 {
+                day_correct = if sign < C(0) {
                     -original_days_in_month1
                 } else {
                     days_in_month1
@@ -3000,11 +3000,11 @@ impl DateDifference {
             let day0_trunc = t::SpanDays::rfrom(day1.min(days_in_month1));
             days = t::SpanDays::rfrom(day2) - day0_trunc + day_correct;
 
-            if years != 0 {
+            if years != C(0) {
                 months = t::SpanMonths::rfrom(month2)
                     - t::SpanMonths::rfrom(month1);
                 if months.signum() == -sign {
-                    let month_correct = if sign < 0 {
+                    let month_correct = if sign < C(0) {
                         -t::MONTHS_PER_YEAR
                     } else {
                         t::MONTHS_PER_YEAR
@@ -3019,7 +3019,7 @@ impl DateDifference {
                 }
             }
         }
-        if largest == Unit::Month && years != 0 {
+        if largest == Unit::Month && years != C(0) {
             months = months.try_checked_add(
                 "months",
                 t::SpanMonths::rfrom(years) * t::MONTHS_PER_YEAR,
@@ -3628,7 +3628,7 @@ fn month_add_one(
     let delta = sign.rinto();
 
     month += delta;
-    if month < 1 {
+    if month < C(1) {
         year -= C(1);
         month += t::MONTHS_PER_YEAR;
     } else if month > t::MONTHS_PER_YEAR {

--- a/src/civil/datetime.rs
+++ b/src/civil/datetime.rs
@@ -3248,9 +3248,9 @@ impl DateTimeDifference {
             // then it's impossible for `sign < 0` since the max date is at
             // least as big as every other date. And thus, d2.tomorrow() is
             // never reached in cases where it would fail.
-            if sign > 0 {
+            if sign > C(0) {
                 d2 = d2.yesterday().unwrap();
-            } else if sign < 0 {
+            } else if sign < C(0) {
                 d2 = d2.tomorrow().unwrap();
             }
             time_diff +=
@@ -3536,7 +3536,7 @@ impl DateTimeRound {
                 ));
             }
             // We don't do any rounding in this case, so just bail now.
-            Unit::Nanosecond if increment == 1 => {
+            Unit::Nanosecond if increment == C(1) => {
                 return Ok(dt);
             }
             _ => {}

--- a/src/civil/iso_week_date.rs
+++ b/src/civil/iso_week_date.rs
@@ -664,7 +664,7 @@ impl ISOWeekDate {
         // a little trickier if the range of ISOYear is different from Year.
         debug_assert_eq!(t::Year::MIN, ISOYear::MIN);
         debug_assert_eq!(t::Year::MAX, ISOYear::MAX);
-        if week == 53 && !is_long_year(year) {
+        if week == C(53) && !is_long_year(year) {
             return Err(err!(
                 "ISO week number `{week}` is invalid for year `{year}`"
             ));
@@ -678,7 +678,7 @@ impl ISOWeekDate {
         // (-9999-01-01) corresponds also to the minimum possible combination
         // of an ISO week date's fields: -9999 W01 Monday. Nice.
         if year == ISOYear::MAX_SELF
-            && week == 52
+            && week == C(52)
             && weekday.to_monday_zero_offset()
                 > Weekday::Friday.to_monday_zero_offset()
         {
@@ -707,11 +707,11 @@ impl ISOWeekDate {
         let mut week = week.rinto();
         debug_assert_eq!(t::Year::MIN, ISOYear::MIN);
         debug_assert_eq!(t::Year::MAX, ISOYear::MAX);
-        if week == 53 && !is_long_year(year) {
+        if week == C(53) && !is_long_year(year) {
             week = ISOWeek::new(52).unwrap();
         }
         if year == ISOYear::MAX_SELF
-            && week == 52
+            && week == C(52)
             && weekday.to_monday_zero_offset()
                 > Weekday::Friday.to_monday_zero_offset()
         {

--- a/src/civil/time.rs
+++ b/src/civil/time.rs
@@ -3454,7 +3454,7 @@ mod tests {
         let max = -SignedDuration::MIN.as_nanos();
         let got = time(15, 30, 8, 999_999_999).to_nanosecond();
         let expected = max.rem_euclid(t::NANOS_PER_CIVIL_DAY.bound());
-        assert_eq!(got, expected);
+        assert_eq!(i128::from(got.get()), expected);
     }
 
     // This test checks that a wrapping subtraction with the maximum signed
@@ -3464,7 +3464,7 @@ mod tests {
         let max = -SignedDuration::MAX.as_nanos();
         let got = time(8, 29, 52, 1).to_nanosecond();
         let expected = max.rem_euclid(t::NANOS_PER_CIVIL_DAY.bound());
-        assert_eq!(got, expected);
+        assert_eq!(i128::from(got.get()), expected);
     }
 
     // This test checks that a wrapping subtraction with the maximum unsigned
@@ -3475,7 +3475,7 @@ mod tests {
             -i128::try_from(std::time::Duration::MAX.as_nanos()).unwrap();
         let got = time(16, 59, 44, 1).to_nanosecond();
         let expected = max.rem_euclid(t::NANOS_PER_CIVIL_DAY.bound());
-        assert_eq!(got, expected);
+        assert_eq!(i128::from(got.get()), expected);
     }
 
     /// # `serde` deserializer compatibility test

--- a/src/fmt/friendly/parser.rs
+++ b/src/fmt/friendly/parser.rs
@@ -8,7 +8,10 @@ use crate::{
         },
         Parsed,
     },
-    util::{escape, t},
+    util::{
+        escape,
+        t::{self, C},
+    },
     Error, SignedDuration, Span, Unit,
 };
 
@@ -331,7 +334,7 @@ impl SpanParser {
             let parsed = self.parse_suffix_sign(sign, input)?;
             (parsed.value, parsed.input)
         };
-        if sign < 0 {
+        if sign < C(0) {
             sdur = -sdur;
         }
 

--- a/src/fmt/offset.rs
+++ b/src/fmt/offset.rs
@@ -167,7 +167,7 @@ impl ParsedOffset {
             ParsedOffsetKind::Zulu => Ok(PiecesOffset::Zulu),
             ParsedOffsetKind::Numeric(ref numeric) => {
                 let mut off = PiecesNumericOffset::from(numeric.to_offset()?);
-                if numeric.sign < 0 {
+                if numeric.sign < C(0) {
                     off = off.with_negative_zero();
                 }
                 Ok(PiecesOffset::from(off))
@@ -228,7 +228,7 @@ impl Numeric {
             seconds += part_seconds;
         }
         if let Some(part_nanoseconds) = self.nanoseconds {
-            if part_nanoseconds >= 500_000_000 {
+            if part_nanoseconds >= C(500_000_000) {
                 seconds = seconds
                     .try_checked_add("offset-seconds", C(1))
                     .with_context(|| {
@@ -248,7 +248,7 @@ impl Numeric {
 // `Offset` fails.
 impl core::fmt::Display for Numeric {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        if self.sign == -1 {
+        if self.sign == C(-1) {
             write!(f, "-")?;
         } else {
             write!(f, "+")?;

--- a/src/fmt/rfc2822.rs
+++ b/src/fmt/rfc2822.rs
@@ -1435,7 +1435,7 @@ impl DateTimePrinter {
         // seem clearly indicated, we choose to do that here. An alternative
         // would be to return an error. It isn't clear how important this is in
         // practice though.
-        if offset.part_seconds_ranged().abs() >= 30 {
+        if offset.part_seconds_ranged().abs() >= C(30) {
             if minutes == 59 {
                 hours = hours.saturating_add(1);
                 minutes = 0;

--- a/src/fmt/strtime/format.rs
+++ b/src/fmt/strtime/format.rs
@@ -9,7 +9,7 @@ use crate::{
         Write, WriteExt,
     },
     tz::Offset,
-    util::{escape, utf8},
+    util::{escape, t::C, utf8},
     Error,
 };
 
@@ -480,7 +480,7 @@ impl<'f, 't, 'w, W: Write> Formatter<'f, 't, 'w, W> {
         if ext.width == Some(0) {
             return Err(err!("zero precision with %f is not allowed"));
         }
-        if subsec == 0 && ext.width.is_none() {
+        if subsec == C(0) && ext.width.is_none() {
             self.wtr.write_str("0")?;
             return Ok(());
         }
@@ -491,7 +491,7 @@ impl<'f, 't, 'w, W: Write> Formatter<'f, 't, 'w, W> {
     /// %.f
     fn fmt_dot_fractional(&mut self, ext: Extension) -> Result<(), Error> {
         let Some(subsec) = self.tm.subsec else { return Ok(()) };
-        if subsec == 0 && ext.width.is_none() || ext.width == Some(0) {
+        if subsec == C(0) && ext.width.is_none() || ext.width == Some(0) {
             return Ok(());
         }
         ext.write_str(Case::AsIs, ".", self.wtr)?;

--- a/src/fmt/strtime/parse.rs
+++ b/src/fmt/strtime/parse.rs
@@ -903,7 +903,7 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
         let year = Year2Digit::try_new("year (2 digits)", year)
             .context("year number is invalid")?;
         let mut year = t::Year::rfrom(year);
-        if year <= 68 {
+        if year <= C(68) {
             year += C(2000);
         } else {
             year += C(1900);
@@ -968,7 +968,7 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
         let year = Year2Digit::try_new("year (2 digits)", year)
             .context("ISO 8601 week-based year number is invalid")?;
         let mut year = t::ISOYear::rfrom(year);
-        if year <= 68 {
+        if year <= C(68) {
             year += C(2000);
         } else {
             year += C(1900);

--- a/src/fmt/temporal/parser.rs
+++ b/src/fmt/temporal/parser.rs
@@ -16,7 +16,10 @@ use crate::{
         AmbiguousZoned, Disambiguation, Offset, OffsetConflict, TimeZone,
         TimeZoneDatabase,
     },
-    util::{escape, parse, t},
+    util::{
+        escape, parse,
+        t::{self, C},
+    },
     SignedDuration, Timestamp, Unit, Zoned,
 };
 
@@ -116,7 +119,7 @@ impl<'i> ParsedDateTime<'i> {
             }
             // If the candidate offset we're considering is a whole minute,
             // then we never need rounding.
-            if candidate.part_seconds_ranged() == 0 {
+            if candidate.part_seconds_ranged() == C(0) {
                 return parsed == candidate;
             }
             let Ok(candidate) = candidate.round(Unit::Minute) else {
@@ -805,7 +808,7 @@ impl DateTimeParser {
             })?;
             let year =
                 t::Year::try_new("year", year).context("year is not valid")?;
-            if year == 0 && sign < 0 {
+            if year == C(0) && sign < C(0) {
                 return Err(err!(
                     "year zero must be written without a sign or a \
                      positive sign, but not a negative sign",
@@ -1160,7 +1163,7 @@ impl SpanParser {
                  in {original:?}, but did not find any units",
             ));
         }
-        if sign < 0 {
+        if sign < C(0) {
             span = span.negate();
         }
         Ok(Parsed { value: span, input })
@@ -1183,7 +1186,7 @@ impl SpanParser {
             ));
         }
         let Parsed { value: dur, input } =
-            self.parse_time_units_duration(input, sign == -1)?;
+            self.parse_time_units_duration(input, sign == C(-1))?;
         Ok(Parsed { value: dur, input })
     }
 

--- a/src/fmt/temporal/printer.rs
+++ b/src/fmt/temporal/printer.rs
@@ -8,7 +8,10 @@ use crate::{
     },
     span::Span,
     tz::{Offset, TimeZone},
-    util::{rangeint::RFrom, t},
+    util::{
+        rangeint::RFrom,
+        t::{self, C},
+    },
     SignedDuration, Timestamp, Zoned,
 };
 
@@ -290,7 +293,7 @@ impl DateTimePrinter {
         // to suggest that the number of minutes should be "as close as
         // possible" to the actual offset. So we just do basic rounding
         // here.
-        if offset.part_seconds_ranged().abs() >= 30 {
+        if offset.part_seconds_ranged().abs() >= C(30) {
             if minutes == 59 {
                 hours = hours.saturating_add(1);
                 minutes = 0;
@@ -411,29 +414,29 @@ impl SpanPrinter {
         wtr.write_str("P")?;
 
         let mut non_zero_greater_than_second = false;
-        if span.get_years_ranged() != 0 {
+        if span.get_years_ranged() != C(0) {
             wtr.write_int(&FMT_INT, span.get_years_ranged().get().abs())?;
             wtr.write_char(self.label('Y'))?;
             non_zero_greater_than_second = true;
         }
-        if span.get_months_ranged() != 0 {
+        if span.get_months_ranged() != C(0) {
             wtr.write_int(&FMT_INT, span.get_months_ranged().get().abs())?;
             wtr.write_char(self.label('M'))?;
             non_zero_greater_than_second = true;
         }
-        if span.get_weeks_ranged() != 0 {
+        if span.get_weeks_ranged() != C(0) {
             wtr.write_int(&FMT_INT, span.get_weeks_ranged().get().abs())?;
             wtr.write_char(self.label('W'))?;
             non_zero_greater_than_second = true;
         }
-        if span.get_days_ranged() != 0 {
+        if span.get_days_ranged() != C(0) {
             wtr.write_int(&FMT_INT, span.get_days_ranged().get().abs())?;
             wtr.write_char(self.label('D'))?;
             non_zero_greater_than_second = true;
         }
 
         let mut printed_time_prefix = false;
-        if span.get_hours_ranged() != 0 {
+        if span.get_hours_ranged() != C(0) {
             if !printed_time_prefix {
                 wtr.write_str("T")?;
                 printed_time_prefix = true;
@@ -442,7 +445,7 @@ impl SpanPrinter {
             wtr.write_char(self.label('H'))?;
             non_zero_greater_than_second = true;
         }
-        if span.get_minutes_ranged() != 0 {
+        if span.get_minutes_ranged() != C(0) {
             if !printed_time_prefix {
                 wtr.write_str("T")?;
                 printed_time_prefix = true;
@@ -462,17 +465,17 @@ impl SpanPrinter {
             span.get_microseconds_ranged().abs(),
             span.get_nanoseconds_ranged().abs(),
         );
-        if (seconds != 0 || !non_zero_greater_than_second)
-            && millis == 0
-            && micros == 0
-            && nanos == 0
+        if (seconds != C(0) || !non_zero_greater_than_second)
+            && millis == C(0)
+            && micros == C(0)
+            && nanos == C(0)
         {
             if !printed_time_prefix {
                 wtr.write_str("T")?;
             }
             wtr.write_int(&FMT_INT, seconds.get())?;
             wtr.write_char(self.label('S'))?;
-        } else if millis != 0 || micros != 0 || nanos != 0 {
+        } else if millis != C(0) || micros != C(0) || nanos != C(0) {
             if !printed_time_prefix {
                 wtr.write_str("T")?;
             }
@@ -496,7 +499,7 @@ impl SpanPrinter {
                 combined_as_nanos % t::NANOS_PER_SECOND,
             );
             wtr.write_int(&FMT_INT, fraction_second.get())?;
-            if fraction_nano != 0 {
+            if fraction_nano != C(0) {
                 wtr.write_str(".")?;
                 wtr.write_fraction(&FMT_FRACTION, fraction_nano.get())?;
             }

--- a/src/fmt/util.rs
+++ b/src/fmt/util.rs
@@ -1,7 +1,11 @@
 use crate::{
     error::{err, ErrorContext},
     fmt::Parsed,
-    util::{escape, parse, rangeint::RFrom, t},
+    util::{
+        escape, parse,
+        rangeint::RFrom,
+        t::{self, C},
+    },
     Error, SignedDuration, Span, Unit,
 };
 
@@ -466,7 +470,7 @@ pub(crate) fn fractional_time_to_span(
         _ => unreachable!("unsupported unit: {unit:?}"),
     };
 
-    if unit >= Unit::Hour && nanos > 0 {
+    if unit >= Unit::Hour && nanos > C(0) {
         let mut hours = nanos / t::NANOS_PER_HOUR;
         nanos %= t::NANOS_PER_HOUR;
         if hours > t::SpanHours::MAX_SELF {
@@ -476,7 +480,7 @@ pub(crate) fn fractional_time_to_span(
         // OK because we just checked that our units are in range.
         span = span.try_hours_ranged(hours).unwrap();
     }
-    if unit >= Unit::Minute && nanos > 0 {
+    if unit >= Unit::Minute && nanos > C(0) {
         let mut minutes = nanos / t::NANOS_PER_MINUTE;
         nanos %= t::NANOS_PER_MINUTE;
         if minutes > t::SpanMinutes::MAX_SELF {
@@ -487,7 +491,7 @@ pub(crate) fn fractional_time_to_span(
         // OK because we just checked that our units are in range.
         span = span.try_minutes_ranged(minutes).unwrap();
     }
-    if unit >= Unit::Second && nanos > 0 {
+    if unit >= Unit::Second && nanos > C(0) {
         let mut seconds = nanos / t::NANOS_PER_SECOND;
         nanos %= t::NANOS_PER_SECOND;
         if seconds > t::SpanSeconds::MAX_SELF {
@@ -498,7 +502,7 @@ pub(crate) fn fractional_time_to_span(
         // OK because we just checked that our units are in range.
         span = span.try_seconds_ranged(seconds).unwrap();
     }
-    if unit >= Unit::Millisecond && nanos > 0 {
+    if unit >= Unit::Millisecond && nanos > C(0) {
         let mut millis = nanos / t::NANOS_PER_MILLI;
         nanos %= t::NANOS_PER_MILLI;
         if millis > t::SpanMilliseconds::MAX_SELF {
@@ -509,7 +513,7 @@ pub(crate) fn fractional_time_to_span(
         // OK because we just checked that our units are in range.
         span = span.try_milliseconds_ranged(millis).unwrap();
     }
-    if unit >= Unit::Microsecond && nanos > 0 {
+    if unit >= Unit::Microsecond && nanos > C(0) {
         let mut micros = nanos / t::NANOS_PER_MICRO;
         nanos %= t::NANOS_PER_MICRO;
         if micros > t::SpanMicroseconds::MAX_SELF {
@@ -520,7 +524,7 @@ pub(crate) fn fractional_time_to_span(
         // OK because we just checked that our units are in range.
         span = span.try_microseconds_ranged(micros).unwrap();
     }
-    if nanos > 0 {
+    if nanos > C(0) {
         span = span.try_nanoseconds_ranged(nanos).with_context(|| {
             err!(
                 "failed to set nanosecond value {nanos} on span \

--- a/src/span.rs
+++ b/src/span.rs
@@ -1380,7 +1380,7 @@ impl Span {
     /// ```
     #[inline]
     pub fn is_positive(self) -> bool {
-        self.get_sign_ranged() > 0
+        self.get_sign_ranged() > C(0)
     }
 
     /// Returns true if and only if this span is negative.
@@ -1397,7 +1397,7 @@ impl Span {
     /// ```
     #[inline]
     pub fn is_negative(self) -> bool {
-        self.get_sign_ranged() < 0
+        self.get_sign_ranged() < C(0)
     }
 
     /// Returns true if and only if every field in this span is set to `0`.
@@ -1415,7 +1415,7 @@ impl Span {
     /// ```
     #[inline]
     pub fn is_zero(self) -> bool {
-        self.sign == 0
+        self.sign == C(0)
     }
 
     /// Returns this `Span` as a value with a type that implements the
@@ -1508,51 +1508,51 @@ impl Span {
         // actually going to multiply with it. If our span has non-zero years,
         // then our multiple can't exceed the bounds of `SpanYears`, otherwise
         // it is guaranteed to overflow.
-        if self.years != 0 {
+        if self.years != C(0) {
             let rhs = t::SpanYears::try_new("years multiple", rhs)?;
             self.years = self.years.try_checked_mul("years", rhs.abs())?;
         }
-        if self.months != 0 {
+        if self.months != C(0) {
             let rhs = t::SpanMonths::try_new("months multiple", rhs)?;
             self.months = self.months.try_checked_mul("months", rhs.abs())?;
         }
-        if self.weeks != 0 {
+        if self.weeks != C(0) {
             let rhs = t::SpanWeeks::try_new("weeks multiple", rhs)?;
             self.weeks = self.weeks.try_checked_mul("weeks", rhs.abs())?;
         }
-        if self.days != 0 {
+        if self.days != C(0) {
             let rhs = t::SpanDays::try_new("days multiple", rhs)?;
             self.days = self.days.try_checked_mul("days", rhs.abs())?;
         }
-        if self.hours != 0 {
+        if self.hours != C(0) {
             let rhs = t::SpanHours::try_new("hours multiple", rhs)?;
             self.hours = self.hours.try_checked_mul("hours", rhs.abs())?;
         }
-        if self.minutes != 0 {
+        if self.minutes != C(0) {
             let rhs = t::SpanMinutes::try_new("minutes multiple", rhs)?;
             self.minutes =
                 self.minutes.try_checked_mul("minutes", rhs.abs())?;
         }
-        if self.seconds != 0 {
+        if self.seconds != C(0) {
             let rhs = t::SpanSeconds::try_new("seconds multiple", rhs)?;
             self.seconds =
                 self.seconds.try_checked_mul("seconds", rhs.abs())?;
         }
-        if self.milliseconds != 0 {
+        if self.milliseconds != C(0) {
             let rhs =
                 t::SpanMilliseconds::try_new("milliseconds multiple", rhs)?;
             self.milliseconds = self
                 .milliseconds
                 .try_checked_mul("milliseconds", rhs.abs())?;
         }
-        if self.microseconds != 0 {
+        if self.microseconds != C(0) {
             let rhs =
                 t::SpanMicroseconds::try_new("microseconds multiple", rhs)?;
             self.microseconds = self
                 .microseconds
                 .try_checked_mul("microseconds", rhs.abs())?;
         }
-        if self.nanoseconds != 0 {
+        if self.nanoseconds != C(0) {
             let rhs =
                 t::SpanNanoseconds::try_new("nanoseconds multiple", rhs)?;
             self.nanoseconds =
@@ -2486,7 +2486,7 @@ impl Span {
         let years = years.rinto();
         let mut span = Span { years: years.abs(), ..self };
         span.sign = self.resign(years, &span);
-        span.units = span.units.set(Unit::Year, years == 0);
+        span.units = span.units.set(Unit::Year, years == C(0));
         span
     }
 
@@ -2498,7 +2498,7 @@ impl Span {
         let months = months.rinto();
         let mut span = Span { months: months.abs(), ..self };
         span.sign = self.resign(months, &span);
-        span.units = span.units.set(Unit::Month, months == 0);
+        span.units = span.units.set(Unit::Month, months == C(0));
         span
     }
 
@@ -2507,7 +2507,7 @@ impl Span {
         let weeks = weeks.rinto();
         let mut span = Span { weeks: weeks.abs(), ..self };
         span.sign = self.resign(weeks, &span);
-        span.units = span.units.set(Unit::Week, weeks == 0);
+        span.units = span.units.set(Unit::Week, weeks == C(0));
         span
     }
 
@@ -2516,7 +2516,7 @@ impl Span {
         let days = days.rinto();
         let mut span = Span { days: days.abs(), ..self };
         span.sign = self.resign(days, &span);
-        span.units = span.units.set(Unit::Day, days == 0);
+        span.units = span.units.set(Unit::Day, days == C(0));
         span
     }
 
@@ -2525,7 +2525,7 @@ impl Span {
         let hours = hours.rinto();
         let mut span = Span { hours: hours.abs(), ..self };
         span.sign = self.resign(hours, &span);
-        span.units = span.units.set(Unit::Hour, hours == 0);
+        span.units = span.units.set(Unit::Hour, hours == C(0));
         span
     }
 
@@ -2537,7 +2537,7 @@ impl Span {
         let minutes = minutes.rinto();
         let mut span = Span { minutes: minutes.abs(), ..self };
         span.sign = self.resign(minutes, &span);
-        span.units = span.units.set(Unit::Minute, minutes == 0);
+        span.units = span.units.set(Unit::Minute, minutes == C(0));
         span
     }
 
@@ -2549,7 +2549,7 @@ impl Span {
         let seconds = seconds.rinto();
         let mut span = Span { seconds: seconds.abs(), ..self };
         span.sign = self.resign(seconds, &span);
-        span.units = span.units.set(Unit::Second, seconds == 0);
+        span.units = span.units.set(Unit::Second, seconds == C(0));
         span
     }
 
@@ -2561,7 +2561,7 @@ impl Span {
         let milliseconds = milliseconds.rinto();
         let mut span = Span { milliseconds: milliseconds.abs(), ..self };
         span.sign = self.resign(milliseconds, &span);
-        span.units = span.units.set(Unit::Millisecond, milliseconds == 0);
+        span.units = span.units.set(Unit::Millisecond, milliseconds == C(0));
         span
     }
 
@@ -2573,7 +2573,7 @@ impl Span {
         let microseconds = microseconds.rinto();
         let mut span = Span { microseconds: microseconds.abs(), ..self };
         span.sign = self.resign(microseconds, &span);
-        span.units = span.units.set(Unit::Microsecond, microseconds == 0);
+        span.units = span.units.set(Unit::Microsecond, microseconds == C(0));
         span
     }
 
@@ -2585,7 +2585,7 @@ impl Span {
         let nanoseconds = nanoseconds.rinto();
         let mut span = Span { nanoseconds: nanoseconds.abs(), ..self };
         span.sign = self.resign(nanoseconds, &span);
-        span.units = span.units.set(Unit::Nanosecond, nanoseconds == 0);
+        span.units = span.units.set(Unit::Nanosecond, nanoseconds == C(0));
         span
     }
 
@@ -3018,9 +3018,9 @@ impl Span {
     /// fractional second unit.
     #[inline]
     pub(crate) fn has_fractional_seconds(&self) -> bool {
-        self.milliseconds != 0
-            || self.microseconds != 0
-            || self.nanoseconds != 0
+        self.milliseconds != C(0)
+            || self.microseconds != C(0)
+            || self.nanoseconds != C(0)
     }
 
     /// Returns an equivalent span, but with all non-calendar (units below
@@ -3034,11 +3034,11 @@ impl Span {
         span.milliseconds = t::SpanMilliseconds::N::<0>();
         span.microseconds = t::SpanMicroseconds::N::<0>();
         span.nanoseconds = t::SpanNanoseconds::N::<0>();
-        if span.sign != 0
-            && span.years == 0
-            && span.months == 0
-            && span.weeks == 0
-            && span.days == 0
+        if span.sign != C(0)
+            && span.years == C(0)
+            && span.months == C(0)
+            && span.weeks == C(0)
+            && span.days == C(0)
         {
             span.sign = t::Sign::N::<0>();
         }
@@ -3055,13 +3055,13 @@ impl Span {
         span.months = t::SpanMonths::N::<0>();
         span.weeks = t::SpanWeeks::N::<0>();
         span.days = t::SpanDays::N::<0>();
-        if span.sign != 0
-            && span.hours == 0
-            && span.minutes == 0
-            && span.seconds == 0
-            && span.milliseconds == 0
-            && span.microseconds == 0
-            && span.nanoseconds == 0
+        if span.sign != C(0)
+            && span.hours == C(0)
+            && span.minutes == C(0)
+            && span.seconds == C(0)
+            && span.milliseconds == C(0)
+            && span.microseconds == C(0)
+            && span.nanoseconds == C(0)
         {
             span.sign = t::Sign::N::<0>();
         }
@@ -3193,34 +3193,34 @@ impl Span {
         let mut buf = alloc::string::String::new();
         write!(buf, "Span {{ sign: {:?}, units: {:?}", self.sign, self.units)
             .unwrap();
-        if self.years != 0 {
+        if self.years != C(0) {
             write!(buf, ", years: {:?}", self.years).unwrap();
         }
-        if self.months != 0 {
+        if self.months != C(0) {
             write!(buf, ", months: {:?}", self.months).unwrap();
         }
-        if self.weeks != 0 {
+        if self.weeks != C(0) {
             write!(buf, ", weeks: {:?}", self.weeks).unwrap();
         }
-        if self.days != 0 {
+        if self.days != C(0) {
             write!(buf, ", days: {:?}", self.days).unwrap();
         }
-        if self.hours != 0 {
+        if self.hours != C(0) {
             write!(buf, ", hours: {:?}", self.hours).unwrap();
         }
-        if self.minutes != 0 {
+        if self.minutes != C(0) {
             write!(buf, ", minutes: {:?}", self.minutes).unwrap();
         }
-        if self.seconds != 0 {
+        if self.seconds != C(0) {
             write!(buf, ", seconds: {:?}", self.seconds).unwrap();
         }
-        if self.milliseconds != 0 {
+        if self.milliseconds != C(0) {
             write!(buf, ", milliseconds: {:?}", self.milliseconds).unwrap();
         }
-        if self.microseconds != 0 {
+        if self.microseconds != C(0) {
             write!(buf, ", microseconds: {:?}", self.microseconds).unwrap();
         }
-        if self.nanoseconds != 0 {
+        if self.nanoseconds != C(0) {
             write!(buf, ", nanoseconds: {:?}", self.nanoseconds).unwrap();
         }
         write!(buf, " }}").unwrap();
@@ -3233,25 +3233,25 @@ impl Span {
     fn resign(&self, units: impl RInto<NoUnits>, new: &Span) -> Sign {
         let units = units.rinto();
         // Negative units anywhere always makes the entire span negative.
-        if units < 0 {
+        if units < C(0) {
             return Sign::N::<-1>();
         }
-        let mut new_is_zero = new.sign == 0 && units == 0;
+        let mut new_is_zero = new.sign == C(0) && units == C(0);
         // When `units == 0` and it was previously non-zero, then `new.sign`
         // won't be `0` and thus `new_is_zero` will be false when it should
         // be true. So in this case, we need to re-check all the units to set
         // the sign correctly.
-        if units == 0 {
-            new_is_zero = new.years == 0
-                && new.months == 0
-                && new.weeks == 0
-                && new.days == 0
-                && new.hours == 0
-                && new.minutes == 0
-                && new.seconds == 0
-                && new.milliseconds == 0
-                && new.microseconds == 0
-                && new.nanoseconds == 0;
+        if units == C(0) {
+            new_is_zero = new.years == C(0)
+                && new.months == C(0)
+                && new.weeks == C(0)
+                && new.days == C(0)
+                && new.hours == C(0)
+                && new.minutes == C(0)
+                && new.seconds == C(0)
+                && new.milliseconds == C(0)
+                && new.microseconds == C(0)
+                && new.nanoseconds == C(0);
         }
         match (self.is_zero(), new_is_zero) {
             (_, true) => Sign::N::<0>(),
@@ -6032,8 +6032,8 @@ impl<'a> Relative<'a> {
             }
         };
         let relspan = kind.into_relative_span(largest)?;
-        if span.get_sign_ranged() != 0
-            && relspan.span.get_sign_ranged() != 0
+        if span.get_sign_ranged() != C(0)
+            && relspan.span.get_sign_ranged() != C(0)
             && span.get_sign_ranged() != relspan.span.get_sign_ranged()
         {
             // I haven't quite figured out when this case is hit. I think it's
@@ -6058,7 +6058,7 @@ impl<'a> Relative<'a> {
         mode: RoundMode,
     ) -> Result<Span, Error> {
         let relspan = self.into_relative_span(largest, span)?;
-        if relspan.span.get_sign_ranged() == 0 {
+        if relspan.span.get_sign_ranged() == C(0) {
             return Ok(relspan.span);
         }
         let nudge = match relspan.kind {
@@ -6539,7 +6539,7 @@ impl Nudge {
 
         let mut day_delta = NoUnits::N::<0>();
         let rounded_relative_end =
-            if beyond_day_nanos == 0 || beyond_day_nanos.signum() == sign {
+            if beyond_day_nanos == C(0) || beyond_day_nanos.signum() == sign {
                 day_delta += C(1);
                 rounded_time_nanos = mode.round_by_unit_in_nanoseconds(
                     beyond_day_nanos,
@@ -6564,7 +6564,7 @@ impl Nudge {
                 .months_ranged(balanced.get_months_ranged())
                 .weeks_ranged(balanced.get_weeks_ranged())
                 .days_ranged(balanced.get_days_ranged() + day_delta);
-        let grew_big_unit = day_delta != 0;
+        let grew_big_unit = day_delta != C(0);
         Ok(Nudge { span, rounded_relative_end, grew_big_unit })
     }
 
@@ -6631,7 +6631,7 @@ impl Nudge {
             };
             let beyond =
                 self.rounded_relative_end - threshold.as_nanosecond_ranged();
-            if beyond == 0 || beyond.signum() == sign {
+            if beyond == C(0) || beyond.signum() == sign {
                 balanced = span_end;
             } else {
                 break;
@@ -7126,15 +7126,18 @@ mod tests {
 
     #[test]
     fn span_sign() {
-        assert_eq!(Span::new().get_sign_ranged(), 0);
-        assert_eq!(Span::new().days(1).get_sign_ranged(), 1);
-        assert_eq!(Span::new().days(-1).get_sign_ranged(), -1);
-        assert_eq!(Span::new().days(1).days(0).get_sign_ranged(), 0);
-        assert_eq!(Span::new().days(-1).days(0).get_sign_ranged(), 0);
-        assert_eq!(Span::new().years(1).days(1).days(0).get_sign_ranged(), 1);
+        assert_eq!(Span::new().get_sign_ranged(), C(0));
+        assert_eq!(Span::new().days(1).get_sign_ranged(), C(1));
+        assert_eq!(Span::new().days(-1).get_sign_ranged(), C(-1));
+        assert_eq!(Span::new().days(1).days(0).get_sign_ranged(), C(0));
+        assert_eq!(Span::new().days(-1).days(0).get_sign_ranged(), C(0));
+        assert_eq!(
+            Span::new().years(1).days(1).days(0).get_sign_ranged(),
+            C(1)
+        );
         assert_eq!(
             Span::new().years(-1).days(-1).days(0).get_sign_ranged(),
-            -1
+            C(-1)
         );
     }
 

--- a/src/tz/offset.rs
+++ b/src/tz/offset.rs
@@ -14,7 +14,7 @@ use crate::{
     util::{
         array_str::ArrayStr,
         rangeint::{self, Composite, RFrom, RInto, TryRFrom},
-        t,
+        t::{self, C},
     },
     RoundMode, SignedDuration, SignedDurationRound, Unit,
 };
@@ -377,7 +377,7 @@ impl Offset {
     /// assert!(!tz::offset(-5).is_positive());
     /// ```
     pub fn is_positive(self) -> bool {
-        self.seconds_ranged() > 0
+        self.seconds_ranged() > C(0)
     }
 
     /// Returns true if and only if this offset is less than zero.
@@ -392,7 +392,7 @@ impl Offset {
     /// assert!(tz::offset(-5).is_negative());
     /// ```
     pub fn is_negative(self) -> bool {
-        self.seconds_ranged() < 0
+        self.seconds_ranged() < C(0)
     }
 
     /// Returns true if and only if this offset is zero.
@@ -409,7 +409,7 @@ impl Offset {
     /// assert!(!tz::offset(-5).is_zero());
     /// ```
     pub fn is_zero(self) -> bool {
-        self.seconds_ranged() == 0
+        self.seconds_ranged() == C(0)
     }
 
     /// Converts this offset into a [`TimeZone`].
@@ -1107,7 +1107,7 @@ impl Offset {
 
 impl core::fmt::Debug for Offset {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        let sign = if self.seconds_ranged() < 0 { "-" } else { "" };
+        let sign = if self.seconds_ranged() < C(0) { "-" } else { "" };
         write!(
             f,
             "{sign}{:02}:{:02}:{:02}",
@@ -1120,7 +1120,7 @@ impl core::fmt::Debug for Offset {
 
 impl core::fmt::Display for Offset {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        let sign = if self.span < 0 { "-" } else { "+" };
+        let sign = if self.span < C(0) { "-" } else { "+" };
         let hours = self.part_hours_ranged().abs().get();
         let minutes = self.part_minutes_ranged().abs().get();
         let seconds = self.part_seconds_ranged().abs().get();

--- a/src/tz/zic.rs
+++ b/src/tz/zic.rs
@@ -2011,62 +2011,62 @@ mod tests {
     #[test]
     fn parse_rule_in_ok() {
         let inn: RuleInP = "Ja".parse().unwrap();
-        assert_eq!(inn.month, 1);
+        assert_eq!(inn.month.get(), 1);
         let inn: RuleInP = "January".parse().unwrap();
-        assert_eq!(inn.month, 1);
+        assert_eq!(inn.month.get(), 1);
 
         let inn: RuleInP = "F".parse().unwrap();
-        assert_eq!(inn.month, 2);
+        assert_eq!(inn.month.get(), 2);
         let inn: RuleInP = "February".parse().unwrap();
-        assert_eq!(inn.month, 2);
+        assert_eq!(inn.month.get(), 2);
 
         let inn: RuleInP = "Mar".parse().unwrap();
-        assert_eq!(inn.month, 3);
+        assert_eq!(inn.month.get(), 3);
         let inn: RuleInP = "March".parse().unwrap();
-        assert_eq!(inn.month, 3);
+        assert_eq!(inn.month.get(), 3);
 
         let inn: RuleInP = "Ap".parse().unwrap();
-        assert_eq!(inn.month, 4);
+        assert_eq!(inn.month.get(), 4);
         let inn: RuleInP = "April".parse().unwrap();
-        assert_eq!(inn.month, 4);
+        assert_eq!(inn.month.get(), 4);
 
         let inn: RuleInP = "May".parse().unwrap();
-        assert_eq!(inn.month, 5);
+        assert_eq!(inn.month.get(), 5);
 
         let inn: RuleInP = "Jun".parse().unwrap();
-        assert_eq!(inn.month, 6);
+        assert_eq!(inn.month.get(), 6);
         let inn: RuleInP = "June".parse().unwrap();
-        assert_eq!(inn.month, 6);
+        assert_eq!(inn.month.get(), 6);
 
         let inn: RuleInP = "Jul".parse().unwrap();
-        assert_eq!(inn.month, 7);
+        assert_eq!(inn.month.get(), 7);
         let inn: RuleInP = "July".parse().unwrap();
-        assert_eq!(inn.month, 7);
+        assert_eq!(inn.month.get(), 7);
 
         let inn: RuleInP = "Au".parse().unwrap();
-        assert_eq!(inn.month, 8);
+        assert_eq!(inn.month.get(), 8);
         let inn: RuleInP = "August".parse().unwrap();
-        assert_eq!(inn.month, 8);
+        assert_eq!(inn.month.get(), 8);
 
         let inn: RuleInP = "S".parse().unwrap();
-        assert_eq!(inn.month, 9);
+        assert_eq!(inn.month.get(), 9);
         let inn: RuleInP = "September".parse().unwrap();
-        assert_eq!(inn.month, 9);
+        assert_eq!(inn.month.get(), 9);
 
         let inn: RuleInP = "O".parse().unwrap();
-        assert_eq!(inn.month, 10);
+        assert_eq!(inn.month.get(), 10);
         let inn: RuleInP = "October".parse().unwrap();
-        assert_eq!(inn.month, 10);
+        assert_eq!(inn.month.get(), 10);
 
         let inn: RuleInP = "N".parse().unwrap();
-        assert_eq!(inn.month, 11);
+        assert_eq!(inn.month.get(), 11);
         let inn: RuleInP = "November".parse().unwrap();
-        assert_eq!(inn.month, 11);
+        assert_eq!(inn.month.get(), 11);
 
         let inn: RuleInP = "D".parse().unwrap();
-        assert_eq!(inn.month, 12);
+        assert_eq!(inn.month.get(), 12);
         let inn: RuleInP = "December".parse().unwrap();
-        assert_eq!(inn.month, 12);
+        assert_eq!(inn.month.get(), 12);
     }
 
     #[test]
@@ -2576,12 +2576,12 @@ mod tests {
 
     #[test]
     fn parse_year_ok() {
-        assert_eq!(parse_year("0").unwrap(), 0);
-        assert_eq!(parse_year("1").unwrap(), 1);
-        assert_eq!(parse_year("-1").unwrap(), -1);
-        assert_eq!(parse_year("2025").unwrap(), 2025);
-        assert_eq!(parse_year("9999").unwrap(), 9999);
-        assert_eq!(parse_year("-9999").unwrap(), -9999);
+        assert_eq!(parse_year("0").unwrap().get(), 0);
+        assert_eq!(parse_year("1").unwrap().get(), 1);
+        assert_eq!(parse_year("-1").unwrap().get(), -1);
+        assert_eq!(parse_year("2025").unwrap().get(), 2025);
+        assert_eq!(parse_year("9999").unwrap().get(), 9999);
+        assert_eq!(parse_year("-9999").unwrap().get(), -9999);
     }
 
     #[test]
@@ -2665,15 +2665,15 @@ mod tests {
 
     #[test]
     fn parse_day_ok() {
-        assert_eq!(parse_day("1").unwrap(), 1);
-        assert_eq!(parse_day("2").unwrap(), 2);
-        assert_eq!(parse_day("20").unwrap(), 20);
-        assert_eq!(parse_day("30").unwrap(), 30);
-        assert_eq!(parse_day("31").unwrap(), 31);
+        assert_eq!(parse_day("1").unwrap().get(), 1);
+        assert_eq!(parse_day("2").unwrap().get(), 2);
+        assert_eq!(parse_day("20").unwrap().get(), 20);
+        assert_eq!(parse_day("30").unwrap().get(), 30);
+        assert_eq!(parse_day("31").unwrap().get(), 31);
 
-        assert_eq!(parse_day("01").unwrap(), 1);
-        assert_eq!(parse_day("00000001").unwrap(), 1);
-        assert_eq!(parse_day("0000000000000000000001").unwrap(), 1);
+        assert_eq!(parse_day("01").unwrap().get(), 1);
+        assert_eq!(parse_day("00000001").unwrap().get(), 1);
+        assert_eq!(parse_day("0000000000000000000001").unwrap().get(), 1);
     }
 
     #[test]

--- a/src/util/rangeint.rs
+++ b/src/util/rangeint.rs
@@ -1151,17 +1151,6 @@ macro_rules! define_ranged {
             }
 
             impl<
-                const MIN: i128,
-                const MAX: i128,
-            > PartialEq<$smaller_repr> for $name<MIN, MAX>
-            {
-                #[inline]
-                fn eq(&self, other: &$smaller_repr) -> bool {
-                    self.eq(&<$repr>::from(*other))
-                }
-            }
-
-            impl<
                 const MIN1: i128,
                 const MAX1: i128,
                 const MIN2: i128,
@@ -1174,20 +1163,6 @@ macro_rules! define_ranged {
                     other: &$smaller_name<MIN1, MAX1>,
                 ) -> Option<Ordering> {
                     self.partial_cmp(&Self::rfrom(*other))
-                }
-            }
-
-            impl<
-                const MIN: i128,
-                const MAX: i128,
-            > PartialOrd<$smaller_repr> for $name<MIN, MAX>
-            {
-                #[inline]
-                fn partial_cmp(
-                    &self,
-                    other: &$smaller_repr,
-                ) -> Option<Ordering> {
-                    self.partial_cmp(&<$repr>::from(*other))
                 }
             }
 
@@ -1467,17 +1442,6 @@ macro_rules! define_ranged {
             }
 
             impl<
-                const MIN: i128,
-                const MAX: i128,
-            > PartialEq<$bigger_repr> for $name<MIN, MAX>
-            {
-                #[inline]
-                fn eq(&self, other: &$bigger_repr) -> bool {
-                    <$bigger_name<MIN, MAX>>::rfrom(*self).eq(other)
-                }
-            }
-
-            impl<
                 const MIN1: i128,
                 const MAX1: i128,
                 const MIN2: i128,
@@ -1490,20 +1454,6 @@ macro_rules! define_ranged {
                     other: &$bigger_name<MIN1, MAX1>,
                 ) -> Option<Ordering> {
                     <$bigger_name<MIN1, MAX1>>::rfrom(*self).partial_cmp(other)
-                }
-            }
-
-            impl<
-                const MIN: i128,
-                const MAX: i128,
-            > PartialOrd<$bigger_repr> for $name<MIN, MAX>
-            {
-                #[inline]
-                fn partial_cmp(
-                    &self,
-                    other: &$bigger_repr,
-                ) -> Option<Ordering> {
-                    <$bigger_name<MIN, MAX>>::rfrom(*self).partial_cmp(other)
                 }
             }
 
@@ -2084,20 +2034,6 @@ macro_rules! define_ranged {
             }
         }
 
-        impl<const MIN: i128, const MAX: i128> PartialEq<$repr> for $name<MIN, MAX> {
-            #[inline]
-            fn eq(&self, other: &$repr) -> bool {
-                self.val.eq(other)
-            }
-        }
-
-        impl<const MIN: i128, const MAX: i128> PartialEq<$name<MIN, MAX>> for $repr {
-            #[inline]
-            fn eq(&self, other: &$name<MIN, MAX>) -> bool {
-                self.eq(&other.val)
-            }
-        }
-
         impl<const MIN: i128, const MAX: i128> Ord for $name<MIN, MAX> {
             #[inline]
             fn cmp(&self, other: &Self) -> core::cmp::Ordering {
@@ -2137,26 +2073,6 @@ macro_rules! define_ranged {
                 other: &$name<MIN, MAX>,
             ) -> Option<core::cmp::Ordering> {
                 <$repr>::from(*self).partial_cmp(&other.val)
-            }
-        }
-
-        impl<const MIN: i128, const MAX: i128> PartialOrd<$repr> for $name<MIN, MAX> {
-            #[inline]
-            fn partial_cmp(
-                &self,
-                other: &$repr,
-            ) -> Option<core::cmp::Ordering> {
-                self.val.partial_cmp(other)
-            }
-        }
-
-        impl<const MIN: i128, const MAX: i128> PartialOrd<$name<MIN, MAX>> for $repr {
-            #[inline]
-            fn partial_cmp(
-                &self,
-                other: &$name<MIN, MAX>,
-            ) -> Option<core::cmp::Ordering> {
-                self.partial_cmp(&other.val)
             }
         }
 

--- a/src/util/round/increment.rs
+++ b/src/util/round/increment.rs
@@ -118,7 +118,7 @@ fn get_with_limit(
 ) -> Result<t::NoUnits128, Error> {
     // OK because `NoUnits` specifically allows any `i64` value.
     let increment = t::NoUnits::new_unchecked(increment);
-    if increment <= 0 {
+    if increment <= C(0) {
         return Err(err!(
             "rounding increment {increment} for {unit} must be \
              greater than zero",
@@ -152,7 +152,7 @@ fn get_with_max(
 ) -> Result<t::NoUnits128, Error> {
     // OK because `NoUnits` specifically allows any `i64` value.
     let increment = t::NoUnits::new_unchecked(increment);
-    if increment <= 0 {
+    if increment <= C(0) {
         return Err(err!(
             "rounding increment {increment} for {unit} must be \
              greater than zero",

--- a/src/util/round/mode.rs
+++ b/src/util/round/mode.rs
@@ -119,22 +119,22 @@ impl RoundMode {
         ) -> NoUnits128 {
             let mut quotient = quantity.div_ceil(increment);
             let remainder = quantity.rem_ceil(increment);
-            if remainder == 0 {
+            if remainder == C(0) {
                 return quantity;
             }
-            let sign = if remainder < 0 { C128(-1) } else { C128(1) };
+            let sign = if remainder < C(0) { C128(-1) } else { C128(1) };
             let tiebreaker = (remainder * C128(2)).abs();
             let tie = tiebreaker == increment;
             let expand_is_nearer = tiebreaker > increment;
             // ref: https://tc39.es/proposal-temporal/#sec-temporal-roundnumbertoincrement
             match mode {
                 RoundMode::Ceil => {
-                    if sign > 0 {
+                    if sign > C(0) {
                         quotient += sign;
                     }
                 }
                 RoundMode::Floor => {
-                    if sign < 0 {
+                    if sign < C(0) {
                         quotient += sign;
                     }
                 }
@@ -143,12 +143,12 @@ impl RoundMode {
                 }
                 RoundMode::Trunc => {}
                 RoundMode::HalfCeil => {
-                    if expand_is_nearer || (tie && sign > 0) {
+                    if expand_is_nearer || (tie && sign > C(0)) {
                         quotient += sign;
                     }
                 }
                 RoundMode::HalfFloor => {
-                    if expand_is_nearer || (tie && sign < 0) {
+                    if expand_is_nearer || (tie && sign < C(0)) {
                         quotient += sign;
                     }
                 }
@@ -163,7 +163,7 @@ impl RoundMode {
                     }
                 }
                 RoundMode::HalfEven => {
-                    if expand_is_nearer || (tie && quotient % C(2) == 1) {
+                    if expand_is_nearer || (tie && quotient % C(2) == C(1)) {
                         quotient += sign;
                     }
                 }

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -3905,7 +3905,7 @@ impl<'a> ZonedDifference<'a> {
         let zdt2 = self.zoned;
 
         let sign = t::sign(zdt2, zdt1);
-        if sign == 0 {
+        if sign == C(0) {
             return Ok(Span::new());
         }
 
@@ -3952,7 +3952,7 @@ impl<'a> ZonedDifference<'a> {
             )
         })?;
         if t::sign(zdt2, &zmid) == -sign {
-            if sign == -1 {
+            if sign == C(-1) {
                 panic!("this should be an error");
             }
             day_correct += C(1);


### PR DESCRIPTION
Unfortunately, these impls can cause inference regressions when
non-robust code is written that assumes there is only one
Partial{Eq,Ord} impl for a particular integer type.

It would be one thing if these trait impls were external or somehow
fundamental to Jiff's design. But they only existed as a convenience. So
we remove the trait impls and take our medicine. We already had a
`Constant` wrapper type (also used for trait impls), so we just switch
all equality and inequality comparisons over to that.

I tested this with the following program:

```rust
use env_logger;

fn main() {
    let x: u64 = 1;
    let y: i128 = 0;
    assert!(y < x.into());

    let x: u32 = 1;
    let y: i64 = 0;
    assert!(y < x.into());

    let x: u16 = 1;
    let y: i32 = 0;
    assert!(y < x.into());

    let x: u8 = 1;
    let y: i16 = 0;
    assert!(y < x.into());
}
```

And this `Cargo.toml`:

```toml
[package]
publish = false
name = "jiff-inference-regression"
version = "0.1.0"
edition = "2024"

[patch.crates-io]
jiff = { path = "/home/andrew/rust/jiff/fixit" }

[dependencies]
env_logger = { version = "0.11.7", features = ["humantime"] }

[[bin]]
name = "jiff-inference-regression"
path = "main.rs"

[profile.release]
debug = true
```

I took this path because it's either this or the reporter fixes their
code. Arguably, the reporter should fix their code since it's likely
their code will break when or if some other crate adds similar trait
impls. But as I said, these trait impls are just for convenience, so
the pragmatic trade-off is to remove them and thus not be the source of
whatever problems folks hit.

[I asked the lang team about this problem][lang-zulip-question], and
they seem to agree that this is the right course of action. (And there
are ideas swirling around on how to mitigate this problem, but that's
for the future.)

Fixes #293

[lang-zulip-question]: https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang/topic/about.20the.20breakage.20that.20results.20from.20relying.20on.20inference/with/504689811
