### PR TITLE
migrate `jiff-icu` to ICU4X 2.0 (beta 2), add `Custom` trait for hooking localization into Jiff's `fmt::strtime` APIs, optimize `strftime`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # CHANGELOG
 
+0.2.11 (TBD)
+============
+This release includes new APIs for customizing Jiff's `strtime` behavior.
+
+This release also coincides with the publication of `jiff-icu 0.2.0-beta.2`,
+which has support for `icu 2.0.0-beta.2`.
+
+Enhancements:
+
+* [#338](https://github.com/BurntSushi/jiff/pull/338):
+Add support for the `%c`, `%r`, `%X` and `%x` conversion specifiers.
+
+
 0.2.10 (2025-04-21)
 ===================
 This release includes a bug fix for parsing `Tuesday` when using `%A` via

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Enhancements:
 * [#338](https://github.com/BurntSushi/jiff/pull/338):
 Add support for the `%c`, `%r`, `%X` and `%x` conversion specifiers.
 
+Performance:
+
+* [#338](https://github.com/BurntSushi/jiff/pull/338):
+Jiff's `strftime` APIs are now approximately twice as fast as they were.
+Performance should be comparable to `chrono` and `time`'s prebuilt APIs.
+
 
 0.2.10 (2025-04-21)
 ===================

--- a/bench/src/print.rs
+++ b/bench/src/print.rs
@@ -7,6 +7,7 @@ use crate::{benchmark, convert::ConvertFrom};
 
 pub(super) fn define(c: &mut Criterion) {
     print_civil_datetime(c);
+    print_strftime(c);
 }
 
 /// Measures the time it takes to print a civil datetime in ISO 8601 format.
@@ -85,6 +86,91 @@ fn print_civil_datetime(c: &mut Criterion) {
                 // I get making that opt-in, but this IMO should not be the
                 // default paved path for ISO 8601 formatting.
                 assert_eq!(buf, b"2024-06-30T09:46:00.000000000");
+            })
+        });
+    }
+}
+
+/// Measures the time it takes to print a datetime via `strftime`.
+///
+/// This tries to use the fastest possible API instead of the most convenient.
+/// Specifically, this means using APIs that avoid allocating a new `String`
+/// for every call.
+fn print_strftime(c: &mut Criterion) {
+    const NAME: &str = "print/strftime";
+    const EXPECTED: &str = "Mon Jul 15 04:24:59 PM -0400 2024";
+    const DATETIME: civil::DateTime =
+        civil::date(2024, 7, 15).at(16, 24, 59, 0);
+    const FMT: &str = "%a %b %e %I:%M:%S %p %z %Y";
+    const TZ: jiff::tz::TimeZone =
+        jiff::tz::TimeZone::fixed(jiff::tz::offset(-4));
+    // `time` doesn't have strtime-like APIs, but does provide its own
+    // custom formatting machinery. So we just use that since it's solving
+    // roughly the same problem as strftime.
+    //
+    // NOTE: At time of writing (2025-04-28), `time` actually does have
+    // `strftime`-style APIs, but I decided to just copy this from the existing
+    // `strptime` benchmark for now. (Which was written before `time` had a
+    // `strptime`-style API.)
+    const TIME_FMT: &[time::format_description::BorrowedFormatItem] = time::macros::format_description!(
+        "[weekday repr:short case_sensitive:false] \
+         [month repr:short case_sensitive:false] \
+         [day] \
+         [hour repr:12]:[minute]:[second] \
+         [period] \
+         [offset_hour sign:mandatory][offset_minute] \
+         [year]"
+    );
+    let zdt = DATETIME.to_zoned(TZ.clone()).unwrap();
+    let mut buf = String::with_capacity(1024);
+
+    {
+        benchmark(c, format!("{NAME}/oneshot/jiff"), |b| {
+            b.iter(|| {
+                buf.clear();
+                let tm = jiff::fmt::strtime::BrokenDownTime::from(&zdt);
+                tm.format(bb(FMT), &mut buf).unwrap();
+                assert_eq!(buf, EXPECTED);
+            })
+        });
+    }
+
+    {
+        let dt = chrono::DateTime::convert_from(zdt.clone());
+        benchmark(c, format!("{NAME}/oneshot/chrono"), |b| {
+            b.iter(|| {
+                buf.clear();
+                bb(dt).format(bb(FMT)).write_to(&mut buf).unwrap();
+                assert_eq!(buf, EXPECTED);
+            })
+        });
+    }
+
+    {
+        let dt = chrono::DateTime::convert_from(zdt.clone());
+        let items =
+            chrono::format::strftime::StrftimeItems::new(FMT).parse().unwrap();
+        benchmark(c, format!("{NAME}/prebuilt/chrono"), |b| {
+            b.iter(|| {
+                buf.clear();
+                bb(dt)
+                    .format_with_items(items.as_slice().iter())
+                    .write_to(&mut buf)
+                    .unwrap();
+                assert_eq!(buf, EXPECTED);
+            })
+        });
+    }
+
+    {
+        // `time` requires `std::io::Write`...
+        let mut buf = Vec::with_capacity(1024);
+        let odt = time::OffsetDateTime::convert_from(zdt.clone());
+        benchmark(c, format!("{NAME}/prebuilt/time"), |b| {
+            b.iter(|| {
+                buf.clear();
+                bb(odt).format_into(&mut buf, &TIME_FMT).unwrap();
+                assert_eq!(buf, EXPECTED.as_bytes());
             })
         });
     }

--- a/crates/jiff-icu/Cargo.toml
+++ b/crates/jiff-icu/Cargo.toml
@@ -10,7 +10,7 @@ description = "Conversion routines between Jiff and ICU4X."
 categories = ["date-and-time"]
 keywords = ["date", "time", "temporal", "zone", "icu"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.82"
 include = ["/src/*.rs", "/*.dat", "COPYING", "LICENSE-MIT", "UNLICENSE"]
 
 # Integration crates in Jiff are explicitly isolated from the workspace to
@@ -27,14 +27,15 @@ bench = false
 path = "src/lib.rs"
 
 [features]
-default = ["std"]
-std = ["alloc", "icu_calendar/std", "jiff/std"]
-alloc = ["jiff/alloc"]
+default = ["alloc", "time"]
+alloc = ["jiff/alloc", "icu_calendar/alloc", "icu_time?/alloc"]
+time = ["dep:icu_time"]
 
 [dependencies]
 jiff = { version = "0.2.0", path = "../..", default-features = false }
-icu_calendar = { version = "1.5.2", default-features = false }
+icu_calendar = { version = "2.0.0-beta.2", default-features = false }
+icu_time = { version = "2.0.0-beta.2", optional = true, default-features = false }
 
 [dev-dependencies]
 jiff = { version = "0.2.0", path = "../..", default-features = true }
-icu = { version = "1.5.0", features = ["std"] }
+icu = { version = "2.0.0-beta.2" }

--- a/crates/jiff-icu/src/error.rs
+++ b/crates/jiff-icu/src/error.rs
@@ -43,9 +43,8 @@ impl core::fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for Error {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self.kind {
             ErrorKind::Adhoc(_) => None,
             ErrorKind::Jiff(ref err) => Some(err),

--- a/crates/jiff-icu/src/lib.rs
+++ b/crates/jiff-icu/src/lib.rs
@@ -1,6 +1,6 @@
 /*!
 This crate provides conversion routines between [`jiff`] and
-[`icu`](https://docs.rs/icu/1/).
+[`icu`](https://docs.rs/icu/2.0.0-beta.2/).
 
 The conversion routines are implemented via conversion traits defined in this
 crate. The traits mirror the [`From`], [`Into`], [`TryFrom`] and [`TryInto`]
@@ -9,16 +9,16 @@ traits from the standard library.
 # Available conversions
 
 * [`jiff::civil::DateTime`] infallibly converts to
-[`icu::calendar::DateTime`](icu_calendar::DateTime).
+[`icu::time::DateTime`](icu_time::DateTime).
 The reverse is fallible.
 * [`jiff::civil::Date`] infallibly converts to
 [`icu::calendar::Date`](icu_calendar::Date).
 The reverse is fallible.
 * [`jiff::civil::Time`] infallibly converts to
-[`icu::calendar::Time`](icu_calendar::Time).
+[`icu::time::Time`](icu_time::Time).
 The reverse is fallible.
 * [`jiff::civil::Weekday`] infallibly converts to
-[`icu::calendar::types::IsoWeekday`](icu_calendar::types::IsoWeekday).
+[`icu::calendar::types::Weekday`](icu_calendar::types::Weekday).
 The reverse is also infallible.
 
 # Format a datetime in another locale
@@ -26,38 +26,38 @@ The reverse is also infallible.
 This example shows how one can bridge `jiff` to `icu` in order to format a
 datetime in a particular locale. This makes use of the infallible
 [`ConvertFrom`] trait to convert a [`jiff::civil::DateTime`] into a
-[`icu::calendar::DateTime`](icu_calendar::DateTime).
+[`icu::time::DateTime`](icu_time::DateTime).
 
 ```
 use icu::{
-    calendar::{gregorian::Gregorian, DateTime},
-    datetime::TypedDateTimeFormatter,
-    locid::locale,
+    time::DateTime,
+    datetime::{fieldsets, DateTimeFormatter},
+    locale::locale,
 };
 use jiff::Zoned;
 use jiff_icu::{ConvertFrom as _};
 
 let zdt: Zoned = "2024-09-10T23:37:20-04[America/New_York]".parse()?;
-let icu_datetime = DateTime::convert_from(zdt.datetime()).to_calendar(Gregorian);
+let icu_datetime = DateTime::convert_from(zdt.datetime());
 
 // Format for the en-GB locale:
-let formatter = TypedDateTimeFormatter::try_new(
-    &locale!("en-GB").into(),
-    Default::default(),
+let formatter = DateTimeFormatter::try_new(
+    locale!("en-GB").into(),
+    fieldsets::YMDET::medium(),
 )?;
 assert_eq!(
     formatter.format(&icu_datetime).to_string(),
-    "10 Sept 2024, 23:37:20",
+    "Tue, 10 Sept 2024, 23:37:20",
 );
 
 // Or in the en-US locale:
-let formatter = TypedDateTimeFormatter::try_new(
-    &locale!("en-US").into(),
-    Default::default(),
+let formatter = DateTimeFormatter::try_new(
+    locale!("en-US").into(),
+    fieldsets::YMDET::medium(),
 )?;
 assert_eq!(
     formatter.format(&icu_datetime).to_string(),
-    "Sep 10, 2024, 11:37:20 PM",
+    "Tue, Sep 10, 2024, 11:37:20 PM",
 );
 
 # Ok::<(), Box<dyn std::error::Error>>(())
@@ -69,17 +69,21 @@ While Jiff only supports the Gregorian calendar (technically the ISO
 8601 calendar), ICU4X supports [many calendars](icu_calendar). This
 example shows how to convert a date in the Hebrew calendar to a Jiff
 date. This makes use of the fallible [`ConvertTryFrom`] trait to
-convert a [`icu::calendar::DateTime`](icu_calendar::DateTime) into a
+convert a [`icu::time::DateTime`](icu_time::DateTime) into a
 [`jiff::civil::DateTime`]:
 
 ```
 use icu::{
-    calendar::{DateTime as IcuDateTime},
+    calendar::Date as IcuDate,
+    time::{DateTime as IcuDateTime, Time as IcuTime},
 };
 use jiff::civil::DateTime;
 use jiff_icu::{ConvertTryFrom as _};
 
-let datetime = IcuDateTime::try_new_hebrew_datetime(5785, 5, 4, 17, 30, 0)?;
+let datetime = IcuDateTime {
+    date: IcuDate::try_new_hebrew(5785, 5, 4)?,
+    time: IcuTime::try_new(17, 30, 0, 0)?,
+};
 let zdt = DateTime::convert_try_from(datetime)?.in_tz("America/New_York")?;
 assert_eq!(zdt.to_string(), "2025-02-02T17:30:00-05:00[America/New_York]");
 
@@ -90,16 +94,18 @@ assert_eq!(zdt.to_string(), "2025-02-02T17:30:00-05:00[America/New_York]");
 #![no_std]
 #![deny(missing_docs)]
 
-#[cfg(any(test, feature = "std"))]
+#[cfg(test)]
 extern crate std;
 
 #[cfg(any(test, feature = "alloc"))]
 extern crate alloc;
 
 use icu_calendar::{
-    types::IsoWeekday as IcuWeekday, AsCalendar as IcuAsCalendar,
-    Date as IcuDate, DateTime as IcuDateTime, Iso, Time as IcuTime,
+    types::Weekday as IcuWeekday, AsCalendar as IcuAsCalendar,
+    Date as IcuDate, Iso,
 };
+#[cfg(feature = "time")]
+use icu_time::{DateTime as IcuDateTime, Time as IcuTime};
 use jiff::civil::{
     Date as JiffDate, DateTime as JiffDateTime, Time as JiffTime,
     Weekday as JiffWeekday,
@@ -114,7 +120,7 @@ pub use self::{
 mod error;
 mod traits;
 
-/// Converts from a [`icu_calendar::DateTime<Iso>`](icu_calendar::DateTime) to
+/// Converts from a [`icu_time::DateTime<Iso>`](icu_time::DateTime) to
 /// a [`jiff::civil::DateTime`].
 ///
 /// # Examples
@@ -122,36 +128,44 @@ mod traits;
 /// ```
 /// use jiff_icu::{ConvertTryFrom as _};
 ///
-/// let icu_datetime = icu_calendar::DateTime::local_unix_epoch();
+/// let icu_datetime = icu_time::DateTime {
+///     date: icu_calendar::Date::try_new_iso(1970, 1, 1).unwrap(),
+///     time: icu_time::Time::try_new(0, 0, 0, 0).unwrap(),
+/// };
 /// let jiff_datetime = jiff::civil::DateTime::convert_try_from(icu_datetime)?;
 /// assert_eq!(jiff_datetime.to_string(), "1970-01-01T00:00:00");
 ///
-/// let icu_datetime = icu_calendar::DateTime::try_new_iso_datetime(
-///     2025, 1, 30, 17, 58, 30,
-/// ).unwrap();
+/// let icu_datetime = icu_time::DateTime {
+///     date: icu_calendar::Date::try_new_iso(2025, 1, 30).unwrap(),
+///     time: icu_time::Time::try_new(17, 58, 30, 0).unwrap(),
+/// };
 /// let jiff_datetime = jiff::civil::DateTime::convert_try_from(icu_datetime)?;
 /// assert_eq!(jiff_datetime.to_string(), "2025-01-30T17:58:30");
 ///
-/// let icu_datetime = icu_calendar::DateTime::try_new_iso_datetime(
-///     -9999, 1, 1, 0, 0, 0,
-/// ).unwrap();
+/// let icu_datetime = icu_time::DateTime {
+///     date: icu_calendar::Date::try_new_iso(-9999, 1, 1).unwrap(),
+///     time: icu_time::Time::try_new(0, 0, 0, 0).unwrap(),
+/// };
 /// let jiff_datetime = jiff::civil::DateTime::convert_try_from(icu_datetime)?;
 /// assert_eq!(jiff_datetime.to_string(), "-009999-01-01T00:00:00");
 ///
-/// let icu_datetime = icu_calendar::DateTime::try_new_iso_datetime(
-///     9999, 12, 31, 23, 59, 59,
-/// ).unwrap();
+/// let icu_datetime = icu_time::DateTime {
+///     date: icu_calendar::Date::try_new_iso(9999, 12, 31).unwrap(),
+///     time: icu_time::Time::try_new(23, 59, 59, 999_999_999).unwrap(),
+/// };
 /// let jiff_datetime = jiff::civil::DateTime::convert_try_from(icu_datetime)?;
-/// assert_eq!(jiff_datetime.to_string(), "9999-12-31T23:59:59");
+/// assert_eq!(jiff_datetime.to_string(), "9999-12-31T23:59:59.999999999");
 ///
-/// let icu_datetime = icu_calendar::DateTime::try_new_iso_datetime(
-///     0, 1, 30, 0, 0, 0,
-/// ).unwrap();
+/// let icu_datetime = icu_time::DateTime {
+///     date: icu_calendar::Date::try_new_iso(0, 1, 30).unwrap(),
+///     time: icu_time::Time::try_new(0, 0, 0, 0).unwrap(),
+/// };
 /// let jiff_datetime = jiff::civil::DateTime::convert_try_from(icu_datetime)?;
 /// assert_eq!(jiff_datetime.to_string(), "0000-01-30T00:00:00");
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
+#[cfg(feature = "time")]
 impl<C: IcuAsCalendar> ConvertTryFrom<IcuDateTime<C>> for JiffDateTime {
     type Error = Error;
 
@@ -163,7 +177,7 @@ impl<C: IcuAsCalendar> ConvertTryFrom<IcuDateTime<C>> for JiffDateTime {
 }
 
 /// Converts from a [`jiff::civil::DateTime`] to a
-/// [`icu_calendar::DateTime<Iso>`](icu_calendar::DateTime).
+/// [`icu_time::DateTime<Iso>`](icu_time::DateTime).
 ///
 /// # Examples
 ///
@@ -171,54 +185,55 @@ impl<C: IcuAsCalendar> ConvertTryFrom<IcuDateTime<C>> for JiffDateTime {
 /// use jiff_icu::{ConvertFrom as _};
 ///
 /// let jiff_datetime = jiff::civil::date(2025, 1, 30).at(17, 58, 30, 0);
-/// let icu_datetime = icu_calendar::DateTime::convert_from(jiff_datetime);
+/// let icu_datetime = icu_time::DateTime::convert_from(jiff_datetime);
 /// assert_eq!(
 ///     format!("{:?}", icu_datetime.date),
 ///     "Date(2025-1-30, default era, for calendar ISO)",
 /// );
 /// assert_eq!(
 ///     format!("{:?}", icu_datetime.time),
-///     "Time { hour: IsoHour(17), minute: IsoMinute(58), second: IsoSecond(30), nanosecond: NanoSecond(0) }",
+///     "Time { hour: Hour(17), minute: Minute(58), second: Second(30), subsecond: Nanosecond(0) }",
 /// );
 ///
 /// let jiff_datetime = jiff::civil::DateTime::MIN;
-/// let icu_datetime = icu_calendar::DateTime::convert_from(jiff_datetime);
+/// let icu_datetime = icu_time::DateTime::convert_from(jiff_datetime);
 /// assert_eq!(
 ///     format!("{:?}", icu_datetime.date),
 ///     "Date(-9999-1-1, default era, for calendar ISO)",
 /// );
 /// assert_eq!(
 ///     format!("{:?}", icu_datetime.time),
-///     "Time { hour: IsoHour(0), minute: IsoMinute(0), second: IsoSecond(0), nanosecond: NanoSecond(0) }",
+///     "Time { hour: Hour(0), minute: Minute(0), second: Second(0), subsecond: Nanosecond(0) }",
 /// );
 ///
 /// let jiff_datetime = jiff::civil::DateTime::MAX;
-/// let icu_datetime = icu_calendar::DateTime::convert_from(jiff_datetime);
+/// let icu_datetime = icu_time::DateTime::convert_from(jiff_datetime);
 /// assert_eq!(
 ///     format!("{:?}", icu_datetime.date),
 ///     "Date(9999-12-31, default era, for calendar ISO)",
 /// );
 /// assert_eq!(
 ///     format!("{:?}", icu_datetime.time),
-///     "Time { hour: IsoHour(23), minute: IsoMinute(59), second: IsoSecond(59), nanosecond: NanoSecond(999999999) }",
+///     "Time { hour: Hour(23), minute: Minute(59), second: Second(59), subsecond: Nanosecond(999999999) }",
 /// );
 ///
 /// let jiff_datetime = jiff::civil::date(0, 1, 30).at(0, 0, 0, 0);
-/// let icu_datetime = icu_calendar::DateTime::convert_from(jiff_datetime);
+/// let icu_datetime = icu_time::DateTime::convert_from(jiff_datetime);
 /// assert_eq!(
 ///     format!("{:?}", icu_datetime.date),
 ///     "Date(0-1-30, default era, for calendar ISO)",
 /// );
 /// assert_eq!(
 ///     format!("{:?}", icu_datetime.time),
-///     "Time { hour: IsoHour(0), minute: IsoMinute(0), second: IsoSecond(0), nanosecond: NanoSecond(0) }",
+///     "Time { hour: Hour(0), minute: Minute(0), second: Second(0), subsecond: Nanosecond(0) }",
 /// );
 /// ```
+#[cfg(feature = "time")]
 impl ConvertFrom<JiffDateTime> for IcuDateTime<Iso> {
     fn convert_from(v: JiffDateTime) -> IcuDateTime<Iso> {
         let date: IcuDate<Iso> = v.date().convert_into();
         let time: IcuTime = v.time().convert_into();
-        IcuDateTime::new(date, time)
+        IcuDateTime { date, time }
     }
 }
 
@@ -229,23 +244,23 @@ impl ConvertFrom<JiffDateTime> for IcuDateTime<Iso> {
 /// ```
 /// use jiff_icu::{ConvertTryFrom as _};
 ///
-/// let icu_date = icu_calendar::Date::unix_epoch();
+/// let icu_date = icu_calendar::Date::try_new_iso(1970, 1, 1).unwrap();
 /// let jiff_date = jiff::civil::Date::convert_try_from(icu_date)?;
 /// assert_eq!(jiff_date.to_string(), "1970-01-01");
 ///
-/// let icu_date = icu_calendar::Date::try_new_iso_date(2025, 1, 30).unwrap();
+/// let icu_date = icu_calendar::Date::try_new_iso(2025, 1, 30).unwrap();
 /// let jiff_date = jiff::civil::Date::convert_try_from(icu_date)?;
 /// assert_eq!(jiff_date.to_string(), "2025-01-30");
 ///
-/// let icu_date = icu_calendar::Date::try_new_iso_date(-9999, 1, 1).unwrap();
+/// let icu_date = icu_calendar::Date::try_new_iso(-9999, 1, 1).unwrap();
 /// let jiff_date = jiff::civil::Date::convert_try_from(icu_date)?;
 /// assert_eq!(jiff_date.to_string(), "-009999-01-01");
 ///
-/// let icu_date = icu_calendar::Date::try_new_iso_date(9999, 12, 31).unwrap();
+/// let icu_date = icu_calendar::Date::try_new_iso(9999, 12, 31).unwrap();
 /// let jiff_date = jiff::civil::Date::convert_try_from(icu_date)?;
 /// assert_eq!(jiff_date.to_string(), "9999-12-31");
 ///
-/// let icu_date = icu_calendar::Date::try_new_iso_date(0, 1, 30).unwrap();
+/// let icu_date = icu_calendar::Date::try_new_iso(0, 1, 30).unwrap();
 /// let jiff_date = jiff::civil::Date::convert_try_from(icu_date)?;
 /// assert_eq!(jiff_date.to_string(), "0000-01-30");
 ///
@@ -257,7 +272,7 @@ impl ConvertFrom<JiffDateTime> for IcuDateTime<Iso> {
 /// ```
 /// use jiff_icu::{ConvertTryFrom as _};
 ///
-/// let icu_date = icu_calendar::Date::try_new_hebrew_date(5785, 5, 4).unwrap();
+/// let icu_date = icu_calendar::Date::try_new_hebrew(5785, 5, 4).unwrap();
 /// let jiff_date = jiff::civil::Date::convert_try_from(icu_date)?;
 /// assert_eq!(jiff_date.to_string(), "2025-02-02");
 ///
@@ -268,7 +283,7 @@ impl<C: IcuAsCalendar> ConvertTryFrom<IcuDate<C>> for JiffDate {
 
     fn convert_try_from(v: IcuDate<C>) -> Result<JiffDate, Error> {
         let v = v.to_iso();
-        let year = v.year().number;
+        let year = v.year().extended_year;
         let year = i16::try_from(year).map_err(|_| {
             err!("failed to convert `icu` year of {year} to `i16`")
         })?;
@@ -331,7 +346,7 @@ impl<C: IcuAsCalendar> ConvertTryFrom<IcuDate<C>> for JiffDate {
 ///
 /// let jiff_date = jiff::civil::date(2025, 2, 2);
 /// let icu_iso_date = icu_calendar::Date::convert_from(jiff_date);
-/// let icu_hebrew_date = icu_iso_date.to_calendar(icu_calendar::hebrew::Hebrew);
+/// let icu_hebrew_date = icu_iso_date.to_calendar(icu_calendar::cal::Hebrew);
 /// assert_eq!(
 ///     format!("{icu_hebrew_date:?}"),
 ///     "Date(5785-5-4, hebrew era, for calendar Hebrew)",
@@ -343,31 +358,32 @@ impl ConvertFrom<JiffDate> for IcuDate<Iso> {
         let month = v.month().unsigned_abs();
         let day = v.day().unsigned_abs();
         // All Jiff civil dates are valid ICU4X dates.
-        IcuDate::try_new_iso_date(year, month, day).unwrap()
+        IcuDate::try_new_iso(year, month, day).unwrap()
     }
 }
 
-/// Converts from a [`icu_calendar::Time`] to a [`jiff::civil::Time`].
+/// Converts from a [`icu_time::Time`] to a [`jiff::civil::Time`].
 ///
 /// # Examples
 ///
 /// ```
 /// use jiff_icu::{ConvertTryFrom as _};
 ///
-/// let icu_time = icu_calendar::Time::try_new(0, 0, 0, 0).unwrap();
+/// let icu_time = icu_time::Time::try_new(0, 0, 0, 0).unwrap();
 /// let jiff_time = jiff::civil::Time::convert_try_from(icu_time)?;
 /// assert_eq!(jiff_time, jiff::civil::time(0, 0, 0, 0));
 ///
-/// let icu_time = icu_calendar::Time::try_new(24, 0, 0, 0).unwrap();
+/// let icu_time = icu_time::Time::try_new(23, 59, 59, 999_999_999).unwrap();
 /// let jiff_time = jiff::civil::Time::convert_try_from(icu_time)?;
-/// assert_eq!(jiff_time, jiff::civil::time(0, 0, 0, 0));
+/// assert_eq!(jiff_time, jiff::civil::time(23, 59, 59, 999_999_999));
 ///
-/// let icu_time = icu_calendar::Time::try_new(17, 59, 4, 0).unwrap();
+/// let icu_time = icu_time::Time::try_new(17, 59, 4, 0).unwrap();
 /// let jiff_time = jiff::civil::Time::convert_try_from(icu_time)?;
 /// assert_eq!(jiff_time, jiff::civil::time(17, 59, 4, 0));
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
+#[cfg(feature = "time")]
 impl ConvertTryFrom<IcuTime> for JiffTime {
     type Error = Error;
 
@@ -385,13 +401,13 @@ impl ConvertTryFrom<IcuTime> for JiffTime {
         let second = i8::try_from(v.second.number()).unwrap();
 
         // OK because it's guaranteed by API docs.
-        let subsec_nano = i32::try_from(v.nanosecond.number()).unwrap();
+        let subsec_nano = i32::try_from(v.subsecond.number()).unwrap();
 
         Ok(JiffTime::new(hour, minute, second, subsec_nano)?)
     }
 }
 
-/// Converts from a [`jiff::civil::Time`] to a [`icu_calendar::Time`].
+/// Converts from a [`jiff::civil::Time`] to a [`icu_time::Time`].
 ///
 /// # Examples
 ///
@@ -399,19 +415,20 @@ impl ConvertTryFrom<IcuTime> for JiffTime {
 /// use jiff_icu::{ConvertFrom as _};
 ///
 /// let jiff_time = jiff::civil::time(0, 0, 0, 0);
-/// let icu_time = icu_calendar::Time::convert_from(jiff_time);
+/// let icu_time = icu_time::Time::convert_from(jiff_time);
 /// assert_eq!(
 ///     format!("{icu_time:?}"),
-///     "Time { hour: IsoHour(0), minute: IsoMinute(0), second: IsoSecond(0), nanosecond: NanoSecond(0) }",
+///     "Time { hour: Hour(0), minute: Minute(0), second: Second(0), subsecond: Nanosecond(0) }",
 /// );
 ///
 /// let jiff_time = jiff::civil::time(17, 59, 4, 0);
-/// let icu_time = icu_calendar::Time::convert_from(jiff_time);
+/// let icu_time = icu_time::Time::convert_from(jiff_time);
 /// assert_eq!(
 ///     format!("{icu_time:?}"),
-///     "Time { hour: IsoHour(17), minute: IsoMinute(59), second: IsoSecond(4), nanosecond: NanoSecond(0) }",
+///     "Time { hour: Hour(17), minute: Minute(59), second: Second(4), subsecond: Nanosecond(0) }",
 /// );
 /// ```
+#[cfg(feature = "time")]
 impl ConvertFrom<JiffTime> for IcuTime {
     fn convert_from(v: JiffTime) -> IcuTime {
         let hour = v.hour().unsigned_abs();
@@ -423,7 +440,7 @@ impl ConvertFrom<JiffTime> for IcuTime {
     }
 }
 
-/// Converts from a [`icu_calendar::types::IsoWeekday`] to a
+/// Converts from a [`icu_calendar::types::Weekday`] to a
 /// [`jiff::civil::Weekday`].
 ///
 /// # Examples
@@ -431,7 +448,7 @@ impl ConvertFrom<JiffTime> for IcuTime {
 /// ```
 /// use jiff_icu::{ConvertFrom as _};
 ///
-/// let icu_weekday = icu_calendar::types::IsoWeekday::Wednesday;
+/// let icu_weekday = icu_calendar::types::Weekday::Wednesday;
 /// let jiff_weekday = jiff::civil::Weekday::convert_from(icu_weekday);
 /// assert_eq!(jiff_weekday, jiff::civil::Weekday::Wednesday);
 /// ```
@@ -450,7 +467,7 @@ impl ConvertFrom<IcuWeekday> for JiffWeekday {
 }
 
 /// Converts from a [`jiff::civil::Weekday`] to a
-/// [`icu_calendar::types::IsoWeekday`].
+/// [`icu_calendar::types::Weekday`].
 ///
 /// # Examples
 ///
@@ -458,8 +475,8 @@ impl ConvertFrom<IcuWeekday> for JiffWeekday {
 /// use jiff_icu::{ConvertFrom as _};
 ///
 /// let jiff_weekday = jiff::civil::Weekday::Wednesday;
-/// let icu_weekday = icu_calendar::types::IsoWeekday::convert_from(jiff_weekday);
-/// assert_eq!(icu_weekday, icu_calendar::types::IsoWeekday::Wednesday);
+/// let icu_weekday = icu_calendar::types::Weekday::convert_from(jiff_weekday);
+/// assert_eq!(icu_weekday, icu_calendar::types::Weekday::Wednesday);
 /// ```
 impl ConvertFrom<JiffWeekday> for IcuWeekday {
     fn convert_from(v: JiffWeekday) -> IcuWeekday {
@@ -504,6 +521,7 @@ mod tests {
     ///
     /// We skip nanoseconds because it would take too long to exhaustively
     /// test. Without nanoseconds, this is quick enough to run in debug mode.
+    #[cfg(feature = "time")]
     #[test]
     fn all_jiff_times_are_valid_icu_times() {
         for jiff_time in jiff::civil::Time::MIN.series(1.second()) {

--- a/crates/jiff-icu/src/lib.rs
+++ b/crates/jiff-icu/src/lib.rs
@@ -170,11 +170,10 @@ use icu_time::{
     DateTime as IcuDateTime, Time as IcuTime, TimeZone as IcuTimeZone,
     TimeZoneInfo as IcuTimeZoneInfo, ZonedDateTime as IcuZonedDateTime,
 };
+use jiff::civil::{Date as JiffDate, Weekday as JiffWeekday};
+#[cfg(feature = "time")]
 use jiff::{
-    civil::{
-        Date as JiffDate, DateTime as JiffDateTime, Time as JiffTime,
-        Weekday as JiffWeekday,
-    },
+    civil::{DateTime as JiffDateTime, Time as JiffTime},
     tz::{Offset as JiffOffset, TimeZone as JiffTimeZone},
     Zoned as JiffZoned,
 };

--- a/scripts/test-integrations
+++ b/scripts/test-integrations
@@ -14,7 +14,7 @@ cd "$(dirname "$0")/.."
 integrations=(
   "jiff-diesel mysql"
   "jiff-diesel postgres"
-  "jiff-icu std"
+  "jiff-icu alloc,time"
   "jiff-sqlx postgres"
   "jiff-sqlx sqlite"
 )

--- a/src/error.rs
+++ b/src/error.rs
@@ -110,13 +110,33 @@ enum ErrorKind {
 }
 
 impl Error {
+    /// Creates a new error value from `core::fmt::Arguments`.
+    ///
+    /// It is expected to use [`format_args!`](format_args) from
+    /// Rust's standard library (available in `core`) to create a
+    /// `core::fmt::Arguments`.
+    ///
+    /// Callers should generally use their own error types. But in some
+    /// circumstances, it can be convenient to manufacture a Jiff error value
+    /// specifically.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use jiff::Error;
+    ///
+    /// let err = Error::from_args(format_args!("something failed"));
+    /// assert_eq!(err.to_string(), "something failed");
+    /// ```
+    pub fn from_args<'a>(message: core::fmt::Arguments<'a>) -> Error {
+        Error::from(ErrorKind::Adhoc(AdhocError::from_args(message)))
+    }
+}
+
+impl Error {
     /// Creates a new "ad hoc" error value.
     ///
-    /// An ad hoc error value is just an opaque string. In theory we should
-    /// avoid creating such error values, but in practice, they are extremely
-    /// convenient. And the alternative is quite brutal given the varied ways
-    /// in which things in a datetime library can fail. (Especially parsing
-    /// errors.)
+    /// An ad hoc error value is just an opaque string.
     #[cfg(feature = "alloc")]
     pub(crate) fn adhoc<'a>(message: impl core::fmt::Display + 'a) -> Error {
         Error::from(ErrorKind::Adhoc(AdhocError::from_display(message)))

--- a/src/fmt/strtime/mod.rs
+++ b/src/fmt/strtime/mod.rs
@@ -465,12 +465,6 @@ pub fn format(
 // only catch is that you can't omit time units bigger than any present time
 // unit. For example, only `%M` doesn't fly. If you want to parse minutes, you
 // also have to parse hours.
-//
-// This design does also let us possibly do "incomplete" parsing by asking
-// the caller for a datetime to "seed" a `Fields` struct, and then execute
-// parsing. But Jiff doesn't currently expose an API to do that. But this
-// implementation was intentionally designed to support that use case, C
-// style, if it comes up.
 #[derive(Debug, Default)]
 pub struct BrokenDownTime {
     year: Option<t::Year>,

--- a/src/fmt/strtime/mod.rs
+++ b/src/fmt/strtime/mod.rs
@@ -162,6 +162,7 @@ strings, the strings are matched without regard to ASCII case.
 | `%A`, `%a` | `Sunday`, `Sun` | The full and abbreviated weekday, respectively. |
 | `%B`, `%b`, `%h` | `June`, `Jun`, `Jun` | The full and abbreviated month name, respectively. |
 | `%C` | `20` | The century of the year. No padding. |
+| `%c` | `2024 M07 14, Sun 17:31:59` | The date and clock time via [`Custom`]. Supported when formatting only. |
 | `%D` | `7/14/24` | Equivalent to `%m/%d/%y`. |
 | `%d`, `%e` | `25`, ` 5` | The day of the month. `%d` is zero-padded, `%e` is space padded. |
 | `%F` | `2024-07-14` | Equivalent to `%Y-%m-%d`. |
@@ -182,6 +183,7 @@ strings, the strings are matched without regard to ASCII case.
 | `%Q` | `America/New_York`, `+0530` | An IANA time zone identifier, or `%z` if one doesn't exist. |
 | `%:Q` | `America/New_York`, `+05:30` | An IANA time zone identifier, or `%:z` if one doesn't exist. |
 | `%R` | `23:30` | Equivalent to `%H:%M`. |
+| `%r` | `8:30:00 AM` | The 12-hour clock time via [`Custom`]. Supported when formatting only. |
 | `%S` | `59` | The second. Zero padded. |
 | `%s` | `1737396540` | A Unix timestamp, in seconds. |
 | `%T` | `23:30:59` | Equivalent to `%H:%M:%S`. |
@@ -191,6 +193,8 @@ strings, the strings are matched without regard to ASCII case.
 | `%V` | `05` | Week number in the [ISO 8601 week-based] calendar. Zero padded. |
 | `%W` | `03` | Week number. Week 1 is the first week starting with a Monday. Zero padded. |
 | `%w` | `0` | The day of the week beginning with Sunday at `0`. |
+| `%X` | `17:31:59` | The clock time via [`Custom`]. Supported when formatting only. |
+| `%x` | `2024 M07 14` | The date via [`Custom`]. Supported when formatting only. |
 | `%Y` | `2024` | A full year, including century. Zero padded to 4 digits. |
 | `%y` | `24` | A two-digit year. Represents only 1969-2068. Zero padded. |
 | `%Z` | `EDT` | A time zone abbreviation. Supported when formatting only. |
@@ -210,8 +214,8 @@ entirely in uppercase by default.
 
 The above flags override the "default" settings of a specifier. For example,
 `%_d` pads with spaces instead of zeros, and `%0e` pads with zeros instead of
-spaces. The exceptions are the `%z` and `%:z` specifiers. They are unaffected
-by any flags.
+spaces. The exceptions are the locale (`%c`, `%r`, `%X`, `%x`), and time zone
+(`%z`, `%:z`) specifiers. They are unaffected by any flags.
 
 Moreover, any number of decimal digits can be inserted after the (possibly
 absent) flag and before the directive, so long as the parsed number is less
@@ -247,9 +251,17 @@ is variable width data. If you have a use case for this, please
 The following things are currently unsupported:
 
 * Parsing or formatting fractional seconds in the time time zone offset.
-* Locale oriented conversion specifiers, such as `%c`, `%r` and `%+`, are not
-  supported by Jiff. For locale oriented datetime formatting, please use the
-  [`icu`] crate via [`jiff-icu`].
+* The `%::z` and `%:::z` specifiers found in GNU date.
+* The `%+` conversion specifier is not supported since there doesn't seem to
+  be any consistent definition for it.
+* With only Jiff, the `%c`, `%r`, `%X` and `%x` locale oriented specifiers
+  use a default "unknown" locale via the [`DefaultCustom`] implementation
+  of the [`Custom`] trait. An example of the default locale format for `%c`
+  is `2024 M07 14, Sun 17:31:59`. One can either switch the POSIX locale
+  via [`PosixCustom`] (e.g., `Sun Jul 14 17:31:59 2024`), or write your own
+  implementation of [`Custom`] powered by [`icu`] and glued together with Jiff
+  via [`jiff-icu`].
+* The `E` and `O` locale modifiers are not supported.
 
 [`strftime`]: https://pubs.opengroup.org/onlinepubs/009695399/functions/strftime.html
 [`strptime`]: https://pubs.opengroup.org/onlinepubs/009695399/functions/strptime.html
@@ -421,6 +433,315 @@ pub fn format(
     let mut buf = alloc::string::String::new();
     broken_down_time.format(format, &mut buf)?;
     Ok(buf)
+}
+
+/// Configuration for customizing the behavior of formatting or parsing.
+///
+/// Currently, this type is limited to being a vehicle for setting the
+/// [`Custom`] trait implementation to use when calling
+/// [`BrokenDownTime::format_with_config`]
+/// or [`BrokenDownTime::to_string_with_config`].
+///
+/// More functionality may be added in the future.
+///
+/// It is generally expected that most callers should not need to use this.
+/// At present, the only reason to use this is if you specifically need to
+/// provide locale aware formatting within the context of `strtime`-style
+/// APIs. Unless you specifically need this, you should prefer using the
+/// [`icu`] crate via [`jiff-icu`] to do type conversions. More specifically,
+/// follow the examples in the `icu::datetime` module for a modern approach
+/// to datetime localization that leverages Unicode.
+///
+/// # Example
+///
+/// This example shows how to use [`PosixCustom`] via `strtime` formatting:
+///
+/// ```
+/// use jiff::{civil, fmt::strtime::{BrokenDownTime, PosixCustom, Config}};
+///
+/// let config = Config::new().custom(PosixCustom::new());
+/// let dt = civil::date(2025, 7, 1).at(17, 30, 0, 0);
+/// let tm = BrokenDownTime::from(dt);
+/// assert_eq!(
+///     tm.to_string_with_config(&config, "%c")?,
+///     "Tue Jul  1 17:30:00 2025",
+/// );
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+///
+/// [`icu`]: https://docs.rs/icu
+/// [`jiff-icu`]: https://docs.rs/jiff-icu
+#[derive(Clone, Debug)]
+pub struct Config<C> {
+    custom: C,
+}
+
+impl Config<DefaultCustom> {
+    /// Create a new default `Config` that uses [`DefaultCustom`].
+    pub const fn new() -> Config<DefaultCustom> {
+        Config { custom: DefaultCustom::new() }
+    }
+}
+
+impl<C> Config<C> {
+    /// Set the implementation of [`Custom`] to use in `strtime`-style APIs
+    /// that use this configuration.
+    pub fn custom<U: Custom>(self, custom: U) -> Config<U> {
+        Config { custom }
+    }
+}
+
+/// An interface for customizing `strtime`-style parsing and formatting.
+///
+/// Each method on this trait comes with a default implementation corresponding
+/// to the behavior of [`DefaultCustom`]. More methods on this trait may be
+/// added in the future.
+///
+/// Implementors of this trait can be attached to a [`Config`] which can then
+/// be passed to [`BrokenDownTime::format_with_config`] or
+/// [`BrokenDownTime::to_string_with_config`].
+///
+/// New methods with default implementations may be added to this trait in
+/// semver compatible releases of Jiff.
+///
+/// # Motivation
+///
+/// While Jiff's API is generally locale-agnostic, this trait is meant to
+/// provide a best effort "hook" for tailoring the behavior of `strtime`
+/// routines. More specifically, for conversion specifiers in `strtime`-style
+/// APIs that are influenced by locale settings.
+///
+/// In general, a `strtime`-style API is not optimal for localization.
+/// It's both too flexible and not expressive enough. As a result, mixing
+/// localization with `strtime`-style APIs is likely not a good idea. However,
+/// this is sometimes required for legacy or convenience reasons, and that's
+/// why Jiff provides this hook.
+///
+/// If you do need to localize datetimes but don't have a requirement to
+/// have it integrate with `strtime`-style APIs, then you should use the
+/// [`icu`] crate via [`jiff-icu`] for type conversions. And then follow the
+/// examples in the `icu::datetime` API for formatting datetimes.
+///
+/// # Supported conversion specifiers
+///
+/// Currently, only formatting for the following specifiers is supported:
+///
+/// * `%c` - Formatting the date and time.
+/// * `%r` - Formatting the 12-hour clock time.
+/// * `%X` - Formatting the clock time.
+/// * `%x` - Formatting the date.
+///
+/// # Unsupported behavior
+///
+/// This trait currently does not support parsing based on locale in any way.
+///
+/// This trait also does not support locale specific behavior for `%a`/`%A`
+/// (day of the week), `%b/`%B` (name of the month) or `%p`/`%P` (AM or PM).
+/// Supporting these is problematic with modern localization APIs, since
+/// modern APIs do not expose options to localize these things independent of
+/// anything else. Instead, they are subsumed most holistically into, e.g.,
+/// "print the long form of a date in the current locale."
+///
+/// Since the motivation for this trait is not really to provide the best way
+/// to localize datetimes, but rather, to facilitate convenience and
+/// inter-operation with legacy systems, it is plausible that the behaviors
+/// listed above could be supported by Jiff. If you need the above behaviors,
+/// please [open a new issue](https://github.com/BurntSushi/jiff/issues/new)
+/// with a proposal.
+///
+/// # Example
+///
+/// This example shows the difference between the default locale and the
+/// POSIX locale:
+///
+/// ```
+/// use jiff::{civil, fmt::strtime::{BrokenDownTime, PosixCustom, Config}};
+///
+/// let dt = civil::date(2025, 7, 1).at(17, 30, 0, 0);
+/// let tm = BrokenDownTime::from(dt);
+/// assert_eq!(
+///     tm.to_string("%c")?,
+///     "2025 M07 1, Tue 17:30:00",
+/// );
+///
+/// let config = Config::new().custom(PosixCustom::new());
+/// assert_eq!(
+///     tm.to_string_with_config(&config, "%c")?,
+///     "Tue Jul  1 17:30:00 2025",
+/// );
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+///
+/// [`icu`]: https://docs.rs/icu
+/// [`jiff-icu`]: https://docs.rs/jiff-icu
+pub trait Custom: Sized {
+    /// Called when formatting a datetime with the `%c` flag.
+    ///
+    /// This defaults to the implementation for [`DefaultCustom`].
+    fn format_datetime<W: Write>(
+        &self,
+        config: &Config<Self>,
+        _ext: &Extension,
+        tm: &BrokenDownTime,
+        wtr: &mut W,
+    ) -> Result<(), Error> {
+        tm.format_with_config(config, "%Y M%m %-d, %a %H:%M:%S", wtr)
+    }
+
+    /// Called when formatting a datetime with the `%x` flag.
+    ///
+    /// This defaults to the implementation for [`DefaultCustom`].
+    fn format_date<W: Write>(
+        &self,
+        config: &Config<Self>,
+        _ext: &Extension,
+        tm: &BrokenDownTime,
+        wtr: &mut W,
+    ) -> Result<(), Error> {
+        // 2025 M04 27
+        tm.format_with_config(config, "%Y M%m %-d", wtr)
+    }
+
+    /// Called when formatting a datetime with the `%X` flag.
+    ///
+    /// This defaults to the implementation for [`DefaultCustom`].
+    fn format_time<W: Write>(
+        &self,
+        config: &Config<Self>,
+        _ext: &Extension,
+        tm: &BrokenDownTime,
+        wtr: &mut W,
+    ) -> Result<(), Error> {
+        tm.format_with_config(config, "%H:%M:%S", wtr)
+    }
+
+    /// Called when formatting a datetime with the `%r` flag.
+    ///
+    /// This defaults to the implementation for [`DefaultCustom`].
+    fn format_12hour_time<W: Write>(
+        &self,
+        config: &Config<Self>,
+        _ext: &Extension,
+        tm: &BrokenDownTime,
+        wtr: &mut W,
+    ) -> Result<(), Error> {
+        tm.format_with_config(config, "%-I:%M:%S %p", wtr)
+    }
+}
+
+/// The default trait implementation of [`Custom`].
+///
+/// Whenever one uses the formatting or parsing routines in this module
+/// without providing a configuration, then this customization is the one
+/// that gets used.
+///
+/// The behavior of the locale formatting of this type is meant to match that
+/// of Unicode's `und` locale.
+///
+/// # Example
+///
+/// This example shows how to explicitly use [`DefaultCustom`] via `strtime`
+/// formatting:
+///
+/// ```
+/// use jiff::{civil, fmt::strtime::{BrokenDownTime, DefaultCustom, Config}};
+///
+/// let config = Config::new().custom(DefaultCustom::new());
+/// let dt = civil::date(2025, 7, 1).at(17, 30, 0, 0);
+/// let tm = BrokenDownTime::from(dt);
+/// assert_eq!(
+///     tm.to_string_with_config(&config, "%c")?,
+///     "2025 M07 1, Tue 17:30:00",
+/// );
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct DefaultCustom(());
+
+impl DefaultCustom {
+    /// Create a new instance of this default customization.
+    pub const fn new() -> DefaultCustom {
+        DefaultCustom(())
+    }
+}
+
+impl Custom for DefaultCustom {}
+
+/// A POSIX locale implementation of [`Custom`].
+///
+/// The behavior of the locale formatting of this type is meant to match that
+/// of POSIX's `C` locale.
+///
+/// # Example
+///
+/// This example shows how to use [`PosixCustom`] via `strtime` formatting:
+///
+/// ```
+/// use jiff::{civil, fmt::strtime::{BrokenDownTime, PosixCustom, Config}};
+///
+/// let config = Config::new().custom(PosixCustom::new());
+/// let dt = civil::date(2025, 7, 1).at(17, 30, 0, 0);
+/// let tm = BrokenDownTime::from(dt);
+/// assert_eq!(
+///     tm.to_string_with_config(&config, "%c")?,
+///     "Tue Jul  1 17:30:00 2025",
+/// );
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct PosixCustom(());
+
+impl PosixCustom {
+    /// Create a new instance of this POSIX customization.
+    pub const fn new() -> PosixCustom {
+        PosixCustom(())
+    }
+}
+
+impl Custom for PosixCustom {
+    fn format_datetime<W: Write>(
+        &self,
+        config: &Config<Self>,
+        _ext: &Extension,
+        tm: &BrokenDownTime,
+        wtr: &mut W,
+    ) -> Result<(), Error> {
+        tm.format_with_config(config, "%a %b %e %H:%M:%S %Y", wtr)
+    }
+
+    fn format_date<W: Write>(
+        &self,
+        config: &Config<Self>,
+        _ext: &Extension,
+        tm: &BrokenDownTime,
+        wtr: &mut W,
+    ) -> Result<(), Error> {
+        tm.format_with_config(config, "%m/%d/%y", wtr)
+    }
+
+    fn format_time<W: Write>(
+        &self,
+        config: &Config<Self>,
+        _ext: &Extension,
+        tm: &BrokenDownTime,
+        wtr: &mut W,
+    ) -> Result<(), Error> {
+        tm.format_with_config(config, "%H:%M:%S", wtr)
+    }
+
+    fn format_12hour_time<W: Write>(
+        &self,
+        config: &Config<Self>,
+        _ext: &Extension,
+        tm: &BrokenDownTime,
+        wtr: &mut W,
+    ) -> Result<(), Error> {
+        tm.format_with_config(config, "%I:%M:%S %p", wtr)
+    }
 }
 
 /// The "broken down time" used by parsing and formatting.
@@ -694,8 +1015,59 @@ impl BrokenDownTime {
         format: impl AsRef<[u8]>,
         mut wtr: W,
     ) -> Result<(), Error> {
+        self.format_with_config(&Config::new(), format, &mut wtr)
+    }
+
+    /// Format this broken down time with a specific configuration using the
+    /// format string given.
+    ///
+    /// See the [module documentation](self) for details on what's supported.
+    ///
+    /// This routine is like [`BrokenDownTime::format`], except that it
+    /// permits callers to provide their own configuration instead of using
+    /// the default. This routine also accepts a `&mut W` instead of a `W`,
+    /// which may be more flexible in some situations.
+    ///
+    /// # Errors
+    ///
+    /// This returns an error when formatting failed. Formatting can fail
+    /// either because of an invalid format string, or if formatting requires
+    /// a field in `BrokenDownTime` to be set that isn't. For example, trying
+    /// to format a [`DateTime`] with the `%z` specifier will fail because a
+    /// `DateTime` has no time zone or offset information associated with it.
+    ///
+    /// Formatting also fails if writing to the given writer fails.
+    ///
+    /// # Example
+    ///
+    /// This example shows how to use [`PosixCustom`] to get formatting
+    /// for conversion specifiers like `%c` in the POSIX locale:
+    ///
+    /// ```
+    /// use jiff::{civil, fmt::strtime::{BrokenDownTime, PosixCustom, Config}};
+    ///
+    /// let mut buf = String::new();
+    /// let dt = civil::date(2025, 7, 1).at(17, 30, 0, 0);
+    /// let tm = BrokenDownTime::from(dt);
+    /// tm.format("%c", &mut buf)?;
+    /// assert_eq!(buf, "2025 M07 1, Tue 17:30:00");
+    ///
+    /// let config = Config::new().custom(PosixCustom::new());
+    /// buf.clear();
+    /// tm.format_with_config(&config, "%c", &mut buf)?;
+    /// assert_eq!(buf, "Tue Jul  1 17:30:00 2025");
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[inline]
+    pub fn format_with_config<W: Write, L: Custom>(
+        &self,
+        config: &Config<L>,
+        format: impl AsRef<[u8]>,
+        wtr: &mut W,
+    ) -> Result<(), Error> {
         let fmt = format.as_ref();
-        let mut formatter = Formatter { fmt, tm: self, wtr: &mut wtr };
+        let mut formatter = Formatter { config, fmt, tm: self, wtr };
         formatter.format().context("strftime formatting failed")?;
         Ok(())
     }
@@ -743,6 +1115,58 @@ impl BrokenDownTime {
     ) -> Result<alloc::string::String, Error> {
         let mut buf = alloc::string::String::new();
         self.format(format, &mut buf)?;
+        Ok(buf)
+    }
+
+    /// Format this broken down time with a specific configuration using the
+    /// format string given into a new `String`.
+    ///
+    /// See the [module documentation](self) for details on what's supported.
+    ///
+    /// This routine is like [`BrokenDownTime::to_string`], except that it
+    /// permits callers to provide their own configuration instead of using
+    /// the default.
+    ///
+    /// # Errors
+    ///
+    /// This returns an error when formatting failed. Formatting can fail
+    /// either because of an invalid format string, or if formatting requires
+    /// a field in `BrokenDownTime` to be set that isn't. For example, trying
+    /// to format a [`DateTime`] with the `%z` specifier will fail because a
+    /// `DateTime` has no time zone or offset information associated with it.
+    ///
+    /// # Example
+    ///
+    /// This example shows how to use [`PosixCustom`] to get formatting
+    /// for conversion specifiers like `%c` in the POSIX locale:
+    ///
+    /// ```
+    /// use jiff::{civil, fmt::strtime::{BrokenDownTime, PosixCustom, Config}};
+    ///
+    /// let dt = civil::date(2025, 7, 1).at(17, 30, 0, 0);
+    /// let tm = BrokenDownTime::from(dt);
+    /// assert_eq!(
+    ///     tm.to_string("%c")?,
+    ///     "2025 M07 1, Tue 17:30:00",
+    /// );
+    ///
+    /// let config = Config::new().custom(PosixCustom::new());
+    /// assert_eq!(
+    ///     tm.to_string_with_config(&config, "%c")?,
+    ///     "Tue Jul  1 17:30:00 2025",
+    /// );
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[cfg(feature = "alloc")]
+    #[inline]
+    pub fn to_string_with_config<L: Custom>(
+        &self,
+        config: &Config<L>,
+        format: impl AsRef<[u8]>,
+    ) -> Result<alloc::string::String, Error> {
+        let mut buf = alloc::string::String::new();
+        self.format_with_config(config, format, &mut buf)?;
         Ok(buf)
     }
 
@@ -2643,10 +3067,15 @@ impl From<Time> for Meridiem {
 
 /// These are "extensions" to the standard `strftime` conversion specifiers.
 ///
-/// Basically, these provide control over padding (zeros, spaces or none),
-/// how much to pad and the case of string enumerations.
-#[derive(Clone, Copy, Debug)]
-struct Extension {
+/// This type represents which flags and/or padding were provided with a
+/// specifier. For example, `%_3d` uses 3 spaces of padding.
+///
+/// Currently, this type provides no structured introspection facilities. It
+/// is exported and available only via implementations of the [`Custom`] trait
+/// for reasons of semver compatible API evolution. If you have use cases for
+/// introspecting this type, please open an issue.
+#[derive(Clone, Debug)]
+pub struct Extension {
     flag: Option<Flag>,
     width: Option<u8>,
 }

--- a/src/fmt/strtime/parse.rs
+++ b/src/fmt/strtime/parse.rs
@@ -112,6 +112,20 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
                         }
                     }
                 }
+                b'c' => {
+                    return Err(err!("cannot parse locale date and time"));
+                }
+                b'r' => {
+                    return Err(err!(
+                        "cannot parse locale 12-hour clock time"
+                    ));
+                }
+                b'X' => {
+                    return Err(err!("cannot parse locale clock time"));
+                }
+                b'x' => {
+                    return Err(err!("cannot parse locale date"));
+                }
                 b'Z' => {
                     return Err(err!("cannot parse time zone abbreviations"));
                 }
@@ -997,7 +1011,7 @@ impl Extension {
     /// input is empty.
     #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_number<'i>(
-        self,
+        &self,
         default_pad_width: usize,
         default_flag: Flag,
         mut inp: &'i [u8],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -701,6 +701,15 @@ For more, see the [`fmt::serde`] sub-module. (This requires enabling Jiff's
     ),
     deny(rustdoc::broken_intra_doc_links)
 )]
+#![cfg_attr(
+    not(all(
+        feature = "std",
+        feature = "serde",
+        feature = "static",
+        feature = "tzdb-zoneinfo"
+    )),
+    allow(rustdoc::broken_intra_doc_links)
+)]
 // These are just too annoying to squash otherwise.
 #![cfg_attr(
     not(all(


### PR DESCRIPTION
The ICU4X project seems to be slowly working toward a 2.0 release. It
is currently on `beta.2`. There are some nice improvements here, in
particular, the ability to localize zoned datetimes.

This PR migrates to ICU4X 2.0 (first commit) and then adds support for
conversions between time zones, offsets and zoned datetimes (second
commit). I've also added a basic example demonstrating how to format a
`jiff::Zoned` value.

I've also added support for `%c`, `%r`, `%X` and `%x` to `jiff::fmt::strtime`.
Since I have no plans for Jiff to do localization, and since these specifiers
are commonly implemented via localization, I've added some
infrastructure to `jiff::fmt::strtime` that enables overriding the behavior
of these specifiers. Specifically, in Biff (not yet released), I've used this
trait with ICU4X to provide localized datetime formatting.

I'm somewhat conflicted about adding a hook for localization into
`strtime`-style APIs. In particular, the ideal way to do localization is
just by using ICU4X directly. By doing it through `strftime`, you're
somewhat limiting yourself quite a bit. But it can be quite
convenient, and it can be important if one is trying to build or
integrate with legacy APIs like POSIX. To mitigate this, I've added
documentation warning folks against using this functionality, and
instead pointing them toward ICU4X.

I also did some work optimizing `strftime` in this PR, spurred by
https://github.com/uutils/coreutils/issues/7852.

Here's the improvement from this PR for Jiff:

```
$ critcmp base change1 -f jiff
group                          base                                   change1
-----                          ----                                   -------
parse/strptime/oneshot/jiff    1.01     59.9±0.88ns        ? ?/sec    1.00     59.2±0.71ns        ? ?/sec
print/strftime/oneshot/jiff    1.74    174.7±1.45ns        ? ?/sec    1.00    100.6±0.39ns        ? ?/sec
```

And relative to `chrono` and `time` (a little tricky to read this output since we distinguish between `prebuilt` and `oneshot`, and it is appropriate to compare Jiff's `oneshot` with Chrono's `prebuilt`, since Jiff doesn't have a `prebuilt` API):

```
$ critcmp change1 -g '(.*)/(?:humantime|jiff|chrono|time)$'
group                      change1//chrono                        change1//jiff                          change1//time
-----                      ---------------                        -------------                          -------------
parse/strptime/oneshot     2.86    169.2±2.63ns        ? ?/sec    1.00     59.2±0.71ns        ? ?/sec
parse/strptime/prebuilt    1.00     81.6±0.93ns        ? ?/sec                                           1.36    110.9±0.85ns        ? ?/sec
print/strftime/oneshot     2.13    214.7±3.63ns        ? ?/sec    1.00    100.6±0.39ns        ? ?/sec
print/strftime/prebuilt    1.00     89.3±0.77ns        ? ?/sec                                           1.14    101.7±0.87ns        ? ?/sec
```