### PR TITLE
rustc: slightly improve compile times and add `perf-inline` crate feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -559,21 +559,21 @@ jobs:
       run: |
         jiff-cli generate shared
         if ! git diff --exit-code; then
-          echo 'Please run `jiff-cli generated shared`'
+          echo 'Please run `jiff-cli generate shared`'
           exit 1
         fi
     - name: Generate crc32 code
       run: |
         jiff-cli generate crc32
         if ! git diff --exit-code; then
-          echo 'Please run `jiff-cli generated crc32`'
+          echo 'Please run `jiff-cli generate crc32`'
           exit 1
         fi
     - name: Generate unit designator match expression
       run: |
         jiff-cli generate unit-designator-match
         if ! git diff --exit-code; then
-          echo 'Please run `jiff-cli generated unit-designator-match`'
+          echo 'Please run `jiff-cli generate unit-designator-match`'
           exit 1
         fi
     - name: Generate mapping from Windows zones to IANA time zone identifiers
@@ -583,6 +583,13 @@ jobs:
         if ! git diff --exit-code; then
           echo 'In a separate PR, please download windowsZones.xml'
           echo 'from github.com/unicode-org/cldr and run'
-          echo '`jiff-cli generated windows-zones`'
+          echo '`jiff-cli generate windows-zones`'
+          exit 1
+        fi
+    - name: Generate shared code used in both `jiff` and `jiff-static`
+      run: |
+        jiff-cli generate shared
+        if ! git diff --exit-code; then
+          echo 'Please run `jiff-cli generate shared`'
           exit 1
         fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # CHANGELOG
 
+0.2.7 (TBD)
+===========
+TODO
+
+Enhancements:
+
+* [#xxx](https://github.com/BurntSushi/jiff/pull/xxx):
+Remove some internal uses of generics to mildly improve compile times.
+* [#xxx](https://github.com/BurntSushi/jiff/pull/xxx):
+Add `perf-literal` crate feature for controlling `inline(always)` annotations.
+
+Bug fixes:
+
+* [#311](https://github.com/BurntSushi/jiff/issues/311):
+Make `TZ=` indistinguishable from `TZ=UTC`.
+
+
 0.2.6 (2025-04-07)
 ==================
 This release includes a few bug fixes and support for discovering the IANA Time

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ default = [
   "tzdb-bundle-platform",
   "tzdb-zoneinfo",
   "tzdb-concatenated",
+  "perf-inline",
 ]
 std = ["alloc", "log?/std", "serde?/std"]
 alloc = ["serde?/alloc", "portable-atomic-util/alloc"]
@@ -170,6 +171,11 @@ tzdb-concatenated = ["std"]
 #
 # (This is the same dependency setup that the `getrandom` crate uses.)
 js = ["dep:wasm-bindgen", "dep:js-sys"]
+
+# When enabled, more aggressive inline annotations are used. This can
+# improve performance in some cases, particularly around the areas of parsing
+# and formatting.
+perf-inline = []
 
 [dependencies]
 jiff-static = { version = "0.2", path = "crates/jiff-static", optional = true }

--- a/crates/jiff-cli/cmd/generate/shared.rs
+++ b/crates/jiff-cli/cmd/generate/shared.rs
@@ -40,7 +40,7 @@ pub fn run(p: &mut Parser) -> anyhow::Result<()> {
 
     let jiff = config.jiff();
     let jiff_dir = jiff.join("src");
-    let macro_dir = jiff.join("crates/jiff-static");
+    let macro_dir = jiff.join("crates/jiff-static/src");
     let dir = Path::new("shared");
     copy(&jiff_dir, &macro_dir, dir)?;
 

--- a/crates/jiff-static/src/shared/mod.rs
+++ b/crates/jiff-static/src/shared/mod.rs
@@ -354,7 +354,6 @@ pub enum TzifTransitionKind {
 /// extremely cheap. This is especially useful since we do a binary search on
 /// `&[TzifDateTime]` when doing a TZ lookup for a civil datetime.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-#[repr(align(8))]
 pub struct TzifDateTime {
     bits: i64,
 }

--- a/crates/jiff-static/src/shared/posix.rs
+++ b/crates/jiff-static/src/shared/posix.rs
@@ -23,8 +23,7 @@ impl PosixTimeZone<Abbreviation> {
         // `0..=24`.) Requiring strict POSIX rules doesn't seem necessary
         // since the extension is a strict superset. Plus, GNU tooling
         // seems to accept the extension.
-        let parser =
-            Parser { ianav3plus: true, ..Parser::new(bytes.as_ref()) };
+        let parser = Parser { ianav3plus: true, ..Parser::new(bytes) };
         parser.parse()
     }
 }

--- a/src/civil/date.rs
+++ b/src/civil/date.rs
@@ -2167,12 +2167,12 @@ impl Date {
         (end - start).rinto()
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) fn to_unix_epoch_day(self) -> UnixEpochDay {
         self.to_idate().map(|x| x.to_epoch_day().epoch_day).to_rint()
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) fn from_unix_epoch_day(epoch_day: UnixEpochDay) -> Date {
         let epoch_day = rangeint::composite!((epoch_day) => {
             IEpochDay { epoch_day }

--- a/src/civil/datetime.rs
+++ b/src/civil/datetime.rs
@@ -3261,7 +3261,7 @@ impl DateTimeDifference {
                 t::SpanNanoseconds::rfrom(t::NANOS_PER_CIVIL_DAY) * sign;
         }
         let date_span = d1.until((largest, d2))?;
-        Ok(Span::from_invariant_nanoseconds(largest, time_diff)
+        Ok(Span::from_invariant_nanoseconds(largest, time_diff.rinto())
             // Unlike in the <=Unit::Day case, this always succeeds because
             // every unit except for nanoseconds (which is not used here) can
             // represent all possible spans of time between any two civil

--- a/src/civil/iso_week_date.rs
+++ b/src/civil/iso_week_date.rs
@@ -834,7 +834,7 @@ impl quickcheck::Arbitrary for ISOWeekDate {
 /// with 52 weeks.
 fn is_long_year(year: ISOYear) -> bool {
     // Inspired by: https://en.wikipedia.org/wiki/ISO_week_date#Weeks_per_year
-    let last = Date::new_ranged(year, C(12), C(31))
+    let last = Date::new_ranged(year.rinto(), C(12).rinto(), C(31).rinto())
         .expect("last day of year is always valid");
     let weekday = last.weekday();
     weekday == Weekday::Thursday

--- a/src/civil/time.rs
+++ b/src/civil/time.rs
@@ -1775,7 +1775,7 @@ impl Time {
     /// Converts the given second to a time value. The second should correspond
     /// to the number of seconds that have elapsed since `00:00:00`. The
     /// fractional second component of the `Time` returned is always `0`.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) fn from_second(second: CivilDaySecond) -> Time {
         let second = rangeint::composite!((second) => {
             ITimeSecond { second }
@@ -1796,7 +1796,7 @@ impl Time {
     /// Converts the given nanosecond to a time value. The nanosecond should
     /// correspond to the number of nanoseconds that have elapsed since
     /// `00:00:00.000000000`.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) fn from_nanosecond(nanosecond: CivilDayNanosecond) -> Time {
         let nano = rangeint::composite!((nanosecond) => {
             ITimeNanosecond { nanosecond }

--- a/src/civil/time.rs
+++ b/src/civil/time.rs
@@ -2590,8 +2590,9 @@ impl TimeDifference {
         }
         let start = t1.to_nanosecond();
         let end = t2.to_nanosecond();
-        let span = Span::from_invariant_nanoseconds(largest, end - start)
-            .expect("difference in civil times is always in bounds");
+        let span =
+            Span::from_invariant_nanoseconds(largest, (end - start).rinto())
+                .expect("difference in civil times is always in bounds");
         Ok(span)
     }
 }

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -18,7 +18,7 @@ impl Duration {
     ///
     /// This returns an error only in the case where this is an unsigned
     /// duration with a number of whole seconds that exceeds `|i64::MIN|`.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) fn to_signed(self) -> Result<SDuration, Error> {
         match self {
             Duration::Span(span) => Ok(SDuration::Span(span)),
@@ -55,7 +55,7 @@ impl Duration {
     /// be different, the actual end result is the same (failure).
     ///
     /// TODO: Write unit tests for this.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) fn checked_neg(self) -> Result<Duration, Error> {
         match self {
             Duration::Span(span) => Ok(Duration::Span(span.negate())),
@@ -101,7 +101,7 @@ impl Duration {
     }
 
     /// Returns true if and only if this duration is negative.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) fn is_negative(&self) -> bool {
         match *self {
             Duration::Span(ref span) => span.is_negative(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -561,7 +561,7 @@ pub(crate) trait ErrorContext {
 }
 
 impl ErrorContext for Error {
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn context(self, consequent: impl IntoError) -> Error {
         #[cfg(feature = "alloc")]
         {
@@ -586,7 +586,7 @@ impl ErrorContext for Error {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn with_context<E: IntoError>(
         self,
         consequent: impl FnOnce() -> E,
@@ -616,12 +616,12 @@ impl ErrorContext for Error {
 }
 
 impl<T> ErrorContext for Result<T, Error> {
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn context(self, consequent: impl IntoError) -> Result<T, Error> {
         self.map_err(|err| err.context(consequent))
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn with_context<E: IntoError>(
         self,
         consequent: impl FnOnce() -> E,

--- a/src/fmt/friendly/parser.rs
+++ b/src/fmt/friendly/parser.rs
@@ -255,7 +255,7 @@ impl SpanParser {
         Ok(sdur)
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_to_span<'i>(
         &self,
         input: &'i [u8],
@@ -296,7 +296,7 @@ impl SpanParser {
         Ok(Parsed { value: span * i64::from(sign.get()), input })
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_to_duration<'i>(
         &self,
         input: &'i [u8],
@@ -341,7 +341,7 @@ impl SpanParser {
         Ok(Parsed { value: sdur, input })
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_units_to_span<'i>(
         &self,
         mut input: &'i [u8],
@@ -456,7 +456,7 @@ impl SpanParser {
         Ok(Parsed { value: span, input })
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_units_to_duration<'i>(
         &self,
         mut input: &'i [u8],
@@ -607,7 +607,7 @@ impl SpanParser {
     /// This expects that a unit value has been parsed and looks for a `:`
     /// at `input[0]`. If `:` is found, then this proceeds to parse HMS.
     /// Otherwise, a `None` value is returned.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_hms_maybe<'i>(
         &self,
         input: &'i [u8],
@@ -675,7 +675,7 @@ impl SpanParser {
     ///
     /// Note that this is safe to call on untrusted input. It will not attempt
     /// to consume more input than could possibly fit into a parsed integer.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_unit_value<'i>(
         &self,
         mut input: &'i [u8],
@@ -741,7 +741,7 @@ impl SpanParser {
     /// empty, then this return an error.
     ///
     /// This does not attempt to handle leading or trailing whitespace.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_unit_designator<'i>(
         &self,
         input: &'i [u8],
@@ -864,7 +864,7 @@ impl SpanParser {
     }
 
     /// Parses zero or more bytes of ASCII whitespace.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_optional_whitespace<'i>(
         &self,
         mut input: &'i [u8],
@@ -889,7 +889,7 @@ struct HMS {
 ///
 /// If the value outside the legal boundaries for the given unit, then an error
 /// is returned.
-#[inline(always)]
+#[cfg_attr(feature = "perf-inline", inline(always))]
 fn set_span_unit_value(
     unit: Unit,
     value: t::NoUnits,
@@ -934,7 +934,7 @@ fn set_span_unit_value(
 /// If the given unit is not supported for signed durations (i.e., calendar
 /// units), or if converting the given value to a `SignedDuration` for the
 /// given units overflows, then an error is returned.
-#[inline(always)]
+#[cfg_attr(feature = "perf-inline", inline(always))]
 fn duration_unit_value(
     unit: Unit,
     value: t::NoUnits,
@@ -978,7 +978,7 @@ fn duration_unit_value(
 }
 
 /// Returns true if the byte is ASCII whitespace.
-#[inline(always)]
+#[cfg_attr(feature = "perf-inline", inline(always))]
 fn is_whitespace(byte: &u8) -> bool {
     matches!(*byte, b' ' | b'\t' | b'\n' | b'\r' | b'\x0C')
 }

--- a/src/fmt/offset.rs
+++ b/src/fmt/offset.rs
@@ -395,7 +395,7 @@ impl Parser {
     ///
     /// Basically, if `input` is empty, or is not one of `z`, `Z`, `+` or `-`
     /// then this returns `None`.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) fn parse_optional<'i>(
         &self,
         input: &'i [u8],
@@ -414,7 +414,7 @@ impl Parser {
     ///
     /// The beginning of the input is expected to start with a `+` or a `-`.
     /// Any other case (including an empty string) will result in an error.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_numeric<'i>(
         &self,
         input: &'i [u8],
@@ -531,7 +531,7 @@ impl Parser {
         Ok(Parsed { value: numeric, input })
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_sign<'i>(
         &self,
         input: &'i [u8],
@@ -553,7 +553,7 @@ impl Parser {
         Ok(Parsed { value: sign, input: &input[1..] })
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_hours<'i>(
         &self,
         input: &'i [u8],
@@ -577,7 +577,7 @@ impl Parser {
         Ok(Parsed { value: hours, input })
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_minutes<'i>(
         &self,
         input: &'i [u8],
@@ -599,7 +599,7 @@ impl Parser {
         Ok(Parsed { value: minutes, input })
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_seconds<'i>(
         &self,
         input: &'i [u8],
@@ -631,7 +631,7 @@ impl Parser {
     ///
     /// When in basic mode (not extended), then a subsequent component is only
     /// expected when `input` begins with two ASCII digits.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_separator<'i>(
         &self,
         mut input: &'i [u8],

--- a/src/fmt/rfc2822.rs
+++ b/src/fmt/rfc2822.rs
@@ -360,7 +360,7 @@ impl DateTimeParser {
     ///
     /// Note that this doesn't check that the input has been completely
     /// consumed.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_zoned_internal<'i>(
         &self,
         input: &'i [u8],
@@ -378,7 +378,7 @@ impl DateTimeParser {
     ///
     /// Note that this doesn't check that the input has been completely
     /// consumed.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_timestamp_internal<'i>(
         &self,
         input: &'i [u8],
@@ -395,7 +395,7 @@ impl DateTimeParser {
     /// datetime and its offset.
     ///
     /// This also consumes any trailing (superfluous) whitespace.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_datetime_offset<'i>(
         &self,
         input: &'i [u8],
@@ -419,7 +419,7 @@ impl DateTimeParser {
     /// one whitespace character.
     ///
     /// This basically parses everything except for the zone.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_datetime<'i>(
         &self,
         input: &'i [u8],
@@ -491,7 +491,7 @@ impl DateTimeParser {
     ///
     /// If a weekday is parsed, then this also skips any trailing whitespace
     /// (and requires at least one whitespace character).
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_weekday<'i>(
         &self,
         input: &'i [u8],
@@ -563,7 +563,7 @@ impl DateTimeParser {
     ///
     /// This also parses at least one mandatory whitespace character after the
     /// day.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_day<'i>(
         &self,
         input: &'i [u8],
@@ -594,7 +594,7 @@ impl DateTimeParser {
     ///
     /// This also parses at least one mandatory whitespace character after the
     /// month name.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_month<'i>(
         &self,
         input: &'i [u8],
@@ -663,7 +663,7 @@ impl DateTimeParser {
     /// > ending up with a value between 2000 and 2049. If a two digit year is
     /// > encountered with a value between 50 and 99, or any three digit year
     /// > is encountered, the year is interpreted by adding 1900.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_year<'i>(
         &self,
         input: &'i [u8],
@@ -708,7 +708,7 @@ impl DateTimeParser {
     ///
     /// This parses a mandatory trailing `:`, advancing the input to
     /// immediately after it.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_hour<'i>(
         &self,
         input: &'i [u8],
@@ -729,7 +729,7 @@ impl DateTimeParser {
 
     /// Parses a 2-digit minute. This assumes the input begins with what should
     /// be an ASCII digit. (i.e., It doesn't trim leading whitespace.)
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_minute<'i>(
         &self,
         input: &'i [u8],
@@ -750,7 +750,7 @@ impl DateTimeParser {
 
     /// Parses a 2-digit second. This assumes the input begins with what should
     /// be an ASCII digit. (i.e., It doesn't trim leading whitespace.)
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_second<'i>(
         &self,
         input: &'i [u8],
@@ -776,7 +776,7 @@ impl DateTimeParser {
     ///
     /// This assumes the offset must begin at the beginning of `input`. That
     /// is, any leading whitespace should already have been trimmed.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_offset<'i>(
         &self,
         input: &'i [u8],
@@ -913,7 +913,7 @@ impl DateTimeParser {
 
     /// Parses a time separator. This returns an error if one couldn't be
     /// found.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_time_separator<'i>(
         &self,
         input: &'i [u8],
@@ -934,7 +934,7 @@ impl DateTimeParser {
 
     /// Parses at least one whitespace character. If no whitespace was found,
     /// then this returns an error.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_whitespace<'i>(
         &self,
         input: &'i [u8],
@@ -954,7 +954,7 @@ impl DateTimeParser {
     /// Skips over any ASCII whitespace at the beginning of `input`.
     ///
     /// This returns the input unchanged if it does not begin with whitespace.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn skip_whitespace<'i>(&self, mut input: &'i [u8]) -> Parsed<'i, ()> {
         while input.first().map_or(false, |&b| is_whitespace(b)) {
             input = &input[1..];

--- a/src/fmt/strtime/mod.rs
+++ b/src/fmt/strtime/mod.rs
@@ -2661,7 +2661,7 @@ impl Extension {
     /// Parses an optional directive flag from the beginning of `fmt`. This
     /// assumes `fmt` is not empty and guarantees that the return unconsumed
     /// slice is also non-empty.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_flag<'i>(
         fmt: &'i [u8],
     ) -> Result<(Option<Flag>, &'i [u8]), Error> {
@@ -2694,7 +2694,7 @@ impl Extension {
     /// and `%.f`. In the former case, the width is just re-interpreted as
     /// a precision setting. In the latter case, something like `%5.9f` is
     /// technically valid, but the `5` is ignored.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_width<'i>(
         fmt: &'i [u8],
     ) -> Result<(Option<u8>, &'i [u8]), Error> {

--- a/src/fmt/strtime/mod.rs
+++ b/src/fmt/strtime/mod.rs
@@ -270,6 +270,7 @@ use crate::{
         self,
         array_str::Abbreviation,
         escape,
+        rangeint::RInto,
         t::{self, C},
     },
     Error, Timestamp, Zoned,
@@ -1083,7 +1084,8 @@ impl BrokenDownTime {
     ) -> Result<Option<Date>, Error> {
         let Some(doy) = self.day_of_year else { return Ok(None) };
         Ok(Some({
-            let first = Date::new_ranged(year, C(1), C(1)).unwrap();
+            let first =
+                Date::new_ranged(year, C(1).rinto(), C(1).rinto()).unwrap();
             first
                 .with()
                 .day_of_year(doy.get())
@@ -1114,8 +1116,8 @@ impl BrokenDownTime {
         };
         let week = i16::from(week);
         let wday = i16::from(weekday.to_sunday_zero_offset());
-        let first_of_year =
-            Date::new_ranged(year, C(1), C(1)).context("invalid date")?;
+        let first_of_year = Date::new_ranged(year, C(1).rinto(), C(1).rinto())
+            .context("invalid date")?;
         let first_sunday = first_of_year
             .nth_weekday_of_month(1, Weekday::Sunday)
             .map(|d| d.day_of_year())
@@ -1162,8 +1164,8 @@ impl BrokenDownTime {
         };
         let week = i16::from(week);
         let wday = i16::from(weekday.to_monday_zero_offset());
-        let first_of_year =
-            Date::new_ranged(year, C(1), C(1)).context("invalid date")?;
+        let first_of_year = Date::new_ranged(year, C(1).rinto(), C(1).rinto())
+            .context("invalid date")?;
         let first_monday = first_of_year
             .nth_weekday_of_month(1, Weekday::Monday)
             .map(|d| d.day_of_year())

--- a/src/fmt/strtime/parse.rs
+++ b/src/fmt/strtime/parse.rs
@@ -995,7 +995,7 @@ impl Extension {
     ///
     /// The remaining input is returned. This returns an error if the given
     /// input is empty.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_number<'i>(
         self,
         default_pad_width: usize,
@@ -1052,7 +1052,7 @@ impl Extension {
 /// found, then the sign returned is positive.
 ///
 /// This also returns the remaining unparsed input.
-#[inline(always)]
+#[cfg_attr(feature = "perf-inline", inline(always))]
 fn parse_optional_sign<'i>(input: &'i [u8]) -> (i64, &'i [u8]) {
     if input.is_empty() {
         (1, input)
@@ -1069,7 +1069,7 @@ fn parse_optional_sign<'i>(input: &'i [u8]) -> (i64, &'i [u8]) {
 /// found, then the sign returned is positive.
 ///
 /// This also returns the remaining unparsed input.
-#[inline(always)]
+#[cfg_attr(feature = "perf-inline", inline(always))]
 fn parse_required_sign<'i>(
     input: &'i [u8],
 ) -> Result<(t::Sign, &'i [u8]), Error> {
@@ -1133,7 +1133,7 @@ fn parse_choice<'i>(
 ///
 /// This exists because AM/PM is common and we can take advantage of the fact
 /// that they are both exactly two bytes.
-#[inline(always)]
+#[cfg_attr(feature = "perf-inline", inline(always))]
 fn parse_ampm<'i>(input: &'i [u8]) -> Result<(usize, &'i [u8]), Error> {
     if input.len() < 2 {
         return Err(err!(
@@ -1163,7 +1163,7 @@ fn parse_ampm<'i>(input: &'i [u8]) -> Result<(usize, &'i [u8]), Error> {
 ///
 /// This exists because weekday abbreviations are common and we can take
 /// advantage of the fact that they are all exactly three bytes.
-#[inline(always)]
+#[cfg_attr(feature = "perf-inline", inline(always))]
 fn parse_weekday_abbrev<'i>(
     input: &'i [u8],
 ) -> Result<(usize, &'i [u8]), Error> {
@@ -1204,7 +1204,7 @@ fn parse_weekday_abbrev<'i>(
 ///
 /// This exists because month name abbreviations are common and we can take
 /// advantage of the fact that they are all exactly three bytes.
-#[inline(always)]
+#[cfg_attr(feature = "perf-inline", inline(always))]
 fn parse_month_name_abbrev<'i>(
     input: &'i [u8],
 ) -> Result<(usize, &'i [u8]), Error> {
@@ -1246,7 +1246,7 @@ fn parse_month_name_abbrev<'i>(
     Ok((index, input))
 }
 
-#[inline(always)]
+#[cfg_attr(feature = "perf-inline", inline(always))]
 fn parse_iana<'i>(input: &'i [u8]) -> Result<(&'i str, &'i [u8]), Error> {
     let mkiana = parse::slicer(input);
     let (_, mut input) = parse_iana_component(input)?;
@@ -1266,7 +1266,7 @@ fn parse_iana<'i>(input: &'i [u8]) -> Result<(&'i str, &'i [u8]), Error> {
 /// Parses a single IANA name component. That is, the thing that leads all IANA
 /// time zone identifiers and the thing that must always come after a `/`. This
 /// returns an error if no component could be found.
-#[inline(always)]
+#[cfg_attr(feature = "perf-inline", inline(always))]
 fn parse_iana_component<'i>(
     mut input: &'i [u8],
 ) -> Result<(&'i [u8], &'i [u8]), Error> {

--- a/src/fmt/temporal/parser.rs
+++ b/src/fmt/temporal/parser.rs
@@ -42,7 +42,7 @@ pub(super) struct ParsedDateTime<'i> {
 }
 
 impl<'i> ParsedDateTime<'i> {
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(super) fn to_pieces(&self) -> Result<Pieces<'i>, Error> {
         let mut pieces = Pieces::from(self.date.date);
         if let Some(ref time) = self.time {
@@ -57,7 +57,7 @@ impl<'i> ParsedDateTime<'i> {
         Ok(pieces)
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(super) fn to_zoned(
         &self,
         db: &TimeZoneDatabase,
@@ -68,7 +68,7 @@ impl<'i> ParsedDateTime<'i> {
             .disambiguate(disambiguation)
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(super) fn to_ambiguous_zoned(
         &self,
         db: &TimeZoneDatabase,
@@ -134,7 +134,7 @@ impl<'i> ParsedDateTime<'i> {
         )
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(super) fn to_timestamp(&self) -> Result<Timestamp, Error> {
         let time = self.time.as_ref().map(|p| p.time).ok_or_else(|| {
             err!(
@@ -161,7 +161,7 @@ impl<'i> ParsedDateTime<'i> {
         Ok(timestamp)
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(super) fn to_datetime(&self) -> Result<DateTime, Error> {
         if self.offset.as_ref().map_or(false, |o| o.is_zulu()) {
             return Err(err!(
@@ -173,7 +173,7 @@ impl<'i> ParsedDateTime<'i> {
         Ok(DateTime::from_parts(self.date.date, self.time()))
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(super) fn to_date(&self) -> Result<Date, Error> {
         if self.offset.as_ref().map_or(false, |o| o.is_zulu()) {
             return Err(err!(
@@ -185,7 +185,7 @@ impl<'i> ParsedDateTime<'i> {
         Ok(self.date.date)
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn time(&self) -> Time {
         self.time.as_ref().map(|p| p.time).unwrap_or(Time::midnight())
     }
@@ -315,7 +315,7 @@ impl DateTimeParser {
     // DateTime :::
     //   Date
     //   Date DateTimeSeparator TimeSpec DateTimeUTCOffset[opt]
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(super) fn parse_temporal_datetime<'i>(
         &self,
         input: &'i [u8],
@@ -373,7 +373,7 @@ impl DateTimeParser {
     //
     // TimeDesignator ::: one of
     //   T t
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(super) fn parse_temporal_time<'i>(
         &self,
         mut input: &'i [u8],
@@ -463,7 +463,7 @@ impl DateTimeParser {
         Ok(Parsed { value: time, input })
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(super) fn parse_time_zone<'i>(
         &self,
         mut input: &'i [u8],
@@ -554,7 +554,7 @@ impl DateTimeParser {
     // Date :::
     //   DateYear - DateMonth - DateDay
     //   DateYear DateMonth DateDay
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_date_spec<'i>(
         &self,
         input: &'i [u8],
@@ -604,7 +604,7 @@ impl DateTimeParser {
     //   TimeHour TimeMinute
     //   TimeHour : TimeMinute : TimeSecond TimeFraction[opt]
     //   TimeHour TimeMinute TimeSecond TimeFraction[opt]
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_time_spec<'i>(
         &self,
         input: &'i [u8],
@@ -698,7 +698,7 @@ impl DateTimeParser {
     //
     // NOTE: Jiff doesn't have a "month-day" type, but we still have a parsing
     // function for it so that we can detect ambiguous time strings.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_month_day<'i>(
         &self,
         input: &'i [u8],
@@ -741,7 +741,7 @@ impl DateTimeParser {
     //
     // NOTE: Jiff doesn't have a "year-month" type, but we still have a parsing
     // function for it so that we can detect ambiguous time strings.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_year_month<'i>(
         &self,
         input: &'i [u8],
@@ -787,7 +787,7 @@ impl DateTimeParser {
     // sticking with the Temporal spec. But I may loosen this in the future. We
     // should be careful not to introduce any possible ambiguities, though, I
     // don't think there are any?
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_year<'i>(
         &self,
         input: &'i [u8],
@@ -839,7 +839,7 @@ impl DateTimeParser {
     //   10
     //   11
     //   12
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_month<'i>(
         &self,
         input: &'i [u8],
@@ -864,7 +864,7 @@ impl DateTimeParser {
     //   2 DecimalDigit
     //   30
     //   31
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_day<'i>(
         &self,
         input: &'i [u8],
@@ -892,7 +892,7 @@ impl DateTimeParser {
     //   21
     //   22
     //   23
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_hour<'i>(
         &self,
         input: &'i [u8],
@@ -921,7 +921,7 @@ impl DateTimeParser {
     //   3 DecimalDigit
     //   4 DecimalDigit
     //   5 DecimalDigit
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_minute<'i>(
         &self,
         input: &'i [u8],
@@ -951,7 +951,7 @@ impl DateTimeParser {
     //   3 DecimalDigit
     //   4 DecimalDigit
     //   5 DecimalDigit
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_second<'i>(
         &self,
         input: &'i [u8],
@@ -975,7 +975,7 @@ impl DateTimeParser {
         Ok(Parsed { value: second, input })
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_offset<'i>(
         &self,
         input: &'i [u8],
@@ -985,7 +985,7 @@ impl DateTimeParser {
         P.parse_optional(input)
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_annotations<'i>(
         &self,
         input: &'i [u8],
@@ -1003,7 +1003,7 @@ impl DateTimeParser {
     ///
     /// When in extended mode, a `-` is expected. When not in extended mode,
     /// no input is consumed and this routine never fails.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_date_separator<'i>(
         &self,
         mut input: &'i [u8],
@@ -1045,7 +1045,7 @@ impl DateTimeParser {
     ///
     /// When in basic mode (not extended), then a subsequent component is only
     /// expected when `input` begins with two ASCII digits.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_time_separator<'i>(
         &self,
         mut input: &'i [u8],
@@ -1075,7 +1075,7 @@ impl DateTimeParser {
     // require it?[1]
     //
     // [1]: https://github.com/tc39/proposal-temporal/issues/2843
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_year_sign<'i>(
         &self,
         mut input: &'i [u8],
@@ -1110,7 +1110,7 @@ impl SpanParser {
         SpanParser { _priv: () }
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(super) fn parse_temporal_duration<'i>(
         &self,
         input: &'i [u8],
@@ -1121,7 +1121,7 @@ impl SpanParser {
         )
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(super) fn parse_signed_duration<'i>(
         &self,
         input: &'i [u8],
@@ -1132,7 +1132,7 @@ impl SpanParser {
         )
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_span<'i>(
         &self,
         input: &'i [u8],
@@ -1169,7 +1169,7 @@ impl SpanParser {
         Ok(Parsed { value: span, input })
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_duration<'i>(
         &self,
         input: &'i [u8],
@@ -1196,7 +1196,7 @@ impl SpanParser {
     /// If 1 or more units were found, then `true` is also returned. Otherwise,
     /// `false` indicates that no units were parsed. (Which the caller may want
     /// to treat as an error.)
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_date_units<'i>(
         &self,
         mut input: &'i [u8],
@@ -1243,7 +1243,7 @@ impl SpanParser {
     /// If 1 or more units were found, then `true` is also returned. Otherwise,
     /// `false` indicates that no units were parsed. (Which the caller may want
     /// to treat as an error.)
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_time_units<'i>(
         &self,
         mut input: &'i [u8],
@@ -1321,7 +1321,7 @@ impl SpanParser {
     /// a Jiff signed duration.
     ///
     /// If no time units are found, then this returns an error.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_time_units_duration<'i>(
         &self,
         mut input: &'i [u8],
@@ -1432,7 +1432,7 @@ impl SpanParser {
         Ok(Parsed { value: dur, input })
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_unit_value<'i>(
         &self,
         mut input: &'i [u8],
@@ -1461,7 +1461,7 @@ impl SpanParser {
         Ok(Parsed { value: Some(value), input })
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_unit_date_designator<'i>(
         &self,
         input: &'i [u8],
@@ -1488,7 +1488,7 @@ impl SpanParser {
         Ok(Parsed { value: unit, input: &input[1..] })
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_unit_time_designator<'i>(
         &self,
         input: &'i [u8],
@@ -1516,7 +1516,7 @@ impl SpanParser {
 
     // DurationDesignator ::: one of
     //   P p
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_duration_designator<'i>(
         &self,
         input: &'i [u8],
@@ -1539,7 +1539,7 @@ impl SpanParser {
 
     // TimeDesignator ::: one of
     //   T t
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_time_designator<'i>(&self, input: &'i [u8]) -> Parsed<'i, bool> {
         if input.is_empty() || !matches!(input[0], b'T' | b't') {
             return Parsed { value: false, input };
@@ -1553,7 +1553,7 @@ impl SpanParser {
     //
     // NOTE: Like with other things with signs, we don't support the Unicode
     // <MINUS> sign. Just ASCII.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_sign<'i>(&self, input: &'i [u8]) -> Parsed<'i, t::Sign> {
         let Some(sign) = input.get(0).copied() else {
             return Parsed { value: t::Sign::N::<1>(), input };

--- a/src/fmt/util.rs
+++ b/src/fmt/util.rs
@@ -318,7 +318,7 @@ impl Fractional {
 /// misnomer, but the range of possible values is still correct. (That is, the
 /// fractional component of an hour is still limited to 9 decimal places per
 /// the Temporal spec.)
-#[inline(always)]
+#[cfg_attr(feature = "perf-inline", inline(always))]
 pub(crate) fn parse_temporal_fraction<'i>(
     input: &'i [u8],
 ) -> Result<Parsed<'i, Option<t::SubsecNanosecond>>, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -675,6 +675,15 @@ For more, see the [`fmt::serde`] sub-module. (This requires enabling Jiff's
   This takes a TZif file path, like `/usr/share/zoneinfo/Israel`, as input and
   returns a `TimeZone` value at compile time.
 
+### Performance features
+
+* **perf-inline** (enabled by default) -
+  When enabled, a number of `inline(always)` annotations are used inside of
+  Jiff to improve performance. This can especially impact formatting and
+  parsing of datetimes. If the extra performance isn't needed or if you want
+  to prioritize smaller binary sizes and shorter compilation times over
+  runtime performance, then it can be useful to disable this feature.
+
 [`jiff-static`]: https://docs.rs/jiff-static
 [`jiff-tzdb`]: https://docs.rs/jiff-tzdb
 [Concatenated Time Zone Database]: https://android.googlesource.com/platform/libcore/+/jb-mr2-release/luni/src/main/java/libcore/util/ZoneInfoDB.java

--- a/src/shared/util/itime.rs
+++ b/src/shared/util/itime.rs
@@ -46,7 +46,7 @@ impl ITimestamp {
     ///
     /// The offset should correspond to the number of seconds required to
     /// add to this timestamp to get the local time.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) const fn to_datetime(&self, offset: IOffset) -> IDateTime {
         let ITimestamp { mut second, mut nanosecond } = *self;
         second += offset.second as i64;
@@ -93,7 +93,7 @@ impl IDateTime {
     ///
     /// The offset should correspond to the number of seconds required to
     /// subtract from this datetime in order to get to UTC.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) fn to_timestamp(&self, offset: IOffset) -> ITimestamp {
         let epoch_day = self.date.to_epoch_day().epoch_day;
         let mut second = (epoch_day as i64) * 86_400
@@ -114,7 +114,7 @@ impl IDateTime {
     ///
     /// The offset should correspond to the number of seconds required to
     /// subtract from this datetime in order to get to UTC.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) fn to_timestamp_checked(
         &self,
         offset: IOffset,
@@ -126,7 +126,7 @@ impl IDateTime {
         Some(ts)
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) fn saturating_add_seconds(&self, seconds: i32) -> IDateTime {
         self.checked_add_seconds(seconds).unwrap_or_else(|_| {
             if seconds < 0 {
@@ -137,7 +137,7 @@ impl IDateTime {
         })
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) fn checked_add_seconds(
         &self,
         seconds: i32,
@@ -168,7 +168,7 @@ impl IEpochDay {
     /// This is Neri-Schneider. There's no branching or divisions.
     ///
     /// Ref: <https://github.com/cassioneri/eaf/blob/684d3cc32d14eee371d0abe4f683d6d6a49ed5c1/algorithms/neri_schneider.hpp#L40C3-L40C34>
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     #[allow(non_upper_case_globals, non_snake_case)] // to mimic source
     pub(crate) const fn to_date(&self) -> IDate {
         const s: u32 = 82;
@@ -200,7 +200,7 @@ impl IEpochDay {
     }
 
     /// Returns the day of the week for this epoch day.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) const fn weekday(&self) -> IWeekday {
         // Based on Hinnant's approach here, although we use ISO weekday
         // numbering by default. Basically, this works by using the knowledge
@@ -346,7 +346,7 @@ impl IDate {
     /// This is Neri-Schneider. There's no branching or divisions.
     ///
     /// Ref: https://github.com/cassioneri/eaf/blob/684d3cc32d14eee371d0abe4f683d6d6a49ed5c1/algorithms/neri_schneider.hpp#L83
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     #[allow(non_upper_case_globals, non_snake_case)] // to mimic source
     pub(crate) const fn to_epoch_day(&self) -> IEpochDay {
         const s: u32 = 82;
@@ -562,7 +562,7 @@ impl ITime {
         subsec_nanosecond: 999_999_999,
     };
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) const fn to_second(&self) -> ITimeSecond {
         let mut second: i32 = 0;
         second += (self.hour as i32) * 3600;
@@ -571,7 +571,7 @@ impl ITime {
         ITimeSecond { second }
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) const fn to_nanosecond(&self) -> ITimeNanosecond {
         let mut nanosecond: i64 = 0;
         nanosecond += (self.hour as i64) * 3_600_000_000_000;
@@ -589,7 +589,7 @@ pub(crate) struct ITimeSecond {
 }
 
 impl ITimeSecond {
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) const fn to_time(&self) -> ITime {
         let mut second = self.second;
         let mut time = ITime::ZERO;
@@ -612,7 +612,7 @@ pub(crate) struct ITimeNanosecond {
 }
 
 impl ITimeNanosecond {
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) const fn to_time(&self) -> ITime {
         let mut nanosecond = self.nanosecond;
         let mut time = ITime::ZERO;

--- a/src/signed_duration.rs
+++ b/src/signed_duration.rs
@@ -2490,7 +2490,7 @@ impl From<(Unit, i64)> for SignedDurationRound {
 /// in order to ensure good error messages.
 ///
 /// (We do the same thing for `Span`.)
-#[inline(always)]
+#[cfg_attr(feature = "perf-inline", inline(always))]
 fn parse_iso_or_friendly(bytes: &[u8]) -> Result<SignedDuration, Error> {
     if bytes.is_empty() {
         return Err(err!(

--- a/src/span.rs
+++ b/src/span.rs
@@ -2977,7 +2977,7 @@ impl Span {
 
     /// Returns an equivalent span, but with all non-calendar (units below
     /// days) set to zero.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) fn only_calendar(self) -> Span {
         let mut span = self;
         span.hours = t::SpanHours::N::<0>();
@@ -3000,7 +3000,7 @@ impl Span {
 
     /// Returns an equivalent span, but with all calendar (units above
     /// hours) set to zero.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) fn only_time(self) -> Span {
         let mut span = self;
         span.years = t::SpanYears::N::<0>();
@@ -3023,7 +3023,7 @@ impl Span {
 
     /// Returns an equivalent span, but with all units greater than or equal to
     /// the one given set to zero.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) fn only_lower(self, unit: Unit) -> Span {
         let mut span = self;
         // Unit::Nanosecond is the minimum, so nothing can be smaller than it.
@@ -3059,7 +3059,7 @@ impl Span {
 
     /// Returns an equivalent span, but with all units less than the one given
     /// set to zero.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) fn without_lower(self, unit: Unit) -> Span {
         let mut span = self;
         if unit > Unit::Nanosecond {
@@ -3096,7 +3096,7 @@ impl Span {
     /// Returns an error corresponding to the smallest non-time non-zero unit.
     ///
     /// If all non-time units are zero, then this returns `None`.
-    #[inline(always)]
+    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) fn smallest_non_time_non_zero_unit_error(
         &self,
     ) -> Option<Error> {
@@ -6691,7 +6691,7 @@ fn clamp_relative_span(
 /// in order to ensure good error messages.
 ///
 /// (We do the same thing for `SignedDuration`.)
-#[inline(always)]
+#[cfg_attr(feature = "perf-inline", inline(always))]
 fn parse_iso_or_friendly(bytes: &[u8]) -> Result<Span, Error> {
     if bytes.is_empty() {
         return Err(err!(

--- a/src/span.rs
+++ b/src/span.rs
@@ -918,7 +918,7 @@ impl Span {
     pub fn try_months<I: Into<i64>>(self, months: I) -> Result<Span, Error> {
         type Range = ri64<{ t::SpanMonths::MIN }, { t::SpanMonths::MAX }>;
         let months = Range::try_new("months", months)?;
-        Ok(self.months_ranged(months))
+        Ok(self.months_ranged(months.rinto()))
     }
 
     /// Set the number of weeks on this span. The value may be negative.
@@ -934,7 +934,7 @@ impl Span {
     pub fn try_weeks<I: Into<i64>>(self, weeks: I) -> Result<Span, Error> {
         type Range = ri64<{ t::SpanWeeks::MIN }, { t::SpanWeeks::MAX }>;
         let weeks = Range::try_new("weeks", weeks)?;
-        Ok(self.weeks_ranged(weeks))
+        Ok(self.weeks_ranged(weeks.rinto()))
     }
 
     /// Set the number of days on this span. The value may be negative.
@@ -950,7 +950,7 @@ impl Span {
     pub fn try_days<I: Into<i64>>(self, days: I) -> Result<Span, Error> {
         type Range = ri64<{ t::SpanDays::MIN }, { t::SpanDays::MAX }>;
         let days = Range::try_new("days", days)?;
-        Ok(self.days_ranged(days))
+        Ok(self.days_ranged(days.rinto()))
     }
 
     /// Set the number of hours on this span. The value may be negative.
@@ -966,7 +966,7 @@ impl Span {
     pub fn try_hours<I: Into<i64>>(self, hours: I) -> Result<Span, Error> {
         type Range = ri64<{ t::SpanHours::MIN }, { t::SpanHours::MAX }>;
         let hours = Range::try_new("hours", hours)?;
-        Ok(self.hours_ranged(hours))
+        Ok(self.hours_ranged(hours.rinto()))
     }
 
     /// Set the number of minutes on this span. The value may be negative.
@@ -2482,8 +2482,7 @@ impl Span {
 /// Crate internal APIs that operate on ranged integer types.
 impl Span {
     #[inline]
-    pub(crate) fn years_ranged(self, years: impl RInto<t::SpanYears>) -> Span {
-        let years = years.rinto();
+    pub(crate) fn years_ranged(self, years: t::SpanYears) -> Span {
         let mut span = Span { years: years.abs(), ..self };
         span.sign = self.resign(years, &span);
         span.units = span.units.set(Unit::Year, years == C(0));
@@ -2491,11 +2490,7 @@ impl Span {
     }
 
     #[inline]
-    pub(crate) fn months_ranged(
-        self,
-        months: impl RInto<t::SpanMonths>,
-    ) -> Span {
-        let months = months.rinto();
+    pub(crate) fn months_ranged(self, months: t::SpanMonths) -> Span {
         let mut span = Span { months: months.abs(), ..self };
         span.sign = self.resign(months, &span);
         span.units = span.units.set(Unit::Month, months == C(0));
@@ -2503,8 +2498,7 @@ impl Span {
     }
 
     #[inline]
-    pub(crate) fn weeks_ranged(self, weeks: impl RInto<t::SpanWeeks>) -> Span {
-        let weeks = weeks.rinto();
+    pub(crate) fn weeks_ranged(self, weeks: t::SpanWeeks) -> Span {
         let mut span = Span { weeks: weeks.abs(), ..self };
         span.sign = self.resign(weeks, &span);
         span.units = span.units.set(Unit::Week, weeks == C(0));
@@ -2512,8 +2506,7 @@ impl Span {
     }
 
     #[inline]
-    pub(crate) fn days_ranged(self, days: impl RInto<t::SpanDays>) -> Span {
-        let days = days.rinto();
+    pub(crate) fn days_ranged(self, days: t::SpanDays) -> Span {
         let mut span = Span { days: days.abs(), ..self };
         span.sign = self.resign(days, &span);
         span.units = span.units.set(Unit::Day, days == C(0));
@@ -2521,8 +2514,7 @@ impl Span {
     }
 
     #[inline]
-    pub(crate) fn hours_ranged(self, hours: impl RInto<t::SpanHours>) -> Span {
-        let hours = hours.rinto();
+    pub(crate) fn hours_ranged(self, hours: t::SpanHours) -> Span {
         let mut span = Span { hours: hours.abs(), ..self };
         span.sign = self.resign(hours, &span);
         span.units = span.units.set(Unit::Hour, hours == C(0));
@@ -2530,11 +2522,7 @@ impl Span {
     }
 
     #[inline]
-    pub(crate) fn minutes_ranged(
-        self,
-        minutes: impl RInto<t::SpanMinutes>,
-    ) -> Span {
-        let minutes = minutes.rinto();
+    pub(crate) fn minutes_ranged(self, minutes: t::SpanMinutes) -> Span {
         let mut span = Span { minutes: minutes.abs(), ..self };
         span.sign = self.resign(minutes, &span);
         span.units = span.units.set(Unit::Minute, minutes == C(0));
@@ -2542,11 +2530,7 @@ impl Span {
     }
 
     #[inline]
-    pub(crate) fn seconds_ranged(
-        self,
-        seconds: impl RInto<t::SpanSeconds>,
-    ) -> Span {
-        let seconds = seconds.rinto();
+    pub(crate) fn seconds_ranged(self, seconds: t::SpanSeconds) -> Span {
         let mut span = Span { seconds: seconds.abs(), ..self };
         span.sign = self.resign(seconds, &span);
         span.units = span.units.set(Unit::Second, seconds == C(0));
@@ -2554,11 +2538,7 @@ impl Span {
     }
 
     #[inline]
-    fn milliseconds_ranged(
-        self,
-        milliseconds: impl RInto<t::SpanMilliseconds>,
-    ) -> Span {
-        let milliseconds = milliseconds.rinto();
+    fn milliseconds_ranged(self, milliseconds: t::SpanMilliseconds) -> Span {
         let mut span = Span { milliseconds: milliseconds.abs(), ..self };
         span.sign = self.resign(milliseconds, &span);
         span.units = span.units.set(Unit::Millisecond, milliseconds == C(0));
@@ -2566,11 +2546,7 @@ impl Span {
     }
 
     #[inline]
-    fn microseconds_ranged(
-        self,
-        microseconds: impl RInto<t::SpanMicroseconds>,
-    ) -> Span {
-        let microseconds = microseconds.rinto();
+    fn microseconds_ranged(self, microseconds: t::SpanMicroseconds) -> Span {
         let mut span = Span { microseconds: microseconds.abs(), ..self };
         span.sign = self.resign(microseconds, &span);
         span.units = span.units.set(Unit::Microsecond, microseconds == C(0));
@@ -2580,40 +2556,12 @@ impl Span {
     #[inline]
     pub(crate) fn nanoseconds_ranged(
         self,
-        nanoseconds: impl RInto<t::SpanNanoseconds>,
+        nanoseconds: t::SpanNanoseconds,
     ) -> Span {
-        let nanoseconds = nanoseconds.rinto();
         let mut span = Span { nanoseconds: nanoseconds.abs(), ..self };
         span.sign = self.resign(nanoseconds, &span);
         span.units = span.units.set(Unit::Nanosecond, nanoseconds == C(0));
         span
-    }
-
-    #[inline]
-    fn try_years_ranged(
-        self,
-        years: impl TryRInto<t::SpanYears>,
-    ) -> Result<Span, Error> {
-        let years = years.try_rinto("years")?;
-        Ok(self.years_ranged(years))
-    }
-
-    #[inline]
-    fn try_months_ranged(
-        self,
-        months: impl TryRInto<t::SpanMonths>,
-    ) -> Result<Span, Error> {
-        let months = months.try_rinto("months")?;
-        Ok(self.months_ranged(months))
-    }
-
-    #[inline]
-    fn try_weeks_ranged(
-        self,
-        weeks: impl TryRInto<t::SpanWeeks>,
-    ) -> Result<Span, Error> {
-        let weeks = weeks.try_rinto("weeks")?;
-        Ok(self.weeks_ranged(weeks))
     }
 
     #[inline]
@@ -2683,21 +2631,26 @@ impl Span {
     pub(crate) fn try_units_ranged(
         self,
         unit: Unit,
-        value: impl RInto<NoUnits>,
+        value: NoUnits,
     ) -> Result<Span, Error> {
-        let value = value.rinto();
-        match unit {
-            Unit::Year => self.try_years_ranged(value),
-            Unit::Month => self.try_months_ranged(value),
-            Unit::Week => self.try_weeks_ranged(value),
-            Unit::Day => self.try_days_ranged(value),
-            Unit::Hour => self.try_hours_ranged(value),
-            Unit::Minute => self.try_minutes_ranged(value),
-            Unit::Second => self.try_seconds_ranged(value),
-            Unit::Millisecond => self.try_milliseconds_ranged(value),
-            Unit::Microsecond => self.try_microseconds_ranged(value),
-            Unit::Nanosecond => self.try_nanoseconds_ranged(value),
-        }
+        Ok(match unit {
+            Unit::Year => self.years_ranged(value.try_rinto("years")?),
+            Unit::Month => self.months_ranged(value.try_rinto("months")?),
+            Unit::Week => self.weeks_ranged(value.try_rinto("weeks")?),
+            Unit::Day => self.days_ranged(value.try_rinto("days")?),
+            Unit::Hour => self.hours_ranged(value.try_rinto("hours")?),
+            Unit::Minute => self.minutes_ranged(value.try_rinto("minutes")?),
+            Unit::Second => self.seconds_ranged(value.try_rinto("seconds")?),
+            Unit::Millisecond => {
+                self.milliseconds_ranged(value.try_rinto("milliseconds")?)
+            }
+            Unit::Microsecond => {
+                self.microseconds_ranged(value.try_rinto("microseconds")?)
+            }
+            Unit::Nanosecond => {
+                self.nanoseconds_ranged(value.try_rinto("nanoseconds")?)
+            }
+        })
     }
 
     #[inline]
@@ -2788,9 +2741,8 @@ impl Span {
     /// `largest` unit bigger than `Unit::Hour`.
     pub(crate) fn from_invariant_nanoseconds(
         largest: Unit,
-        nanos: impl RInto<NoUnits128>,
+        nanos: NoUnits128,
     ) -> Result<Span, Error> {
-        let nanos = nanos.rinto();
         let mut span = Span::new();
         match largest {
             Unit::Week => {
@@ -2820,7 +2772,7 @@ impl Span {
                 let weeks = days.div_ceil(t::DAYS_PER_CIVIL_WEEK);
                 span = span
                     .try_days_ranged(days.rem_ceil(t::DAYS_PER_CIVIL_WEEK))?;
-                span = span.try_weeks_ranged(weeks)?;
+                span = span.weeks_ranged(weeks.try_rinto("weeks")?);
                 Ok(span)
             }
             Unit::Year | Unit::Month | Unit::Day => {
@@ -3076,31 +3028,31 @@ impl Span {
         let mut span = self;
         // Unit::Nanosecond is the minimum, so nothing can be smaller than it.
         if unit <= Unit::Microsecond {
-            span = span.microseconds_ranged(C(0));
+            span = span.microseconds_ranged(C(0).rinto());
         }
         if unit <= Unit::Millisecond {
-            span = span.milliseconds_ranged(C(0));
+            span = span.milliseconds_ranged(C(0).rinto());
         }
         if unit <= Unit::Second {
-            span = span.seconds_ranged(C(0));
+            span = span.seconds_ranged(C(0).rinto());
         }
         if unit <= Unit::Minute {
-            span = span.minutes_ranged(C(0));
+            span = span.minutes_ranged(C(0).rinto());
         }
         if unit <= Unit::Hour {
-            span = span.hours_ranged(C(0));
+            span = span.hours_ranged(C(0).rinto());
         }
         if unit <= Unit::Day {
-            span = span.days_ranged(C(0));
+            span = span.days_ranged(C(0).rinto());
         }
         if unit <= Unit::Week {
-            span = span.weeks_ranged(C(0));
+            span = span.weeks_ranged(C(0).rinto());
         }
         if unit <= Unit::Month {
-            span = span.months_ranged(C(0));
+            span = span.months_ranged(C(0).rinto());
         }
         if unit <= Unit::Year {
-            span = span.years_ranged(C(0));
+            span = span.years_ranged(C(0).rinto());
         }
         span
     }
@@ -3111,31 +3063,31 @@ impl Span {
     pub(crate) fn without_lower(self, unit: Unit) -> Span {
         let mut span = self;
         if unit > Unit::Nanosecond {
-            span = span.nanoseconds_ranged(C(0));
+            span = span.nanoseconds_ranged(C(0).rinto());
         }
         if unit > Unit::Microsecond {
-            span = span.microseconds_ranged(C(0));
+            span = span.microseconds_ranged(C(0).rinto());
         }
         if unit > Unit::Millisecond {
-            span = span.milliseconds_ranged(C(0));
+            span = span.milliseconds_ranged(C(0).rinto());
         }
         if unit > Unit::Second {
-            span = span.seconds_ranged(C(0));
+            span = span.seconds_ranged(C(0).rinto());
         }
         if unit > Unit::Minute {
-            span = span.minutes_ranged(C(0));
+            span = span.minutes_ranged(C(0).rinto());
         }
         if unit > Unit::Hour {
-            span = span.hours_ranged(C(0));
+            span = span.hours_ranged(C(0).rinto());
         }
         if unit > Unit::Day {
-            span = span.days_ranged(C(0));
+            span = span.days_ranged(C(0).rinto());
         }
         if unit > Unit::Week {
-            span = span.weeks_ranged(C(0));
+            span = span.weeks_ranged(C(0).rinto());
         }
         if unit > Unit::Month {
-            span = span.months_ranged(C(0));
+            span = span.months_ranged(C(0).rinto());
         }
         // Unit::Year is the max, so nothing can be bigger than it.
         span
@@ -3231,35 +3183,37 @@ impl Span {
     /// new units, this determines the what the sign of `new` should be.
     #[inline]
     fn resign(&self, units: impl RInto<NoUnits>, new: &Span) -> Sign {
-        let units = units.rinto();
-        // Negative units anywhere always makes the entire span negative.
-        if units < C(0) {
-            return Sign::N::<-1>();
+        fn imp(span: &Span, units: NoUnits, new: &Span) -> Sign {
+            // Negative units anywhere always makes the entire span negative.
+            if units < C(0) {
+                return Sign::N::<-1>();
+            }
+            let mut new_is_zero = new.sign == C(0) && units == C(0);
+            // When `units == 0` and it was previously non-zero, then
+            // `new.sign` won't be `0` and thus `new_is_zero` will be false
+            // when it should be true. So in this case, we need to re-check all
+            // the units to set the sign correctly.
+            if units == C(0) {
+                new_is_zero = new.years == C(0)
+                    && new.months == C(0)
+                    && new.weeks == C(0)
+                    && new.days == C(0)
+                    && new.hours == C(0)
+                    && new.minutes == C(0)
+                    && new.seconds == C(0)
+                    && new.milliseconds == C(0)
+                    && new.microseconds == C(0)
+                    && new.nanoseconds == C(0);
+            }
+            match (span.is_zero(), new_is_zero) {
+                (_, true) => Sign::N::<0>(),
+                (true, false) => units.signum().rinto(),
+                // If the old and new span are both non-zero, and we know our new
+                // units are not negative, then the sign remains unchanged.
+                (false, false) => new.sign,
+            }
         }
-        let mut new_is_zero = new.sign == C(0) && units == C(0);
-        // When `units == 0` and it was previously non-zero, then `new.sign`
-        // won't be `0` and thus `new_is_zero` will be false when it should
-        // be true. So in this case, we need to re-check all the units to set
-        // the sign correctly.
-        if units == C(0) {
-            new_is_zero = new.years == C(0)
-                && new.months == C(0)
-                && new.weeks == C(0)
-                && new.days == C(0)
-                && new.hours == C(0)
-                && new.minutes == C(0)
-                && new.seconds == C(0)
-                && new.milliseconds == C(0)
-                && new.microseconds == C(0)
-                && new.nanoseconds == C(0);
-        }
-        match (self.is_zero(), new_is_zero) {
-            (_, true) => Sign::N::<0>(),
-            (true, false) => units.signum().rinto(),
-            // If the old and new span are both non-zero, and we know our new
-            // units are not negative, then the sign remains unchanged.
-            (false, false) => new.sign,
-        }
+        imp(self, units.rinto(), new)
     }
 }
 
@@ -6479,7 +6433,7 @@ impl Nudge {
             * balanced.get_units_ranged(smallest).div_ceil(increment);
         let span = balanced
             .without_lower(smallest)
-            .try_units_ranged(smallest, truncated)
+            .try_units_ranged(smallest, truncated.rinto())
             .with_context(|| {
                 err!(
                     "failed to set {unit} to {truncated} on span {balanced}",
@@ -6506,8 +6460,9 @@ impl Nudge {
         let grew_big_unit =
             ((rounded.get() as f64) - exact).signum() == (sign.get() as f64);
 
-        let span =
-            span.try_units_ranged(smallest, rounded).with_context(|| {
+        let span = span
+            .try_units_ranged(smallest, rounded.rinto())
+            .with_context(|| {
                 err!(
                     "failed to set {unit} to {truncated} on span {span}",
                     unit = smallest.singular()

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -2254,10 +2254,9 @@ impl Timestamp {
 impl Timestamp {
     #[inline]
     pub(crate) fn new_ranged(
-        second: impl RInto<UnixSeconds>,
-        nanosecond: impl RInto<FractionalNanosecond>,
+        second: UnixSeconds,
+        nanosecond: FractionalNanosecond,
     ) -> Result<Timestamp, Error> {
-        let (second, nanosecond) = (second.rinto(), nanosecond.rinto());
         if second == UnixSeconds::MIN_SELF && nanosecond < C(0) {
             return Err(Error::range(
                 "seconds and nanoseconds",

--- a/src/tz/offset.rs
+++ b/src/tz/offset.rs
@@ -820,8 +820,8 @@ impl Offset {
     /// ```
     #[inline]
     pub fn until(self, other: Offset) -> Span {
-        Span::new()
-            .seconds_ranged(other.seconds_ranged() - self.seconds_ranged())
+        let diff = other.seconds_ranged() - self.seconds_ranged();
+        Span::new().seconds_ranged(diff.rinto())
     }
 
     /// Returns the span of time since the other offset given from this offset.

--- a/src/tz/zic.rs
+++ b/src/tz/zic.rs
@@ -704,7 +704,8 @@ impl RuleOnP {
             RuleOnP::Day { day } => Date::new_ranged(year, month, day),
             RuleOnP::Last { weekday } => {
                 // Always a valid month given that year/month are valid.
-                let date = Date::new_ranged(year, month, C(1)).unwrap();
+                let date =
+                    Date::new_ranged(year, month, C(1).rinto()).unwrap();
                 date.nth_weekday_of_month(-1, weekday)
             }
             RuleOnP::OnOrBefore { weekday, day } => {
@@ -1268,7 +1269,7 @@ fn parse_span(span: &str) -> Result<Span, Error> {
     let minutes_ranged = t::Minute::new(minutes).ok_or_else(|| {
         err!("duration minutes '{minutes:?}' is out of range")
     })?;
-    span = span.minutes_ranged(minutes_ranged * sign);
+    span = span.minutes_ranged((minutes_ranged * sign).rinto());
     if rest.is_empty() {
         return Ok(span);
     }
@@ -1290,7 +1291,7 @@ fn parse_span(span: &str) -> Result<Span, Error> {
     let seconds_ranged = t::Second::new(seconds).ok_or_else(|| {
         err!("duration seconds '{seconds:?}' is out of range")
     })?;
-    span = span.seconds_ranged(seconds_ranged * sign);
+    span = span.seconds_ranged((seconds_ranged * sign).rinto());
     if rest.is_empty() {
         return Ok(span);
     }
@@ -1317,7 +1318,7 @@ fn parse_span(span: &str) -> Result<Span, Error> {
         .ok_or_else(|| {
             err!("duration nanoseconds '{nanoseconds:?}' is out of range")
         })?;
-    span = span.nanoseconds_ranged(nanoseconds_ranged * sign);
+    span = span.nanoseconds_ranged((nanoseconds_ranged * sign).rinto());
 
     // We should have consumed everything at this point.
     if !rest.is_empty() {

--- a/src/util/parse.rs
+++ b/src/util/parse.rs
@@ -12,7 +12,7 @@ use crate::{
 /// integer. (We use `i64` because everything in this crate uses signed
 /// integers, and because a higher level routine might want to parse the sign
 /// and then apply it to the result of this routine.)
-#[inline(always)]
+#[cfg_attr(feature = "perf-inline", inline(always))]
 pub(crate) fn i64(bytes: &[u8]) -> Result<i64, Error> {
     if bytes.is_empty() {
         return Err(err!("invalid number, no digits found"));
@@ -166,7 +166,7 @@ where
 ///
 /// If the position is greater than the length of the slice given, then this
 /// returns `None`.
-#[inline(always)]
+#[cfg_attr(feature = "perf-inline", inline(always))]
 pub(crate) fn split(input: &[u8], at: usize) -> Option<(&[u8], &[u8])> {
     if at > input.len() {
         None

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -4038,12 +4038,15 @@ impl<'a> ZonedDifference<'a> {
         dt2 = mid;
 
         let date_span = dt1.date().until((largest, dt2.date()))?;
-        Ok(Span::from_invariant_nanoseconds(Unit::Hour, remainder_nano)
-            .expect("difference between time always fits in span")
-            .years_ranged(date_span.get_years_ranged())
-            .months_ranged(date_span.get_months_ranged())
-            .weeks_ranged(date_span.get_weeks_ranged())
-            .days_ranged(date_span.get_days_ranged()))
+        Ok(Span::from_invariant_nanoseconds(
+            Unit::Hour,
+            remainder_nano.rinto(),
+        )
+        .expect("difference between time always fits in span")
+        .years_ranged(date_span.get_years_ranged())
+        .months_ranged(date_span.get_months_ranged())
+        .weeks_ranged(date_span.get_weeks_ranged())
+        .days_ranged(date_span.get_days_ranged()))
     }
 }
 
@@ -4282,7 +4285,7 @@ impl ZonedRound {
             err!("failed to find start of day for {zdt}")
         })?;
         let end = start
-            .checked_add(Span::new().days_ranged(C(1)))
+            .checked_add(Span::new().days_ranged(C(1).rinto()))
             .with_context(|| {
                 err!("failed to add 1 day to {start} to find length of day")
             })?;


### PR DESCRIPTION
This PR removes some generics on internal APIs. This very modestly
improves compile times in release mode in a simple test. Specifically,
I had:

```rust
fn main() {
    println!("{}", Zoned::now());
}
```

with a dependency on `jiff`. Then I did `cargo clean && time cargo b
-r` to measure compilation time.

I also added a `perf-inline` crate feature that allows disabling all
uses of `inline(always)` inside of Jiff. It is enabled by default
though.
