### PR TITLE
ag/fix from secs panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+0.2.8 (TBD)
+===========
+TODO
+
+Bug fixes:
+
+* [#324](https://github.com/BurntSushi/jiff/issues/324):
+Fix a bug that could produce a panic or incorrect results in
+`SignedDuration::(try_)?from_secs_{f32,f64}`.
+
+
 0.2.7 (2025-04-13)
 ==================
 This release includes a bug fix that changes how an empty but set `TZ`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,19 @@
 # CHANGELOG
 
-0.2.7 (TBD)
-===========
-TODO
+0.2.7 (2025-04-13)
+==================
+This release includes a bug fix that changes how an empty but set `TZ`
+environment variable is interpreted (as indistinguishable from `TZ=UTC`).
+This also includes a new enabled by default create feature, `perf-inline`,
+which allows toggling Jiff's use of `inline(always)`. This may help improve
+compile times or decrease binary size.
 
 Enhancements:
 
-* [#xxx](https://github.com/BurntSushi/jiff/pull/xxx):
+* [#320](https://github.com/BurntSushi/jiff/pull/320):
 Remove some internal uses of generics to mildly improve compile times.
-* [#xxx](https://github.com/BurntSushi/jiff/pull/xxx):
-Add `perf-literal` crate feature for controlling `inline(always)` annotations.
+* [#321](https://github.com/BurntSushi/jiff/pull/321):
+Add `perf-inline` crate feature for controlling `inline(always)` annotations.
 
 Bug fixes:
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jiff"
-version = "0.2.6"  #:version
+version = "0.2.7"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 license = "Unlicense OR MIT"
 repository = "https://github.com/BurntSushi/jiff"
@@ -196,7 +196,7 @@ serde = { version = "1.0.203", optional = true, default-features = false }
 #
 # See: https://github.com/matklad/macro-dep-test
 [target.'cfg(any())'.dependencies]
-jiff-static = { version = "=0.2.6", path = "crates/jiff-static" }
+jiff-static = { version = "=0.2.7", path = "crates/jiff-static" }
 
 # Note that the `cfg` gate for the `tzdb-bundle-platform` must repeat the
 # target gate on this dependency. The intent is that `tzdb-bundle-platform`

--- a/crates/jiff-static/Cargo.toml
+++ b/crates/jiff-static/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jiff-static"
-version = "0.2.6"  #:version
+version = "0.2.7"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 license = "Unlicense OR MIT"
 homepage = "https://github.com/BurntSushi/jiff/tree/master/crates/jiff-static"


### PR DESCRIPTION
- **changelog: 0.2.7**
- **0.2.7**
- **signed_duration: fix panic in `SignedDuration::try_from_secs_f64`**
