### PR TITLE
cargo: fix compilation when only `tzdb-concatenated` is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+0.2.14 (TBD)
+============
+TODO
+
+Bug fixes:
+
+* [#365](https://github.com/BurntSushi/jiff/issues/365):
+Fixes a compile error in Jiff when only the `tzdb-concatenated` feature was
+enabled.
+
+
 0.2.13 (2025-05-05)
 ===================
 This release fixes a bug in a corner case where `TimeZone::following` could

--- a/scripts/test-various-feature-combos
+++ b/scripts/test-various-feature-combos
@@ -17,6 +17,7 @@ features=(
     "std tzdb-bundle-always tzdb-zoneinfo"
     "std tzdb-bundle-always logging"
     "std tzdb-bundle-always serde"
+    "std tzdb-concatenated"
 )
 for f in "${features[@]}"; do
     echo "===== FEATURES: '$f' ====="

--- a/src/error.rs
+++ b/src/error.rs
@@ -197,9 +197,7 @@ impl Error {
     ///
     /// This is a convenience routine for calling `Error::context` with a
     /// `FilePathError`.
-    ///
-    /// This is only available when the `std` feature is enabled.
-    #[cfg(feature = "tzdb-zoneinfo")]
+    #[cfg(any(feature = "tzdb-zoneinfo", feature = "tzdb-concatenated"))]
     pub(crate) fn path(self, path: impl Into<std::path::PathBuf>) -> Error {
         let err = Error::from(ErrorKind::FilePath(FilePathError {
             path: path.into(),


### PR DESCRIPTION
The problem was an incorrect `cfg`. And, of course, that this feature
combination wasn't being tested. That has been fixed too.

Fixes #365
