### PR TITLE
civil: fix `Date::nth_weekday_of_month`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Fixed `Zoned` rounding on days with DST time zone transitions.
 * [#309](https://github.com/BurntSushi/jiff/issues/309):
 Fixed bug where `TimeZone::preceding` could omit historical time zone
 transitions for time zones that have eliminated DST in the present.
+* [#312](https://github.com/BurntSushi/jiff/issues/312):
+Fixed `nth_weekday_in_month`, where it would sometimes incorrectly return an
+error.
 
 
 0.2.5 (2025-03-22)

--- a/src/civil/date.rs
+++ b/src/civil/date.rs
@@ -901,12 +901,10 @@ impl Date {
         weekday: Weekday,
     ) -> Result<Date, Error> {
         let weekday = weekday.to_iweekday();
-        let idate = self
-            .to_idate()
-            .map(|x| x.nth_weekday_of_month(nth, weekday))
-            .transpose()
-            .map_err(Error::shared)?;
-        Ok(Date::from_idate(idate))
+        let idate = self.to_idate_const();
+        Ok(Date::from_idate_const(
+            idate.nth_weekday_of_month(nth, weekday).map_err(Error::shared)?,
+        ))
     }
 
     /// Returns the "nth" weekday from this date, not including itself.
@@ -4065,5 +4063,14 @@ mod tests {
         let deserialized: Date = serde_yaml::from_reader(cursor).unwrap();
 
         assert_eq!(deserialized, expected);
+    }
+
+    /// Regression test where converting to `IDate` and back to do the
+    /// calculation was FUBAR.
+    #[test]
+    fn nth_weekday_of_month() {
+        let d1 = date(1998, 1, 1);
+        let d2 = d1.nth_weekday_of_month(5, Weekday::Saturday).unwrap();
+        assert_eq!(d2, date(1998, 1, 31));
     }
 }

--- a/src/shared/util/itime.rs
+++ b/src/shared/util/itime.rs
@@ -813,6 +813,11 @@ mod tests {
         let wday = IWeekday::from_sunday_zero_offset(1);
         assert!(d1.nth_weekday_of_month(5, wday).is_err());
         assert!(d1.nth_weekday_of_month(-5, wday).is_err());
+
+        let d1 = IDate { year: 1998, month: 1, day: 1 };
+        let wday = IWeekday::from_sunday_zero_offset(6);
+        let d2 = d1.nth_weekday_of_month(5, wday).unwrap();
+        assert_eq!(d2, IDate { year: 1998, month: 1, day: 31 });
     }
 
     #[test]

--- a/src/util/rangeint.rs
+++ b/src/util/rangeint.rs
@@ -2439,34 +2439,6 @@ impl<T, U> Composite<(T, U)> {
     }
 }
 
-impl<T, E> Composite<Result<T, E>> {
-    #[inline]
-    pub(crate) fn transpose(self) -> Result<Composite<T>, E> {
-        #[cfg(not(debug_assertions))]
-        {
-            Ok(Composite { val: self.val? })
-        }
-        #[cfg(debug_assertions)]
-        {
-            Ok(Composite { val: self.val?, min: self.min?, max: self.max? })
-        }
-    }
-}
-
-impl<T> Composite<Option<T>> {
-    #[inline]
-    pub(crate) fn transpose(self) -> Option<Composite<T>> {
-        #[cfg(not(debug_assertions))]
-        {
-            Some(Composite { val: self.val? })
-        }
-        #[cfg(debug_assertions)]
-        {
-            Some(Composite { val: self.val?, min: self.min?, max: self.max? })
-        }
-    }
-}
-
 impl Composite<i8> {
     pub(crate) const fn to_rint<const MIN: i128, const MAX: i128>(
         self,


### PR DESCRIPTION
This also removes the error prone `transpose` functions I had added to
the bridge between the internal non-ranged datetime types and the ranged
datetime types.

Fixes #312
