### PR TITLE
strtime: fix parsing for Tuesday

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+0.2.10 (2025-04-21)
+===================
+This release includes a bug fix for parsing `Tuesday` when using `%A` via
+Jiff's `strptime` APIs. Specifically, it would recognize `Tueday` instead of
+`Tuesday`.
+
+Bug fixes:
+
+* [#333](https://github.com/BurntSushi/jiff/issues/333):
+Fix typo in `strptime` parsing from `Tueday` to `Tuesday`.
+
+
 0.2.9 (2025-04-19)
 ==================
 This release includes a bug fix that, in debug mode, could result in datetime

--- a/src/fmt/strtime/parse.rs
+++ b/src/fmt/strtime/parse.rs
@@ -773,7 +773,7 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
         static CHOICES: &'static [&'static [u8]] = &[
             b"Sunday",
             b"Monday",
-            b"Tueday",
+            b"Tuesday",
             b"Wednesday",
             b"Thursday",
             b"Friday",
@@ -1814,7 +1814,7 @@ mod tests {
         );
         insta::assert_snapshot!(
             p("%A %m/%d/%y", "Mon 7/14/24"),
-            @r###"strptime parsing failed: %A failed: unrecognized weekday abbreviation: failed to find expected choice at beginning of "Mon 7/14/24", available choices are: Sunday, Monday, Tueday, Wednesday, Thursday, Friday, Saturday"###,
+            @r#"strptime parsing failed: %A failed: unrecognized weekday abbreviation: failed to find expected choice at beginning of "Mon 7/14/24", available choices are: Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday"#,
         );
         insta::assert_snapshot!(
             p("%b", "Bad"),


### PR DESCRIPTION
Unfortunately, I had a typo, which meant it recognized Tueday instead
Tuesday.

This was covered by tests, but I missed the typo in the asserted test
output too.

Fixes #333
