### PR TITLE
cargo: restore sanity to iterative development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,16 +346,26 @@ jobs:
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: stable
-    - name: Build sqlx-postgres example
-      run: cargo build --manifest-path ./examples/sqlx-postgres/Cargo.toml
-    - name: Run sqlx-sqlite example
-      run: cargo run --manifest-path ./examples/sqlx-sqlite/Cargo.toml
-    - name: Build diesel-mysql example
-      run: cargo build --manifest-path ./examples/diesel-mysql/Cargo.toml
-    - name: Build diesel-postgres example
-      run: cargo build --manifest-path ./examples/diesel-postgres/Cargo.toml
-    - name: Run diesel-sqlite example
-      run: cargo build --manifest-path ./examples/diesel-sqlite/Cargo.toml
+    - name: Build all examples
+      run: ./scripts/test-examples
+
+  # This job builds and runs tests for Jiff's "integration" crates. That is,
+  # the crates that provide wrappers or traits for integrating with other
+  # crates in the ecosystem. For example, `jiff-diesel`.
+  #
+  # These are outside the workspace because their dependency graphs are
+  # absolutely ludicrous.
+  integrations:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+    - name: Build all examples
+      run: ./scripts/test-integrations
 
   # Generic testing for most cross targets. Some get special treatment in
   # other jobs.

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
-/Cargo.lock
-/examples/**/Cargo.lock
-/target
-/examples/**/target
 /tmp
+Cargo.lock
+target
 /ecma-test262
 /BREADCRUMBS
 # Criterion seems to vomit this out to CWD. wat.

--- a/.vim/coc-settings.json
+++ b/.vim/coc-settings.json
@@ -1,11 +1,15 @@
 {
   "rust-analyzer.linkedProjects": [
     "bench/Cargo.toml",
+    "crates/jiff-diesel/Cargo.toml",
+    "crates/jiff-icu/Cargo.toml",
+    "crates/jiff-sqlx/Cargo.toml",
     "examples/diesel-mysql/Cargo.toml",
     "examples/diesel-postgres/Cargo.toml",
     "examples/diesel-sqlite/Cargo.toml",
     "examples/sqlx-postgres/Cargo.toml",
     "examples/sqlx-sqlite/Cargo.toml",
+    "examples/uptime/Cargo.toml",
     "Cargo.toml"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -609,7 +609,7 @@ support. Here are some examples:
 To quickly demonstrate this new feature, here's a simple CLI program using
 Clap:
 
-```rust,no_run
+```ignore
 use clap::Parser;
 use jiff::{Span, Zoned};
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,7 +223,6 @@ portable-atomic-util = { version = "0.2.4", default-features = false }
 anyhow = "1.0.81"
 chrono = { version = "0.4.38", features = ["serde"] }
 chrono-tz = "0.10.0"
-clap = { version = "4.5.23", features = ["derive"] }
 humantime = "2.1.0"
 insta = "1.39.0"
 # We force `serde` to be enabled in dev mode so that the docs render and test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,20 +31,9 @@ include = [
 [workspace]
 members = [
   "crates/jiff-cli",
-  "crates/jiff-diesel",
-  "crates/jiff-icu",
-  "crates/jiff-sqlx",
   "crates/jiff-static",
   "crates/jiff-tzdb",
   "crates/jiff-tzdb-platform",
-  "examples/*",
-]
-exclude = [
-  "examples/diesel-mysql",
-  "examples/diesel-postgres",
-  "examples/diesel-sqlite",
-  "examples/sqlx-postgres",
-  "examples/sqlx-sqlite",
 ]
 
 # Features are documented in the "Crate features" section of the crate docs:
@@ -236,17 +225,10 @@ chrono = { version = "0.4.38", features = ["serde"] }
 chrono-tz = "0.10.0"
 clap = { version = "4.5.23", features = ["derive"] }
 humantime = "2.1.0"
-# This adds approximately 50 new compilation units when running `cargo test`
-# locally on Unix. Blech.
-icu = { version = "1.5.0", features = ["std"] }
 insta = "1.39.0"
 # We force `serde` to be enabled in dev mode so that the docs render and test
 # correctly. We also enable `static` so that we can test our proc macros.
 jiff = { path = "./", default-features = false, features = ["serde", "static"] }
-# Uncomment if you want to remove `ignore` from `jiff_icu` tests in
-# `COMPARE.md`. Otherwise, this creates a circular dependency and causes
-# `jiff-icu` to get re-compiled all the time.
-# jiff-icu = { path = "./crates/jiff-icu" }
 quickcheck = { version = "1.0.3", default-features = false }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
@@ -255,6 +237,12 @@ tabwriter = "1.4.0"
 time = { version = "0.3.36", features = ["local-offset", "macros", "parsing"] }
 tzfile = "0.1.3"
 walkdir = "2.5.0"
+
+# Uncomment if you want to activate doc tests that import from `jiff_icu`
+# (currently only in `COMPARE.md`). Otherwise, this creates a circular
+# dependency and causes `jiff-icu` to get re-compiled all the time.
+# icu = { version = "1.5.0", features = ["std"] }
+# jiff-icu = { path = "./crates/jiff-icu" }
 
 # hifitime doesn't build on wasm for some reason, so exclude it there.
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies.hifitime]

--- a/crates/jiff-diesel/Cargo.toml
+++ b/crates/jiff-diesel/Cargo.toml
@@ -9,10 +9,17 @@ documentation = "https://docs.rs/jiff-diesel"
 description = "Integration for Jiff with Diesel."
 categories = ["date-and-time"]
 keywords = ["date", "time", "jiff", "diesel", "zone"]
-workspace = "../.."
 edition = "2021"
 rust-version = "1.70"
 include = ["/src/*.rs", "COPYING", "LICENSE-MIT", "UNLICENSE"]
+
+# Integration crates in Jiff are explicitly isolated from the workspace to
+# avoid dependencies accumulating. I was originally motivated to do this
+# because rustc kept getting stun-locked compiling diesel. And this was somehow
+# happening every time I saved a file inside of Jiff proper. So I just ragequit
+# including everything in the same workspace and put integration crates (and
+# examples) into their own little bloated fiefdoms.
+[workspace]
 
 [lib]
 name = "jiff_diesel"

--- a/crates/jiff-icu/Cargo.toml
+++ b/crates/jiff-icu/Cargo.toml
@@ -9,10 +9,17 @@ documentation = "https://docs.rs/jiff-icu"
 description = "Conversion routines between Jiff and ICU4X."
 categories = ["date-and-time"]
 keywords = ["date", "time", "temporal", "zone", "icu"]
-workspace = "../.."
 edition = "2021"
 rust-version = "1.70"
 include = ["/src/*.rs", "/*.dat", "COPYING", "LICENSE-MIT", "UNLICENSE"]
+
+# Integration crates in Jiff are explicitly isolated from the workspace to
+# avoid dependencies accumulating. I was originally motivated to do this
+# because rustc kept getting stun-locked compiling diesel. And this was somehow
+# happening every time I saved a file inside of Jiff proper. So I just ragequit
+# including everything in the same workspace and put integration crates (and
+# examples) into their own little bloated fiefdoms.
+[workspace]
 
 [lib]
 name = "jiff_icu"

--- a/crates/jiff-sqlx/Cargo.toml
+++ b/crates/jiff-sqlx/Cargo.toml
@@ -9,10 +9,17 @@ documentation = "https://docs.rs/jiff-sqlx"
 description = "Integration for Jiff with SQLx."
 categories = ["date-and-time"]
 keywords = ["date", "time", "jiff", "sqlx", "zone"]
-workspace = "../.."
 edition = "2021"
 rust-version = "1.70"
 include = ["/src/*.rs", "/*.dat", "COPYING", "LICENSE-MIT", "UNLICENSE"]
+
+# Integration crates in Jiff are explicitly isolated from the workspace to
+# avoid dependencies accumulating. I was originally motivated to do this
+# because rustc kept getting stun-locked compiling diesel. And this was somehow
+# happening every time I saved a file inside of Jiff proper. So I just ragequit
+# including everything in the same workspace and put integration crates (and
+# examples) into their own little bloated fiefdoms.
+[workspace]
 
 [lib]
 name = "jiff_sqlx"

--- a/examples/diesel-mysql/Cargo.toml
+++ b/examples/diesel-mysql/Cargo.toml
@@ -4,9 +4,9 @@ name = "diesel-mysql-test"
 version = "0.0.1"
 edition = "2021"
 
-# This example has very fat dependencies. And running it requires a PostgreSQL
-# dataabase connection. This makes it so this example won't get compiled or run
-# with `cargo test --all`.
+# Examples in Jiff are explicitly isolated from the workspace to avoid
+# dev-dependencies accumulating. (Not all examples have big dependency trees,
+# but we still exclude them from the workspace as a general rule.)
 [workspace]
 
 [dependencies]

--- a/examples/diesel-postgres/Cargo.toml
+++ b/examples/diesel-postgres/Cargo.toml
@@ -4,9 +4,9 @@ name = "diesel-postgres-test"
 version = "0.0.1"
 edition = "2021"
 
-# This example has very fat dependencies. And running it requires a PostgreSQL
-# dataabase connection. This makes it so this example won't get compiled or run
-# with `cargo test --all`.
+# Examples in Jiff are explicitly isolated from the workspace to avoid
+# dev-dependencies accumulating. (Not all examples have big dependency trees,
+# but we still exclude them from the workspace as a general rule.)
 [workspace]
 
 [dependencies]

--- a/examples/diesel-sqlite/Cargo.toml
+++ b/examples/diesel-sqlite/Cargo.toml
@@ -4,8 +4,9 @@ name = "diesel-sqlite-test"
 version = "0.0.1"
 edition = "2021"
 
-# This example has very fat dependencies. This makes it so this example won't
-# get compiled or run with `cargo test --all`.
+# Examples in Jiff are explicitly isolated from the workspace to avoid
+# dev-dependencies accumulating. (Not all examples have big dependency trees,
+# but we still exclude them from the workspace as a general rule.)
 [workspace]
 
 [dependencies]

--- a/examples/sqlx-postgres/Cargo.toml
+++ b/examples/sqlx-postgres/Cargo.toml
@@ -4,9 +4,9 @@ name = "sqlx-postgres-test"
 version = "0.0.1"
 edition = "2021"
 
-# This example has very fat dependencies. And running it requires a PostgreSQL
-# dataabase connection. This makes it so this example won't get compiled or run
-# with `cargo test --all`.
+# Examples in Jiff are explicitly isolated from the workspace to avoid
+# dev-dependencies accumulating. (Not all examples have big dependency trees,
+# but we still exclude them from the workspace as a general rule.)
 [workspace]
 
 [dependencies]

--- a/examples/sqlx-sqlite/Cargo.toml
+++ b/examples/sqlx-sqlite/Cargo.toml
@@ -4,9 +4,9 @@ name = "sqlx-sqlite-test"
 version = "0.0.1"
 edition = "2021"
 
-# This example has very fat dependencies. And running it requires a PostgreSQL
-# dataabase connection. This makes it so this example won't get compiled or run
-# with `cargo test --all`.
+# Examples in Jiff are explicitly isolated from the workspace to avoid
+# dev-dependencies accumulating. (Not all examples have big dependency trees,
+# but we still exclude them from the workspace as a general rule.)
 [workspace]
 
 [dependencies]

--- a/examples/uptime/Cargo.toml
+++ b/examples/uptime/Cargo.toml
@@ -4,6 +4,11 @@ name = "uptime"
 version = "0.1.0"
 edition = "2021"
 
+# Examples in Jiff are explicitly isolated from the workspace to avoid
+# dev-dependencies accumulating. (Not all examples have big dependency trees,
+# but we still exclude them from the workspace as a general rule.)
+[workspace]
+
 [dependencies]
 anyhow = "1.0.86"
 jiff = { path = "../.." }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,3 @@
+edition = "2021"
 max_width = 79
 use_small_heuristics = "max"

--- a/scripts/test-examples
+++ b/scripts/test-examples
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# This script tests that every example builds.
+#
+# This isn't done as part of, e.g., `cargo build --all`, because we split the
+# examples out of the main workspace to keep dependency trees smaller.
+
+set -e
+
+# cd to the directory containing this crate's Cargo.toml so that we don't need
+# to pass --manifest-path to every `cargo` command.
+cd "$(dirname "$0")/.."
+
+for d in ./examples/*; do
+  echo "===== BUILDING EXAMPLE: $d ====="
+  cargo build --manifest-path "$d/Cargo.toml"
+done

--- a/scripts/test-integrations
+++ b/scripts/test-integrations
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# This script tests "integration" crates explicitly.
+#
+# This isn't done as part of, e.g., `cargo build --all`, because we split these
+# specific crates out of the main workspace to keep dependency trees smaller.
+
+set -e
+
+# cd to the directory containing this crate's Cargo.toml so that we don't need
+# to pass --manifest-path to every `cargo` command.
+cd "$(dirname "$0")/.."
+
+integrations=(
+  "jiff-diesel mysql"
+  "jiff-diesel postgres"
+  "jiff-icu std"
+  "jiff-sqlx postgres"
+  # This is just utter nonsense, but
+  # sqlx-sqlite does not compile in it
+  # default feature configuration. This
+  # is utterly asinine. And it's completely
+  # undocumented. I had to go trawling through
+  # the top-level sqlx Cargo.toml to figure
+  # out which feature to enable.
+  "jiff-sqlx sqlite,sqlx-sqlite/bundled"
+)
+for v in "${integrations[@]}"; do
+  crate="$(echo $v | awk '{print $1}')"
+  feature="$(echo $v | awk '{print $2}')"
+  echo "===== TESTING INTEGRATION CRATE: $crate[$feature] ====="
+  cargo test \
+    --no-default-features \
+    --features "$feature" \
+    --manifest-path "crates/$crate/Cargo.toml"
+done
+
+# Same as above, but with `--lib` only. This is useful when we don't expect
+# doctests to pass for certain feature combinations.
+integrations=(
+  "jiff-icu alloc"
+)
+for v in "${integrations[@]}"; do
+  crate="$(echo $v | awk '{print $1}')"
+  feature="$(echo $v | awk '{print $2}')"
+  echo "===== TESTING INTEGRATION CRATE (--lib only): $crate[$feature] ====="
+  cargo test \
+    --lib \
+    --no-default-features \
+    --features "$feature" \
+    --manifest-path "crates/$crate/Cargo.toml"
+done


### PR DESCRIPTION
I'm not sure when or how exactly it happened, but in the last weeks,
I've noticed that `rustc` gets effectively stun-locked whenever I make a
change to a source file in Jiff. A quick examination of what the fuck my
computer is doing seems to reveal that it's spending oodles of time
compiling diesel over and over.

I have no idea why this is happening and I don't really care to spend
the time unraveling the mysteries of diesel.

So I took a hammer to the problem. I have effectively shunted all
examples and all "integration" crates out of Jiff's core workspace and
into their own little bloated fiefdoms. To compensate for the fact that
`cargo test --all` no longer tests these things, I've added shell
scripts to run the requisite tests. And those shell scripts are now run
in CI.

I'm now back to a state where I can save a file in Jiff and I get
sub-second `cargo check` response times.
