### PR TITLE
doc: clarify the guaranteeds for `Zoned::{since,until}`

### DIFF
--- a/src/civil/datetime.rs
+++ b/src/civil/datetime.rs
@@ -1868,6 +1868,9 @@ impl DateTime {
     /// Depending on the input provided, the span returned is rounded. It may
     /// also be balanced up to bigger units than the default. By default, the
     /// span returned is balanced such that the biggest possible unit is days.
+    /// This default is an API guarantee. Users can rely on the default not
+    /// returning any calendar units bigger than days in the default
+    /// configuration.
     ///
     /// This operation is configured by providing a [`DateTimeDifference`]
     /// value. Since this routine accepts anything that implements
@@ -2647,7 +2650,8 @@ impl core::ops::SubAssign<Span> for DateTime {
 ///
 /// Since this uses the default configuration for calculating a span between
 /// two datetimes (no rounding and largest units is days), this will never
-/// panic or fail in any way.
+/// panic or fail in any way. It is guaranteed that the largest non-zero
+/// unit in the `Span` returned will be days.
 ///
 /// To configure the largest unit or enable rounding, use [`DateTime::since`].
 ///

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -2391,6 +2391,8 @@ impl Zoned {
     /// Depending on the input provided, the span returned is rounded. It may
     /// also be balanced up to bigger units than the default. By default, the
     /// span returned is balanced such that the biggest possible unit is hours.
+    /// This default is an API guarantee. Users can rely on the default not
+    /// returning any calendar units in the default configuration.
     ///
     /// This operation is configured by providing a [`ZonedDifference`]
     /// value. Since this routine accepts anything that implements
@@ -3331,8 +3333,9 @@ impl core::ops::SubAssign<Span> for Zoned {
 /// is greater.
 ///
 /// Since this uses the default configuration for calculating a span between
-/// two zoned datetimes (no rounding and largest units is days), this will
-/// never panic or fail in any way.
+/// two zoned datetimes (no rounding and largest units is hours), this will
+/// never panic or fail in any way. It is guaranteed that the largest non-zero
+/// unit in the `Span` returned will be hours.
 ///
 /// To configure the largest unit or enable rounding, use [`Zoned::since`].
 impl<'a> core::ops::Sub for &'a Zoned {


### PR DESCRIPTION
Specifically, that you can't get any units bigger than hours *by
default*.

We also fix what was probably a copy-and-paste error in the `Sub` trait
implementation docs for `Zoned`. (I probably copied it from
`jiff::civil::DateTime`, where it can return days by default.)

And we apply similar clarifications to the `jiff::civil::DateTime` docs
as well.

Ref https://github.com/microsoft/openvmm/pull/1028#discussion_r1994483092
