### PR TITLE
signed_duration: fix panic in `SignedDuration::try_from_secs_f64`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+0.2.8 (TBD)
+===========
+TODO
+
+Bug fixes:
+
+* [#324](https://github.com/BurntSushi/jiff/issues/324):
+Fix a bug that could produce a panic or incorrect results in
+`SignedDuration::(try_)?from_secs_{f32,f64}`.
+
+
 0.2.7 (2025-04-13)
 ==================
 This release includes a bug fix that changes how an empty but set `TZ`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 ===========
 TODO
 
+Enhancements:
+
+* [#326](https://github.com/BurntSushi/jiff/pull/326):
+Add an alternate `Debug` impl for `SignedDuration` that only shows its second
+and nanosecond components (while using only one component when the other is
+zero).
+
 Bug fixes:
 
 * [#324](https://github.com/BurntSushi/jiff/issues/324):

--- a/src/fmt/temporal/parser.rs
+++ b/src/fmt/temporal/parser.rs
@@ -1603,61 +1603,61 @@ mod tests {
             input: "",
         }
         "###);
-        insta::assert_debug_snapshot!(p(b"PT60s"), @r###"
+        insta::assert_debug_snapshot!(p(b"PT60s"), @r#"
         Parsed {
-            value: 1m,
+            value: 60s,
             input: "",
         }
-        "###);
-        insta::assert_debug_snapshot!(p(b"PT1m"), @r###"
+        "#);
+        insta::assert_debug_snapshot!(p(b"PT1m"), @r#"
         Parsed {
-            value: 1m,
+            value: 60s,
             input: "",
         }
-        "###);
-        insta::assert_debug_snapshot!(p(b"PT1m0.000000001s"), @r###"
+        "#);
+        insta::assert_debug_snapshot!(p(b"PT1m0.000000001s"), @r#"
         Parsed {
-            value: 1m 1ns,
+            value: 60s 1ns,
             input: "",
         }
-        "###);
-        insta::assert_debug_snapshot!(p(b"PT1.25m"), @r###"
+        "#);
+        insta::assert_debug_snapshot!(p(b"PT1.25m"), @r#"
         Parsed {
-            value: 1m 15s,
+            value: 75s,
             input: "",
         }
-        "###);
-        insta::assert_debug_snapshot!(p(b"PT1h"), @r###"
+        "#);
+        insta::assert_debug_snapshot!(p(b"PT1h"), @r#"
         Parsed {
-            value: 1h,
+            value: 3600s,
             input: "",
         }
-        "###);
-        insta::assert_debug_snapshot!(p(b"PT1h0.000000001s"), @r###"
+        "#);
+        insta::assert_debug_snapshot!(p(b"PT1h0.000000001s"), @r#"
         Parsed {
-            value: 1h 1ns,
+            value: 3600s 1ns,
             input: "",
         }
-        "###);
-        insta::assert_debug_snapshot!(p(b"PT1.25h"), @r###"
+        "#);
+        insta::assert_debug_snapshot!(p(b"PT1.25h"), @r#"
         Parsed {
-            value: 1h 15m,
+            value: 4500s,
             input: "",
         }
-        "###);
+        "#);
 
-        insta::assert_debug_snapshot!(p(b"-PT2562047788015215h30m8.999999999s"), @r###"
+        insta::assert_debug_snapshot!(p(b"-PT2562047788015215h30m8.999999999s"), @r#"
         Parsed {
-            value: 2562047788015215h 30m 8s 999ms 999µs 999ns ago,
+            value: -9223372036854775808s 999999999ns,
             input: "",
         }
-        "###);
-        insta::assert_debug_snapshot!(p(b"PT2562047788015215h30m7.999999999s"), @r###"
+        "#);
+        insta::assert_debug_snapshot!(p(b"PT2562047788015215h30m7.999999999s"), @r#"
         Parsed {
-            value: 2562047788015215h 30m 7s 999ms 999µs 999ns,
+            value: 9223372036854775807s 999999999ns,
             input: "",
         }
-        "###);
+        "#);
     }
 
     #[test]

--- a/src/signed_duration.rs
+++ b/src/signed_duration.rs
@@ -2090,9 +2090,24 @@ impl core::fmt::Debug for SignedDuration {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         use crate::fmt::StdFmtWrite;
 
-        friendly::DEFAULT_SPAN_PRINTER
-            .print_duration(self, StdFmtWrite(f))
-            .map_err(|_| core::fmt::Error)
+        if f.alternate() {
+            if self.subsec_nanos() == 0 {
+                write!(f, "{}s", self.as_secs())
+            } else if self.as_secs() == 0 {
+                write!(f, "{}ns", self.subsec_nanos())
+            } else {
+                write!(
+                    f,
+                    "{}s {}ns",
+                    self.as_secs(),
+                    self.subsec_nanos().unsigned_abs()
+                )
+            }
+        } else {
+            friendly::DEFAULT_SPAN_PRINTER
+                .print_duration(self, StdFmtWrite(f))
+                .map_err(|_| core::fmt::Error)
+        }
     }
 }
 


### PR DESCRIPTION
This also resulted in a panic for an undocumented case, in debug mode, in
`SignedDuration::from_secs_f64`.

A similar fix has been applied to the `f32` case as well.

The problem was that if the fractional part of the floating point
duration rounded up to 1, then the nanosecond component would represent
a single full second. This case wasn't correctly accounted for.

This also adds an "alternate" `Debug` implementation for `SignedDuration`.
The alternate impl is a more "straight forward" representation of a
`SignedDuration`'s internals. That is, it just shows seconds and nanoseconds
(omitting zero components). I find this much easier to read when reasoning
about `SignedDuration`, since its internals and, to an extent, its API, are
defined in terms of its second and nanosecond components.

Fixes #324 