### PR TITLE
tz: improve performance of initial `Zoned::now()`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,6 +367,28 @@ jobs:
     - name: Build all examples
       run: ./scripts/test-integrations
 
+  # A test to ensure that `Zoned::now()` doesn't take "too long" on its
+  # first run.
+  time-zone-init:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - os: ubuntu-latest
+        - os: ubuntu-24.04-arm
+        - os: macos-latest
+        - os: windows-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+    - run: cargo test --test integration init::zoned_now -- --nocapture
+
+
   # Generic testing for most cross targets. Some get special treatment in
   # other jobs.
   cross:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Bug fixes:
 * [#365](https://github.com/BurntSushi/jiff/issues/365):
 Fixes a compile error in Jiff when only the `tzdb-concatenated` feature was
 enabled.
+* [#366](https://github.com/BurntSushi/jiff/issues/366):
+Fixes slow initial `Zoned::now()` in environments where `/usr/share/zoneinfo`
+is on a very slow file system (like CI environments).
 
 
 0.2.13 (2025-05-05)

--- a/tests/init/mod.rs
+++ b/tests/init/mod.rs
@@ -1,0 +1,46 @@
+use std::time::{Duration, Instant};
+
+use jiff::Zoned;
+
+/// This test is meant to be run on its own as the only thing in a CI job.
+///
+/// It's supposed to test how long it takes for the first call to
+/// `Zoned::now()` to run. The specific problem is that, when this test was
+/// written, Jiff would walk `/usr/share/zoneinfo` and catalog all time zones
+/// in that directory. While this is generally not much of a problem, it can be
+/// on a very slow file system. In particular, this can evolve a few syscalls
+/// per file, and there might be a couple thousand files inside the directory.
+/// Moreover, Jiff was doing a 4-byte read of each file to check if it was TZif
+/// or not.
+///
+/// Ref: https://github.com/BurntSushi/jiff/issues/366
+#[cfg(feature = "std")]
+#[test]
+fn zoned_now() {
+    let start = Instant::now();
+    println!("{}", Zoned::now());
+    let first = Instant::now().duration_since(start);
+    println!("first-run-elapsed-microseconds:{}", first.as_micros());
+
+    let start = Instant::now();
+    println!("{}", Zoned::now());
+    let second = Instant::now().duration_since(start);
+    println!("second-run-elapsed-microseconds:{}", second.as_micros());
+
+    // These are somewhat arbitrary, but if `Zoned::now()` starts
+    // going above 100ms (even in slow CI), then it probably makes
+    // sense to investigate. At time of writing (2025-05-09), the
+    // biggest time observed here was ~33ms.
+    assert!(
+        first < Duration::from_millis(100),
+        "first `Zoned::now()` call should complete in less than 100ms",
+    );
+    // The second call should run soon enough that the cached
+    // directory traversal results are still valid. So this should
+    // be extremely fast. Ideally even less than 1µs, but we give
+    // CI wide latitude.
+    assert!(
+        second < Duration::from_millis(1),
+        "second `Zoned::now()` call should complete in less than 1ms",
+    );
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,5 +1,6 @@
 // See: https://github.com/rust-lang/rust/pull/121364
 #![allow(unknown_lints, ambiguous_negative_literals)]
 
+mod init;
 mod procmacro;
 mod tc39_262;


### PR DESCRIPTION
Specifically, this improves performance in the case of
`/usr/share/zoneinfo` being on a slow file system. Namely, #366 reports
cases (in CI) where this initialization could take multiple seconds.

In this commit, we remove the file reads---but keep the directory
traversal---for validating files in `/usr/share/zoneinfo` as TZif data.
Namely, it is common that while _most_ files in a zoneinfo directory are
valid TZif, not all are.

The reason for keeping the initial directory traversal is that it
simplifies the implementation for case insensitive time zone identifier
lookups. Without the IDs in memory, doing a case insensitive lookup on
the file system becomes much harder. Especially since IANA time zone
identifiers use mixed case and I believe there is no algorithmic way to
normalize them. If we do need to get rid of the initial directory scan,
we'll likely need to reframe the `TimeZoneDatabase::available()` API as
potentially returning strings that aren't valid identifiers, or do some
kind of data dependent normalization techniques. (Which may need to be
updated as new releases of tzdb come out.)

In any case, removing the 4-byte file reads seems to dramatically cut
down initialization time. From multiple seconds to 33ms in the slowest
case. In particular, the directory traversal is now done in a way where
the number of syscalls on Unix should be about equivalent to the number
of directories in `/usr/share/zoneinfo` and *not* the number of files.

We also add a test for a slow initial `Zoned::now()` call.

Fixes #366 