### PR TITLE
span: avoid cloning when rounding

### DIFF
--- a/src/span.rs
+++ b/src/span.rs
@@ -6088,9 +6088,8 @@ impl<'a> Relative<'a> {
                 if smallest >= Unit::Day {
                     Nudge::relative_calendar(
                         relspan.span,
-                        // FIXME: Find a way to drop these clones.
-                        &Relative::Zoned(start.clone()),
-                        &Relative::Zoned(end.clone()),
+                        &Relative::Zoned(start.borrowed()),
+                        &Relative::Zoned(end.borrowed()),
                         smallest,
                         increment,
                         mode,
@@ -6363,6 +6362,12 @@ impl<'a> RelativeZoned<'a> {
                 zdt2 = other.zoned,
             )
         })
+    }
+
+    /// Returns the borrowed version of self; useful when you need to convert
+    /// `&RelativeZoned` into `RelativeZoned` without cloning anything.
+    fn borrowed(&self) -> RelativeZoned {
+        RelativeZoned { zoned: self.zoned.borrowed() }
     }
 }
 

--- a/src/util/borrow.rs
+++ b/src/util/borrow.rs
@@ -14,6 +14,15 @@ pub(crate) enum DumbCow<'a, T> {
     Borrowed(&'a T),
 }
 
+impl<'a, T> DumbCow<'a, T> {
+    pub(crate) fn borrowed(&self) -> DumbCow<'_, T> {
+        match *self {
+            DumbCow::Owned(ref this) => DumbCow::Borrowed(this),
+            DumbCow::Borrowed(ref this) => DumbCow::Borrowed(this),
+        }
+    }
+}
+
 impl<'a, T> core::ops::Deref for DumbCow<'a, T> {
     type Target = T;
     fn deref(&self) -> &T {


### PR DESCRIPTION
Quick fix - there's no need to actually clone the underlying dates, since we can simply borrow them.