### PR TITLE
fmt/strtime: add support for `%::z` and `%:::z`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Enhancements:
 Add support for the `%c`, `%r`, `%X` and `%x` conversion specifiers.
 * [#341](https://github.com/BurntSushi/jiff/issues/341):
 Add support for `%q` in `jiff::fmt::strtime` (prints quarter of year).
+* [#342](https://github.com/BurntSushi/jiff/issues/342):
+Add support for `%::z` and `%:::z` in `jiff::fmt::strtime`.
 * [#344](https://github.com/BurntSushi/jiff/issues/344):
 Add support for `%N` in `jiff::fmt::strtime` (alias for `%9f`).
 

--- a/src/fmt/strtime/format.rs
+++ b/src/fmt/strtime/format.rs
@@ -1149,6 +1149,7 @@ mod tests {
 
         insta::assert_snapshot!(f("%N", mk(123_000_000)), @"123000000");
         insta::assert_snapshot!(f("%N", mk(0)), @"000000000");
+        insta::assert_snapshot!(f("%N", mk(000_123_000)), @"000123000");
         insta::assert_snapshot!(f("%3N", mk(0)), @"000");
         insta::assert_snapshot!(f("%3N", mk(123_000_000)), @"123");
         insta::assert_snapshot!(f("%6N", mk(123_000_000)), @"123000");

--- a/src/fmt/strtime/mod.rs
+++ b/src/fmt/strtime/mod.rs
@@ -166,7 +166,7 @@ strings, the strings are matched without regard to ASCII case.
 | `%D` | `7/14/24` | Equivalent to `%m/%d/%y`. |
 | `%d`, `%e` | `25`, ` 5` | The day of the month. `%d` is zero-padded, `%e` is space padded. |
 | `%F` | `2024-07-14` | Equivalent to `%Y-%m-%d`. |
-| `%f`, `%N` | `000456` | Fractional seconds, up to nanosecond precision. |
+| `%f` | `000456` | Fractional seconds, up to nanosecond precision. |
 | `%.f` | `.000456` | Optional fractional seconds, with dot, up to nanosecond precision. |
 | `%G` | `2024` | An [ISO 8601 week-based] year. Zero padded to 4 digits. |
 | `%g` | `24` | A two-digit [ISO 8601 week-based] year. Represents only 1969-2068. Zero padded. |
@@ -177,6 +177,7 @@ strings, the strings are matched without regard to ASCII case.
 | `%l` | ` 3` | The hour in a 12 hour clock. Space padded. |
 | `%M` | `04` | The minute. Zero padded. |
 | `%m` | `01` | The month. Zero padded. |
+| `%N` | `123456000` | Fractional seconds, up to nanosecond precision. Alias for `%9f`. |
 | `%n` | `\n` | Formats as a newline character. Parses arbitrary whitespace. |
 | `%P` | `am` | Whether the time is in the AM or PM, lowercase. |
 | `%p` | `PM` | Whether the time is in the AM or PM, uppercase. |

--- a/src/fmt/strtime/parse.rs
+++ b/src/fmt/strtime/parse.rs
@@ -660,9 +660,9 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
         Ok(())
     }
 
-    /// Parses `%f` (or `%N`, which is an alias), which is equivalent to a
-    /// fractional second up to nanosecond precision. This must always parse at
-    /// least one decimal digit and does not parse any leading dot.
+    /// Parses `%f` (or `%N`, which is an alias for `%9f`), which is equivalent
+    /// to a fractional second up to nanosecond precision. This must always
+    /// parse at least one decimal digit and does not parse any leading dot.
     ///
     /// At present, we don't use any flags/width/precision settings to
     /// influence parsing. That is, `%3f` will parse the fractional component

--- a/src/fmt/strtime/parse.rs
+++ b/src/fmt/strtime/parse.rs
@@ -1804,6 +1804,50 @@ mod tests {
     }
 
     #[test]
+    fn ok_parse_offset() {
+        let p = |fmt: &str, input: &str| {
+            BrokenDownTime::parse_mono(fmt.as_bytes(), input.as_bytes())
+                .unwrap()
+                .to_offset()
+                .unwrap()
+        };
+
+        insta::assert_debug_snapshot!(
+            p("%z", "+0530"),
+            @"05:30:00",
+        );
+        insta::assert_debug_snapshot!(
+            p("%z", "-0530"),
+            @"-05:30:00",
+        );
+        insta::assert_debug_snapshot!(
+            p("%z", "-0500"),
+            @"-05:00:00",
+        );
+        insta::assert_debug_snapshot!(
+            p("%z", "+053015"),
+            @"05:30:15",
+        );
+
+        insta::assert_debug_snapshot!(
+            p("%:z", "+05:30"),
+            @"05:30:00",
+        );
+        insta::assert_debug_snapshot!(
+            p("%:z", "-05:30"),
+            @"-05:30:00",
+        );
+        insta::assert_debug_snapshot!(
+            p("%:z", "-05:00"),
+            @"-05:00:00",
+        );
+        insta::assert_debug_snapshot!(
+            p("%:z", "+05:30:15"),
+            @"05:30:15",
+        );
+    }
+
+    #[test]
     fn err_parse() {
         let p = |fmt: &str, input: &str| {
             BrokenDownTime::parse_mono(fmt.as_bytes(), input.as_bytes())
@@ -2094,6 +2138,33 @@ mod tests {
         insta::assert_snapshot!(
             p("%H:%S", "15:59"),
             @"parsing format did not include minute directive, but did include second directive (cannot have smaller time units with bigger time units missing)",
+        );
+    }
+
+    #[test]
+    fn err_parse_offset() {
+        let p = |fmt: &str, input: &str| {
+            BrokenDownTime::parse_mono(fmt.as_bytes(), input.as_bytes())
+                .unwrap_err()
+                .to_string()
+        };
+
+        insta::assert_snapshot!(
+            p("%z", "+05:30"),
+            @"strptime parsing failed: %z failed: failed to parse minutes from time zone offset 05:3: invalid digit, expected 0-9 but got :",
+        );
+        insta::assert_snapshot!(
+            p("%:z", "+0530"),
+            @"strptime parsing failed: %:z failed: expected at least HH:MM digits for time zone offset after sign, but found only 4 bytes remaining",
+        );
+
+        insta::assert_snapshot!(
+            p("%z", "+05"),
+            @"strptime parsing failed: %z failed: expected at least 4 digits for time zone offset after sign, but found only 2 bytes remaining",
+        );
+        insta::assert_snapshot!(
+            p("%:z", "+05"),
+            @"strptime parsing failed: %:z failed: expected at least HH:MM digits for time zone offset after sign, but found only 2 bytes remaining",
         );
     }
 }


### PR DESCRIPTION
These are also motivated by their presence in GNU date. They are
basically just different ways of printing offsets from UTC.

We do some light refactoring to DRY up the code a bit, and to make it a
little nicer to handle a variable number (up to a fixed size limit) of
`:` characters preceding a directive.

This is honestly just a giant clusterfuck (who thinks having `%z`,
`%:z`, `%::z` and `%:::z` is a nice user experience!?!?), but so is
`strptime`/`strftime` I guess. Oh well.

Closes #342
