### PR TITLE
fmt/strtime: add "lenient" mode for `strtime` formatting APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Add support for `%q` in `jiff::fmt::strtime` (prints quarter of year).
 Add support for `%::z` and `%:::z` in `jiff::fmt::strtime`.
 * [#344](https://github.com/BurntSushi/jiff/issues/344):
 Add support for `%N` in `jiff::fmt::strtime` (alias for `%9f`).
+* [#350](https://github.com/BurntSushi/jiff/issues/350):
+Add a "lenient" mode for `strtime` formatting APIs that ignores most errors.
 
 Bug fixes:
 


### PR DESCRIPTION
This is another (IMO) cursed API meant to provide some measure of
compatibility with GNU date: a mode that specifically ignores errors
when formatting datetimes using `jiff::fmt::strtime`.

For example, neither `%0` nor `%+` are valid conversion specifiers
supported by Jiff. By default, using those will result in an error. But
with the new lenient mode (which you need to opt into), no error will
occur and instead `%0` and `%+` just get written literally as-is in the
returned string.

This applies to other kinds of errors. For example, if you use `%z` with
a `BrokenDownTime` that doesn't contain an offset, then that would
normally result in an error. But in lenient mode, it just results in
`%z` being written literally.

The docs for this mode contain a strongly worded warning to avoid
enabling this. It's makes for a terrible user experience because it
squashes failures without so much as a peep. The *only* reason anyone
should enable it is for when strict compatibility with other software
is necessary.

Closes #350
