### PR TITLE
rangeint: implement `Hash` for ranged integers manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Enhancements:
 * [#296](https://github.com/BurntSushi/jiff/issues/296):
 Provide a better panic message when `Zoned::now()` fails on WASM.
 
+Bug fixes:
+
+* [#330](https://github.com/BurntSushi/jiff/issues/330):
+Fix bug where `Hash` on datetime types could yield different hash values for
+the same underlying date/time.
+
 
 0.2.8 (2025-04-13)
 ==================

--- a/src/util/rangeint.rs
+++ b/src/util/rangeint.rs
@@ -22,7 +22,7 @@ macro_rules! define_ranged {
         smaller { $($smaller_name:ident $smaller_repr:ty),* },
         bigger { $($bigger_name:ident $bigger_repr:ty),* }
     ) => {
-        #[derive(Clone, Copy, Hash)]
+        #[derive(Clone, Copy)]
         pub(crate) struct $name<const MIN: i128, const MAX: i128> {
             /// The actual value of the integer.
             ///
@@ -922,6 +922,16 @@ macro_rules! define_ranged {
 
             pub(crate) fn debug(self) -> RangedDebug<MIN, MAX> {
                 RangedDebug { rint: self.rinto() }
+            }
+        }
+
+        // We hand-write the `Hash` impl to avoid the min/max values
+        // influencing the hash. Only the actual value should be hashed.
+        //
+        // See: https://github.com/BurntSushi/jiff/issues/330
+        impl<const MIN: i128, const MAX: i128> core::hash::Hash for $name<MIN, MAX> {
+            fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+                self.val.hash(state);
             }
         }
 


### PR DESCRIPTION
Only the actual value matters. By deriving `Hash`, it was including the
tracked min/max values, which is of course incorrect.

Note that this was only an issue in debug mode. In release mode, the
min/max values aren't compiled in, and so the `Hash` impl was correct.

Fixes #330
