### PR TITLE
fmt/temporal: ensure that `1970-06-01T00-00:45:00[Africa/Monrovia]` does not parse successfully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+0.2.12 (TBD)
+============
+TODO
+
+Bug fixes:
+
+* [#357](https://github.com/BurntSushi/jiff/issues/357):
+Fix a bug where parsing `1970-06-01T00-00:45:00[Africa/Monrovia]` succeeded
+but it should fail.
+
+
 0.2.11 (2025-05-01)
 ===================
 This release includes new APIs for customizing Jiff's `strtime` behavior along

--- a/src/fmt/offset.rs
+++ b/src/fmt/offset.rs
@@ -181,6 +181,14 @@ impl ParsedOffset {
     pub(crate) fn is_zulu(&self) -> bool {
         matches!(self.kind, ParsedOffsetKind::Zulu)
     }
+
+    /// Whether the parsed offset had an explicit sub-minute component or not.
+    pub(crate) fn has_subminute(&self) -> bool {
+        let ParsedOffsetKind::Numeric(ref numeric) = self.kind else {
+            return false;
+        };
+        numeric.seconds.is_some()
+    }
 }
 
 /// The kind of a parsed offset.

--- a/src/fmt/temporal/parser.rs
+++ b/src/fmt/temporal/parser.rs
@@ -119,7 +119,17 @@ impl<'i> ParsedDateTime<'i> {
             }
             // If the candidate offset we're considering is a whole minute,
             // then we never need rounding.
-            if candidate.part_seconds_ranged() == C(0) {
+            //
+            // Alternatively, if the parsed offset has an explicit sub-minute
+            // component (even if it's zero), we should use exact equality.
+            // (The error message for this case when "reject" offset
+            // conflict resolution is used is not the best. But this case
+            // is stupidly rare, so I'm not sure it's worth the effort to
+            // improve the error message. I'd be open to a simple patch
+            // though.)
+            if candidate.part_seconds_ranged() == C(0)
+                || parsed_offset.has_subminute()
+            {
                 return parsed == candidate;
             }
             let Ok(candidate) = candidate.round(Unit::Minute) else {

--- a/src/tz/offset.rs
+++ b/src/tz/offset.rs
@@ -1940,6 +1940,23 @@ impl OffsetConflict {
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    ///
+    /// Rounding does not occur when the parsed offset itself contains
+    /// sub-minute precision. In that case, exact equality is used:
+    ///
+    /// ```
+    /// use jiff::{tz::Offset, Zoned};
+    ///
+    /// let result = "1970-06-01T00-00:45:00[Africa/Monrovia]".parse::<Zoned>();
+    /// assert_eq!(
+    ///     result.unwrap_err().to_string(),
+    ///     "parsing \"1970-06-01T00-00:45:00[Africa/Monrovia]\" failed: \
+    ///      datetime 1970-06-01T00:00:00 could not resolve to a timestamp \
+    ///      since 'reject' conflict resolution was chosen, and because \
+    ///      datetime has offset -00:45, but the time zone Africa/Monrovia \
+    ///      for the given datetime unambiguously has offset -00:44:30",
+    /// );
+    /// ```
     pub fn resolve_with<F>(
         self,
         dt: civil::DateTime,


### PR DESCRIPTION
Previously we were allowing this through since we didn't distinguish
between `-00:45` and `-00:45:00` when checking offset equality. In the
former case, we round the actual offset (which is `-00:44:30` in this
case), and if it matches the provided offset, we allow it. But in the
latter case, we *should* respect the precision specified in the string
and perform exact equality.

We fix this by just querying the parsed structure to see if a second
component was actually parsed or not. If it was, we do exact equality.

(For context, this is only an issue because Temporal, and also Jiff,
generally only support time zone offsets up to minute precision when
formatting. This reflects what RFC 3339 and RFC 9557 support. However,
we still support *parsing* offsets with sub-minute precision. To make
everything consistent and round-trip, we permit rounding as a means to
test offset equality when a time zone offset has sub-minute precision
but a parsed offset does not.)

Fixes #357