### PR TITLE
Correct regression test comment from #324

### DIFF
--- a/src/signed_duration.rs
+++ b/src/signed_duration.rs
@@ -2890,7 +2890,7 @@ mod tests {
         assert_eq!(sdur, SignedDuration::new(-9223372036854775808, 0));
     }
 
-    /// See `panic_try_from_secs_f32`.
+    /// See `panic_try_from_secs_f64`.
     ///
     /// Although note that I could never get this to panic. Perhaps the
     /// particulars of f32 prevent the fractional part from rounding up to


### PR DESCRIPTION
I was idly browsing recent PRs on Jiff and noticed what seems to be a docs typo on a regression test. It was introduced in #324.

It's obviously a tiny thing, but I thought I might as well fix it as soon as I spotted it.

If I've misunderstood, and it's not a typo, sorry for the noise.