### PR TITLE
Use UTC timezone then TZ env var is empty

### DIFF
--- a/src/tz/system/mod.rs
+++ b/src/tz/system/mod.rs
@@ -175,7 +175,9 @@ fn get_env_tz(db: &TimeZoneDatabase) -> Result<Option<TimeZone>, Error> {
 
     let Some(tzenv) = std::env::var_os("TZ") else { return Ok(None) };
     if tzenv.is_empty() {
-        // It is commonly agreed (but not standard) that setting an empty `TZ=` uses UTC.
+        // It is commonly agreed (across GNU and BSD tooling at least),
+        // but not standard, that setting an empty `TZ=` is indistinguishable
+        // from `TZ=UTC`.
         return Ok(Some(TimeZone::UTC));
     }
     let tz_name_or_path = match PosixTzEnv::parse_os_str(&tzenv) {

--- a/src/tz/system/mod.rs
+++ b/src/tz/system/mod.rs
@@ -175,7 +175,8 @@ fn get_env_tz(db: &TimeZoneDatabase) -> Result<Option<TimeZone>, Error> {
 
     let Some(tzenv) = std::env::var_os("TZ") else { return Ok(None) };
     if tzenv.is_empty() {
-        return Ok(None);
+        // It is commonly agreed (but not standard) that setting an empty `TZ=` uses UTC.
+        return Ok(Some(TimeZone::UTC));
     }
     let tz_name_or_path = match PosixTzEnv::parse_os_str(&tzenv) {
         Err(_err) => {


### PR DESCRIPTION
This PR makes an empty `TZ` environment variable act like `TZ=UTC`. Should there be a unit test for this?

Fixes #311