### PR TITLE
ci: disable doc tests for cross compilation jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,7 +432,7 @@ jobs:
     # Note that I also have a very manual testing setup for Android:
     # https://github.com/BurntSushi/tauri-jiff
     - if: "!contains(matrix.target, 'android')"
-      run: cross test --verbose --target ${{ matrix.target }} --all
+      run: cross test --verbose --target ${{ matrix.target }} --all --all-targets
     - if: "!contains(matrix.target, 'android')"
       run: cross test --verbose --target ${{ matrix.target }} -p jiff-cli
 


### PR DESCRIPTION
These were recently made available. In theory it would be nice to test
these, but it would require some tedious work and would likely balloon
CI times.
