### PR TITLE
jiff-sqlx: remove dependency on sqlx-core

### DIFF
--- a/crates/jiff-sqlx/Cargo.toml
+++ b/crates/jiff-sqlx/Cargo.toml
@@ -28,14 +28,13 @@ path = "src/lib.rs"
 
 [features]
 default = []
-postgres = ["dep:sqlx-postgres"]
-sqlite = ["dep:sqlx-sqlite"]
+postgres = ["sqlx/postgres"]
+sqlite = ["sqlx/sqlite"]
 
 [dependencies]
-jiff = { version = "0.2.0", path = "../..", default-features = false }
-sqlx-core = { version = "0.8.0", default-features = false }
-sqlx-postgres = { version = "0.8.0", default-features = false, optional = true }
-sqlx-sqlite = { version = "0.8.0", default-features = false, optional = true }
+# The `std` feature is necessary for the `std::error::Error` impl.
+jiff = { version = "0.2.0", path = "../..", default-features = false, features=["std"] }
+sqlx = { version = "0.8.0", default-features = false }
 
 [dev-dependencies]
 jiff = { version = "0.2.0", path = "../..", default-features = true }

--- a/crates/jiff-sqlx/Cargo.toml
+++ b/crates/jiff-sqlx/Cargo.toml
@@ -33,7 +33,7 @@ sqlite = ["sqlx/sqlite"]
 
 [dependencies]
 # The `std` feature is necessary for the `std::error::Error` impl.
-jiff = { version = "0.2.0", path = "../..", default-features = false, features=["std"] }
+jiff = { version = "0.2.0", path = "../..", default-features = false, features = ["std"] }
 sqlx = { version = "0.8.0", default-features = false }
 
 [dev-dependencies]

--- a/crates/jiff-sqlx/src/postgres.rs
+++ b/crates/jiff-sqlx/src/postgres.rs
@@ -1,14 +1,14 @@
 use jiff::{civil, tz};
-use sqlx_core::{
+use sqlx::postgres::{
+    types::{Oid, PgInterval},
+    PgArgumentBuffer, PgHasArrayType, PgTypeInfo, PgValueFormat, PgValueRef,
+    Postgres,
+};
+use sqlx::{
     decode::Decode,
     encode::{Encode, IsNull},
     error::BoxDynError,
     types::Type,
-};
-use sqlx_postgres::{
-    types::{Oid, PgInterval},
-    PgArgumentBuffer, PgHasArrayType, PgTypeInfo, PgValueFormat, PgValueRef,
-    Postgres,
 };
 
 use crate::{Date, DateTime, Span, Time, Timestamp, ToSqlx};

--- a/crates/jiff-sqlx/src/sqlite.rs
+++ b/crates/jiff-sqlx/src/sqlite.rs
@@ -1,12 +1,12 @@
 use jiff::fmt::temporal::DateTimeParser;
-use sqlx_core::{
+use sqlx::sqlite::{
+    Sqlite, SqliteArgumentValue, SqliteTypeInfo, SqliteValueRef,
+};
+use sqlx::{
     decode::Decode,
     encode::{Encode, IsNull},
     error::BoxDynError,
     types::Type,
-};
-use sqlx_sqlite::{
-    Sqlite, SqliteArgumentValue, SqliteTypeInfo, SqliteValueRef,
 };
 
 use crate::{Date, DateTime, Time, Timestamp, ToSqlx};

--- a/scripts/test-integrations
+++ b/scripts/test-integrations
@@ -16,14 +16,7 @@ integrations=(
   "jiff-diesel postgres"
   "jiff-icu std"
   "jiff-sqlx postgres"
-  # This is just utter nonsense, but
-  # sqlx-sqlite does not compile in it
-  # default feature configuration. This
-  # is utterly asinine. And it's completely
-  # undocumented. I had to go trawling through
-  # the top-level sqlx Cargo.toml to figure
-  # out which feature to enable.
-  "jiff-sqlx sqlite,sqlx-sqlite/bundled"
+  "jiff-sqlx sqlite"
 )
 for v in "${integrations[@]}"; do
   crate="$(echo $v | awk '{print $1}')"


### PR DESCRIPTION
This PR removes the dependency on `sqlx-core` for `jiff-sqlx`. This also enables the `std` feature for `jiff` by default  (which enables the `std::error::Error` impl) because `sqlx::Encode` and `sqlx::Decode` can only return a `Box<dyn Error>` as the error type.

Fixes #322