### PR TITLE
tz: don't search for tzdb at /usr/share/zoneinfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ enabled.
 * [#366](https://github.com/BurntSushi/jiff/issues/366):
 Fixes slow initial `Zoned::now()` in environments where `/usr/share/zoneinfo`
 is on a very slow file system (like CI environments).
+* [#376](https://github.com/BurntSushi/jiff/issues/376):
+Avoids searching for a tzdb at `/usr/share/zoneinfo` on Windows.
 
 
 0.2.13 (2025-05-05)

--- a/src/tz/db/zoneinfo/enabled.rs
+++ b/src/tz/db/zoneinfo/enabled.rs
@@ -28,8 +28,17 @@ use crate::{
 
 const DEFAULT_TTL: Duration = Duration::new(5 * 60, 0);
 
+#[cfg(unix)]
 static ZONEINFO_DIRECTORIES: &[&str] =
     &["/usr/share/zoneinfo", "/usr/share/lib/zoneinfo", "/etc/zoneinfo"];
+
+// In non-Unix environments, there is (as of 2025-05-17) no standard location
+// for the zoneinfo database. And we specifically do not search the Unix-style
+// directories because this can have weird and undesirable effects on Windows.
+//
+// Ref https://github.com/BurntSushi/jiff/issues/376
+#[cfg(not(unix))]
+static ZONEINFO_DIRECTORIES: &[&str] = &[];
 
 pub(crate) struct Database {
     dir: Option<PathBuf>,


### PR DESCRIPTION
Using Unix-style paths in a Windows environment doesn't really work like
you'd expect. Namely, they are interpreted relative to the current
drive. Changing which tzdb Jiff uses based on the current drive seems
undesirable. Moreover, there aren't any (AFAIK) standard locations for
the tzdb on Windows.

Note that Jiff will still respect `TZDIR` on Windows.

Fixes #376
