### PR TITLE
Panic on `wasm32-unknown-unknown` without `js` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+0.2.9 (TBD)
+===========
+TODO
+
+Enhancements:
+
+* [#296](https://github.com/BurntSushi/jiff/issues/296):
+Provide a better panic message when `Zoned::now()` fails on WASM.
+
+
 0.2.8 (2025-04-13)
 ==================
 This release fixes a bug where the constructors on `SignedDuration`

--- a/src/now.rs
+++ b/src/now.rs
@@ -25,23 +25,19 @@ mod sys {
         // `SystemTime::now()` should continue to panic on this exact target in
         // the future as well; Instead of letting `std` panic, we panic first
         // with a more informative error message.
-        #[cfg(all(
+        if cfg!(all(
             not(feature = "js"),
             any(target_arch = "wasm32", target_arch = "wasm64"),
             target_os = "unknown"
-        ))]
-        panic!(
-            "getting the current time in wasm32-unknown-unknown \
-             is not possible, enable jiff's `js` feature if you are \
-             targeting a browser environment",
-        );
-
-        #[cfg(not(all(
-            not(feature = "js"),
-            any(target_arch = "wasm32", target_arch = "wasm64"),
-            target_os = "unknown"
-        )))]
-        std::time::SystemTime::now()
+        )) {
+            panic!(
+                "getting the current time in wasm32-unknown-unknown \
+                 is not possible, enable jiff's `js` feature if you are \
+                 targeting a browser environment",
+            );
+        } else {
+            std::time::SystemTime::now()
+        }
     }
 
     #[cfg(any(
@@ -53,19 +49,15 @@ mod sys {
         // Same reasoning as above, but we return `None` instead of panicking,
         // because `jiff` can deal with environments that don't provide
         // monotonic time.
-        #[cfg(all(
+        if cfg!(all(
             not(feature = "js"),
             any(target_arch = "wasm32", target_arch = "wasm64"),
             target_os = "unknown"
-        ))]
-        None
-
-        #[cfg(not(all(
-            not(feature = "js"),
-            any(target_arch = "wasm32", target_arch = "wasm64"),
-            target_os = "unknown"
-        )))]
-        Some(std::time::Instant::now())
+        )) {
+            None
+        } else {
+            Some(std::time::Instant::now())
+        }
     }
 }
 

--- a/src/now.rs
+++ b/src/now.rs
@@ -32,7 +32,8 @@ mod sys {
         )) {
             panic!(
                 "getting the current time in wasm32-unknown-unknown \
-                 is not possible, enable jiff's `js` feature if you are \
+                 is not possible with just the standard library, \
+                 enable Jiff's `js` feature if you are \
                  targeting a browser environment",
             );
         } else {
@@ -47,7 +48,7 @@ mod sys {
     ))]
     pub(crate) fn monotonic_time() -> Option<std::time::Instant> {
         // Same reasoning as above, but we return `None` instead of panicking,
-        // because `jiff` can deal with environments that don't provide
+        // because Jiff can deal with environments that don't provide
         // monotonic time.
         if cfg!(all(
             not(feature = "js"),

--- a/src/now.rs
+++ b/src/now.rs
@@ -22,16 +22,19 @@ pub(crate) use self::sys::*;
 )))]
 mod sys {
     pub(crate) fn system_time() -> std::time::SystemTime {
-        // `SystemTime::now()` should continue to panic on this exact target in the future
-        // as well; Instead of letting `std` panic, we panic first with a more informative
-        // error message.
+        // `SystemTime::now()` should continue to panic on this exact target in
+        // the future as well; Instead of letting `std` panic, we panic first
+        // with a more informative error message.
         #[cfg(all(
             not(feature = "js"),
             any(target_arch = "wasm32", target_arch = "wasm64"),
             target_os = "unknown"
         ))]
-        panic!("getting the current time in wasm32-unknown-unknown is not possible, \
-                enable jiff's `js` feature if you are targeting a browser environment");
+        panic!(
+            "getting the current time in wasm32-unknown-unknown \
+             is not possible, enable jiff's `js` feature if you are \
+             targeting a browser environment",
+        );
 
         std::time::SystemTime::now()
     }

--- a/src/now.rs
+++ b/src/now.rs
@@ -36,6 +36,11 @@ mod sys {
              targeting a browser environment",
         );
 
+        #[cfg(not(all(
+            not(feature = "js"),
+            any(target_arch = "wasm32", target_arch = "wasm64"),
+            target_os = "unknown"
+        )))]
         std::time::SystemTime::now()
     }
 
@@ -54,6 +59,11 @@ mod sys {
         panic!("getting the current time in wasm32-unknown-unknown is not possible, \
                 enable jiff's `js` feature if you are targeting a browser environment");
 
+        #[cfg(not(all(
+            not(feature = "js"),
+            any(target_arch = "wasm32", target_arch = "wasm64"),
+            target_os = "unknown"
+        )))]
         Some(std::time::Instant::now())
     }
 }

--- a/src/now.rs
+++ b/src/now.rs
@@ -22,6 +22,17 @@ pub(crate) use self::sys::*;
 )))]
 mod sys {
     pub(crate) fn system_time() -> std::time::SystemTime {
+        // `SystemTime::now()` should continue to panic on this exact target in the future
+        // as well; Instead of letting `std` panic, we panic first with a more informative
+        // error message.
+        #[cfg(all(
+            not(feature = "js"),
+            any(target_arch = "wasm32", target_arch = "wasm64"),
+            target_os = "unknown"
+        ))]
+        panic!("getting the current time in wasm32-unknown-unknown is not possible, \
+                enable jiff's `js` feature if you are targeting a browser environment");
+
         std::time::SystemTime::now()
     }
 
@@ -31,6 +42,15 @@ mod sys {
         feature = "tzdb-concatenated"
     ))]
     pub(crate) fn monotonic_time() -> Option<std::time::Instant> {
+        // See above for rationale behind this panic.
+        #[cfg(all(
+            not(feature = "js"),
+            any(target_arch = "wasm32", target_arch = "wasm64"),
+            target_os = "unknown"
+        ))]
+        panic!("getting the current time in wasm32-unknown-unknown is not possible, \
+                enable jiff's `js` feature if you are targeting a browser environment");
+
         Some(std::time::Instant::now())
     }
 }

--- a/src/now.rs
+++ b/src/now.rs
@@ -50,14 +50,15 @@ mod sys {
         feature = "tzdb-concatenated"
     ))]
     pub(crate) fn monotonic_time() -> Option<std::time::Instant> {
-        // See above for rationale behind this panic.
+        // Same reasoning as above, but we return `None` instead of panicking,
+        // because `jiff` can deal with environments that don't provide
+        // monotonic time.
         #[cfg(all(
             not(feature = "js"),
             any(target_arch = "wasm32", target_arch = "wasm64"),
             target_os = "unknown"
         ))]
-        panic!("getting the current time in wasm32-unknown-unknown is not possible, \
-                enable jiff's `js` feature if you are targeting a browser environment");
+        None
 
         #[cfg(not(all(
             not(feature = "js"),


### PR DESCRIPTION
Suggested here: https://github.com/BurntSushi/jiff/issues/296#issuecomment-2718942045

I quickly put together a hello-world `trunk` project, and called `jiff::Zoned::new()` in it, without the `js` feature enabled.

<details><summary>The resulting panic</summary>

```
panicked at /home/dev/jiff/src/now.rs:30:9:
getting the current time in wasm32-unknown-unknown is not possible, enable jiff's `js` feature if you are targeting a browser environment

Stack:

__wbg_get_imports/imports.wbg.__wbg_new_8a6f238a6ece86ea@http://127.0.0.1:8080/trunk-hello-world-39605882ec2e39d8.js:246:21
trunk_hello_world-a7f87d88668d9124.wasm.__wbg_new_8a6f238a6ece86ea externref shim@http://127.0.0.1:8080/trunk-hello-world-39605882ec2e39d8_bg.wasm:wasm-function[2337]:0xace89
trunk_hello_world-a7f87d88668d9124.wasm.console_error_panic_hook::Error::new::hd7ee4fcdd982d38a@http://127.0.0.1:8080/trunk-hello-world-39605882ec2e39d8_bg.wasm:wasm-function[1604]:0xa261a
trunk_hello_world-a7f87d88668d9124.wasm.console_error_panic_hook::hook_impl::h8821c57ba8c469cf@http://127.0.0.1:8080/trunk-hello-world-39605882ec2e39d8_bg.wasm:wasm-function[384]:0x6b573
trunk_hello_world-a7f87d88668d9124.wasm.console_error_panic_hook::hook::ha79e4afb6a587815@http://127.0.0.1:8080/trunk-hello-world-39605882ec2e39d8_bg.wasm:wasm-function[2127]:0xaae76
trunk_hello_world-a7f87d88668d9124.wasm.core::ops::function::Fn::call::hf0dffdd551dbc510@http://127.0.0.1:8080/trunk-hello-world-39605882ec2e39d8_bg.wasm:wasm-function[1836]:0xa6c59
trunk_hello_world-a7f87d88668d9124.wasm.std::panicking::rust_panic_with_hook::he163a328f096b027@http://127.0.0.1:8080/trunk-hello-world-39605882ec2e39d8_bg.wasm:wasm-function[861]:0x8ac32
trunk_hello_world-a7f87d88668d9124.wasm.std::panicking::begin_panic_handler::{{closure}}::h9b4576c502f796bb@http://127.0.0.1:8080/trunk-hello-world-39605882ec2e39d8_bg.wasm:wasm-function[1039]:0x92541
trunk_hello_world-a7f87d88668d9124.wasm.std::sys::backtrace::__rust_end_short_backtrace::h9dcf082627c76851@http://127.0.0.1:8080/trunk-hello-world-39605882ec2e39d8_bg.wasm:wasm-function[2385]:0xad164
trunk_hello_world-a7f87d88668d9124.wasm.rust_begin_unwind@http://127.0.0.1:8080/trunk-hello-world-39605882ec2e39d8_bg.wasm:wasm-function[2218]:0xac02e
trunk_hello_world-a7f87d88668d9124.wasm.core::panicking::panic_fmt::hf09e831ea9f1651a@http://127.0.0.1:8080/trunk-hello-world-39605882ec2e39d8_bg.wasm:wasm-function[2219]:0xac05a
trunk_hello_world-a7f87d88668d9124.wasm.jiff::now::sys::system_time::h898a41a65599799d@http://127.0.0.1:8080/trunk-hello-world-39605882ec2e39d8_bg.wasm:wasm-function[1683]:0xa405a
trunk_hello_world-a7f87d88668d9124.wasm.jiff::zoned::Zoned::now::hc9862d1e6d3623ca@http://127.0.0.1:8080/trunk-hello-world-39605882ec2e39d8_bg.wasm:wasm-function[1068]:0x9364a
trunk_hello_world-a7f87d88668d9124.wasm.trunk_hello_world::main::h4c62d89c82d63174@http://127.0.0.1:8080/trunk-hello-world-39605882ec2e39d8_bg.wasm:wasm-function[232]:0x57da9
trunk_hello_world-a7f87d88668d9124.wasm.core::ops::function::FnOnce::call_once::h891fbf1087931a90@http://127.0.0.1:8080/trunk-hello-world-39605882ec2e39d8_bg.wasm:wasm-function[2038]:0xa9c5a
trunk_hello_world-a7f87d88668d9124.wasm.std::sys::backtrace::__rust_begin_short_backtrace::h8f5930db5e671fb7@http://127.0.0.1:8080/trunk-hello-world-39605882ec2e39d8_bg.wasm:wasm-function[2036]:0xa9bec
trunk_hello_world-a7f87d88668d9124.wasm.std::rt::lang_start::{{closure}}::hcdc519022ca63bd4@http://127.0.0.1:8080/trunk-hello-world-39605882ec2e39d8_bg.wasm:wasm-function[1292]:0x9aa9a
trunk_hello_world-a7f87d88668d9124.wasm.std::rt::lang_start_internal::hca8730f87f82319d@http://127.0.0.1:8080/trunk-hello-world-39605882ec2e39d8_bg.wasm:wasm-function[944]:0x8e7cf
trunk_hello_world-a7f87d88668d9124.wasm.std::rt::lang_start::he22437a03640fe91@http://127.0.0.1:8080/trunk-hello-world-39605882ec2e39d8_bg.wasm:wasm-function[1158]:0x9683b
trunk_hello_world-a7f87d88668d9124.wasm.main@http://127.0.0.1:8080/trunk-hello-world-39605882ec2e39d8_bg.wasm:wasm-function[2302]:0xacb32
trunk_hello_world-a7f87d88668d9124.wasm.@http://127.0.0.1:8080/trunk-hello-world-39605882ec2e39d8_bg.wasm:wasm-function[2362]:0xad048
trunk_hello_world-a7f87d88668d9124.wasm.@http://127.0.0.1:8080/trunk-hello-world-39605882ec2e39d8_bg.wasm:wasm-function[2391]:0xad19c
__wbg_finalize_init@http://127.0.0.1:8080/trunk-hello-world-39605882ec2e39d8.js:315:10
__wbg_init@http://127.0.0.1:8080/trunk-hello-world-39605882ec2e39d8.js:369:12


trunk-hello-world-39605882ec2e39d8.js:230:21
```

</details>

* Closes https://github.com/BurntSushi/jiff/issues/296 - the issue is about discoverability of the `js` feature, and this PR greatly improves that.