### PR TITLE
fmt/rfc2822: fix handling whitespace at comma and time separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Add a "lenient" mode for `strtime` formatting APIs that ignores most errors.
 
 Bug fixes:
 
+* [#340](https://github.com/BurntSushi/jiff/issues/340):
+Allow whitespace in more places in RFC 2822 parser (improves spec compliance).
 * [#346](https://github.com/BurntSushi/jiff/issues/346):
 `TimeZone::get("UTC")` should now always return `TimeZone::UTC`.
 


### PR DESCRIPTION
RFC2822 allows some unusual whitespace configurations which weren't covered previously. In particular, these two cases are now handled properly according to spec:

(1) Whitespace is allowed, but may also be completely omitted, on both sides of the `,` following the weekday;
(2) Whitespace is allowed around the time separators (`:`).

Fixes #339

---

# Implementation notes

1. I changed `skip_whitespace` to return a `bool` whether whitespace was actually encountered. This saved some extra checks in parsing the time, and made `parse_whitespace` slightly cleaner.
1. I'm not that familiar with advanced error handling in Rust (`.with_context`), but I tried my best to keep the same errors as before.
1. I added an extra test to ensure there's whitespace between the time (in minute precision) and timezone. This is easy to miss in the implementation now that whitespace after minute is sometimes required, sometimes not. This test wasn't a good fit for any test method, so I put it in `err_parse_invalid`