### PR TITLE
zoned: fix rounding to "days" when near a time zone transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+0.2.6 (TBD)
+===========
+TODO
+
+Bug fixes:
+
+* [#305](https://github.com/BurntSushi/jiff/issues/305):
+Fixed `Zoned` rounding on days with DST time zone transitions.
+
+
 0.2.5 (2025-03-22)
 ==================
 This release updates Jiff's bundled copy of the [IANA Time Zone Database] to

--- a/src/util/round/mode.rs
+++ b/src/util/round/mode.rs
@@ -106,7 +106,8 @@ impl RoundMode {
         rounded
     }
 
-    fn round(
+    /// Rounds `quantity` to the nearest `increment` in units of nanoseconds.
+    pub(crate) fn round(
         self,
         quantity: impl RInto<NoUnits128>,
         increment: impl RInto<NoUnits128>,


### PR DESCRIPTION
Previously, if one were to round `2025-03-09T12:15[America/New_York]`
using the defaults (the half-expand rounding mode), then it would round
up to 2025-03-10. This is despite 2025-03-09 only being 23 hours long,
and thus, the tip-over point for rounding is actually 12:30 and not
12:00. Namely, at 12:00 on 2025-03-09, it had only been 2025-03-09 for
11 hours and not 12 hours.

This sort of rounding requires a special path that wasn't handled
correctly by civil datetime rounding. Interestingly, I had previously
been feeding the day length (which is 23 hours for the aforementioned
example) into civil datetime rounding, but it seems that it wasn't
actually doing anything. So I've ripped that out and special cased
rounding `Zoned` to the nearest day (following Temporal's lead).

I discovered this while writing docs for Biff and noticed that it wasn't
producing the expected result. I double checked with Temporal, and
indeed, it gets this case correct. Now Jiff does as well.

Fixes #305
