### PR TITLE
doc: fix typo

### DIFF
--- a/src/fmt/strtime/mod.rs
+++ b/src/fmt/strtime/mod.rs
@@ -601,7 +601,7 @@ impl BrokenDownTime {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     ///
-    /// # Example: how to parse a only parse of a timestamp
+    /// # Example: how to parse only a part of a timestamp
     ///
     /// If you only need, for example, the date from a timestamp, then you
     /// can parse it as a prefix:


### PR DESCRIPTION
Coming from chrono, I was looking for an equivalent to `parse_and_remainder`, and found a small typo in `jiff::fmt::strtime::BrokenDownTime::parse_prefix` on the way.

Thanks for the crate! I am having fun using it in my projects :)