### PR TITLE
jiff-static: add `perf-inline` feature to `jiff-static`

### DIFF
--- a/crates/jiff-static/Cargo.toml
+++ b/crates/jiff-static/Cargo.toml
@@ -30,6 +30,10 @@ tzdb = ["dep:jiff-tzdb"]
 # See the `tz-fat` feature in this repository's root `Cargo.toml` for more
 # context.
 tz-fat = []
+# Equivalent to the eponymous feature in `jiff` proper. Except it isn't
+# enabled by default here, since we don't really care about that level of
+# perf at compile time.
+perf-inline = []
 
 [dependencies]
 jiff-tzdb = { version = "0.1.4", path = "../jiff-tzdb", optional = true }


### PR DESCRIPTION
In practice, we do this because otherwise
`cfg_attr(feature = "perf-inline")` will throw a warning otherwise. And
that happens because we use these annotations in code in Jiff that is
shared (via copying) with `jiff-static`. So instead of just removing the
annotations, we add `perf-inline` as a feature to `jiff-static`.

For `jiff-static`, we disable it by default, since we don't really care
about that level of perf when doing datetime calculations at compile
time.
