### PR TITLE
tz: make bundled database return `TimeZone::UTC` when appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Enhancements:
 * [#338](https://github.com/BurntSushi/jiff/pull/338):
 Add support for the `%c`, `%r`, `%X` and `%x` conversion specifiers.
 
+Bug fixes:
+
+* [#346](https://github.com/BurntSushi/jiff/issues/346):
+`TimeZone::get("UTC")` should now always return `TimeZone::UTC`.
+
 Performance:
 
 * [#338](https://github.com/BurntSushi/jiff/pull/338):

--- a/src/tz/db/bundled/enabled.rs
+++ b/src/tz/db/bundled/enabled.rs
@@ -1,4 +1,4 @@
-use crate::tz::{TimeZone, TimeZoneNameIter};
+use crate::tz::{db::special_time_zone, TimeZone, TimeZoneNameIter};
 
 pub(crate) struct Database;
 
@@ -17,10 +17,8 @@ impl Database {
         if let Some(tz) = self::global::get(name) {
             return Some(tz);
         }
-        // Check for the special `Etc/Unknown` value, which isn't in the
-        // IANA time zone database.
-        if name == "Etc/Unknown" {
-            return Some(TimeZone::unknown());
+        if let Some(tz) = special_time_zone(name) {
+            return Some(tz);
         }
         let (canonical_name, tzif) = lookup(name)?;
         let tz = match TimeZone::tzif(canonical_name, tzif) {

--- a/src/tz/timezone.rs
+++ b/src/tz/timezone.rs
@@ -400,6 +400,10 @@ impl TimeZone {
     /// the given time zone identifier. It uses the default global time zone
     /// database via [`tz::db()`](crate::tz::db()).
     ///
+    /// It is guaranteed that if the given time zone name is case insensitively
+    /// equivalent to `UTC`, then the time zone returned will be equivalent to
+    /// `TimeZone::UTC`. Similarly for `Etc/Unknown` and `TimeZone::unknown()`.
+    ///
     /// # Errors
     ///
     /// This returns an error if the given time zone identifier could not be


### PR DESCRIPTION
Previously, this was not being special cased, which in turn read `UTC`
like any other time zone. But really, we should be returning
`TimeZone::UTC` when and if we know that the time zone is actually
`UTC`.

Fixes #346
