### PR TITLE
tz: add `/usr/share/lib/zoneinfo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 ===========
 TODO
 
+Enhancements:
+
+* [#315](https://github.com/BurntSushi/jiff/issues/315):
+Add support for automatically finding the tzdb on Illumos.
+
 Bug fixes:
 
 * [#305](https://github.com/BurntSushi/jiff/issues/305):

--- a/src/tz/db/zoneinfo/enabled.rs
+++ b/src/tz/db/zoneinfo/enabled.rs
@@ -22,7 +22,7 @@ use crate::{
 const DEFAULT_TTL: Duration = Duration::new(5 * 60, 0);
 
 static ZONEINFO_DIRECTORIES: &[&str] =
-    &["/usr/share/zoneinfo", "/etc/zoneinfo"];
+    &["/usr/share/zoneinfo", "/usr/share/lib/zoneinfo", "/etc/zoneinfo"];
 
 pub(crate) struct Database {
     dir: Option<PathBuf>,


### PR DESCRIPTION
Apparently Illumos uses a different directory than most other Unix
systems in active use. So add it to the list of directories to scan.

I've been unable to verify this since I don't know how to run in an
Illumos environment, but hopefully this should work.

Fixes #315
