### PR TITLE
lint: fix a variety of warnings

### DIFF
--- a/COMPARE.md
+++ b/COMPARE.md
@@ -100,7 +100,7 @@ your system's copy of the Time Zone Database.
 
 ```rust
 use anyhow::Context;
-use chrono::{NaiveDate, NaiveDateTime, NaiveTime, TimeZone};
+use chrono::TimeZone;
 use tzfile::Tz;
 
 #[cfg(unix)]
@@ -884,7 +884,7 @@ DST safe arithmetic. Instead, the code above should be written like this
 (unless you have a very specific reason to do otherwise):
 
 ```rust
-use jiff::{civil::date, Unit, Zoned};
+use jiff::{civil::date, Unit};
 
 fn main() -> anyhow::Result<()> {
     // Can also use `.to_zoned(TimeZone::system())` to use your system's
@@ -931,7 +931,7 @@ The `time` crate has no rounding APIs.
 With Jiff, you can add durations with calendar units:
 
 ```rust
-use jiff::{civil::date, ToSpan, Unit};
+use jiff::{civil::date, ToSpan};
 
 fn main() -> anyhow::Result<()> {
     let zdt1 = date(2024, 7, 11).at(21, 0, 0, 0).in_tz("America/New_York")?;

--- a/src/civil/datetime.rs
+++ b/src/civil/datetime.rs
@@ -674,7 +674,7 @@ impl DateTime {
     /// manifests from a specific timestamp.
     ///
     /// ```
-    /// use jiff::{civil, Timestamp};
+    /// use jiff::Timestamp;
     ///
     /// // 1,234 nanoseconds after the Unix epoch.
     /// let zdt = Timestamp::new(0, 1_234)?.in_tz("UTC")?;

--- a/src/civil/time.rs
+++ b/src/civil/time.rs
@@ -534,7 +534,7 @@ impl Time {
     /// manifests from a specific timestamp.
     ///
     /// ```
-    /// use jiff::{civil, Timestamp};
+    /// use jiff::Timestamp;
     ///
     /// // 1,234 nanoseconds after the Unix epoch.
     /// let zdt = Timestamp::new(0, 1_234)?.in_tz("UTC")?;

--- a/src/fmt/friendly/mod.rs
+++ b/src/fmt/friendly/mod.rs
@@ -177,7 +177,7 @@ much detail." You can remove this by rounding the `Span` to the nearest half
 hour before printing:
 
 ```
-use jiff::{civil, RoundMode, ToSpan, Unit, ZonedDifference};
+use jiff::{civil, RoundMode, Unit, ZonedDifference};
 
 let commented_at = civil::date(2024, 8, 1).at(19, 29, 13, 123_456_789).in_tz("US/Eastern")?;
 let now = civil::date(2024, 12, 26).at(12, 49, 0, 0).in_tz("US/Eastern")?;

--- a/src/fmt/strtime/mod.rs
+++ b/src/fmt/strtime/mod.rs
@@ -381,7 +381,7 @@ pub fn parse(
 /// 2822 datetime:
 ///
 /// ```
-/// use jiff::{civil::date, fmt::strtime, tz};
+/// use jiff::{civil::date, fmt::strtime};
 ///
 /// let zdt = date(2024, 7, 15).at(16, 24, 59, 0).in_tz("America/New_York")?;
 /// let string = strtime::format("%a, %-d %b %Y %T %z", &zdt)?;
@@ -401,7 +401,7 @@ pub fn parse(
 /// this is what it looks like on my system:
 ///
 /// ```
-/// use jiff::{civil::date, fmt::strtime, tz};
+/// use jiff::{civil::date, fmt::strtime};
 ///
 /// let zdt = date(2024, 7, 15).at(16, 24, 59, 0).in_tz("America/New_York")?;
 /// let string = strtime::format("%a %b %e %I:%M:%S %p %Z %Y", &zdt)?;
@@ -413,7 +413,7 @@ pub fn parse(
 /// # Example: RFC 3339 compatible output with fractional seconds
 ///
 /// ```
-/// use jiff::{civil::date, fmt::strtime, tz};
+/// use jiff::{civil::date, fmt::strtime};
 ///
 /// let zdt = date(2024, 7, 15)
 ///     .at(16, 24, 59, 123_456_789)
@@ -2861,7 +2861,7 @@ impl BrokenDownTime {
     /// time zone, but where one wants to set a time zone based on the context.
     ///
     /// ```
-    /// use jiff::{fmt::strtime::BrokenDownTime, tz::Offset};
+    /// use jiff::{fmt::strtime::BrokenDownTime};
     ///
     /// let mut tm = BrokenDownTime::parse(
     ///     "%Y-%m-%d at %H:%M:%S",
@@ -2887,7 +2887,7 @@ impl BrokenDownTime {
     /// result printed is non-sensical:
     ///
     /// ```
-    /// use jiff::{civil::date, fmt::strtime::BrokenDownTime, tz};
+    /// use jiff::{civil::date, fmt::strtime::BrokenDownTime};
     ///
     /// let zdt = date(2024, 8, 28).at(14, 56, 0, 0).in_tz("US/Eastern")?;
     /// let mut tm = BrokenDownTime::from(&zdt);
@@ -3079,7 +3079,7 @@ impl From<Time> for BrokenDownTime {
 /// [`Zoned::strftime`]:
 ///
 /// ```
-/// use jiff::{civil::date, fmt::strtime, tz};
+/// use jiff::civil::date;
 ///
 /// let zdt = date(2024, 7, 15).at(16, 24, 59, 0).in_tz("America/New_York")?;
 /// let string = zdt.strftime("%a, %-d %b %Y %T %z").to_string();
@@ -3091,7 +3091,7 @@ impl From<Time> for BrokenDownTime {
 /// Or use it directly when writing to something:
 ///
 /// ```
-/// use jiff::{civil::date, fmt::strtime, tz};
+/// use jiff::{civil::date, fmt::strtime};
 ///
 /// let zdt = date(2024, 7, 15).at(16, 24, 59, 0).in_tz("America/New_York")?;
 ///

--- a/src/fmt/temporal/mod.rs
+++ b/src/fmt/temporal/mod.rs
@@ -962,7 +962,7 @@ impl DateTimeParser {
     /// # Example
     ///
     /// ```
-    /// use jiff::{fmt::temporal::DateTimeParser, tz::{self, TimeZone}};
+    /// use jiff::{fmt::temporal::DateTimeParser, tz::TimeZone};
     ///
     /// static PARSER: DateTimeParser = DateTimeParser::new();
     ///
@@ -1535,7 +1535,7 @@ impl DateTimePrinter {
     /// # Example
     ///
     /// ```
-    /// use jiff::{fmt::temporal::DateTimePrinter, tz::{self, TimeZone}};
+    /// use jiff::{fmt::temporal::DateTimePrinter, tz::TimeZone};
     ///
     /// const PRINTER: DateTimePrinter = DateTimePrinter::new();
     ///

--- a/src/signed_duration.rs
+++ b/src/signed_duration.rs
@@ -70,7 +70,7 @@ use crate::util::libm::Float;
 /// then convert them to a `SignedDuration` by providing a relative date:
 ///
 /// ```
-/// use jiff::{civil::date, SignedDuration, Span};
+/// use jiff::{civil::date, Span};
 ///
 /// let span: Span = "P1d".parse()?;
 /// let relative = date(2024, 11, 3).in_tz("US/Eastern")?;

--- a/src/tz/ambiguous.rs
+++ b/src/tz/ambiguous.rs
@@ -397,7 +397,7 @@ impl AmbiguousTimestamp {
     /// # Example
     ///
     /// ```
-    /// use jiff::{civil::date, tz::{self, AmbiguousOffset}};
+    /// use jiff::{civil::date, tz};
     ///
     /// let tz = tz::db().get("America/New_York")?;
     ///
@@ -959,7 +959,7 @@ impl AmbiguousZoned {
     /// # Example
     ///
     /// ```
-    /// use jiff::{civil::date, tz::{self, AmbiguousOffset}};
+    /// use jiff::{civil::date, tz};
     ///
     /// let tz = tz::db().get("America/New_York")?;
     ///

--- a/src/tz/mod.rs
+++ b/src/tz/mod.rs
@@ -39,7 +39,7 @@ conversion from a [`Timestamp`](crate::Timestamp) to a [`Zoned`](crate::Zoned)
 is infallible:
 
 ```
-use jiff::{tz::TimeZone, Timestamp, Zoned};
+use jiff::{tz::TimeZone, Timestamp};
 
 let tz = TimeZone::get("America/New_York")?;
 let ts = Timestamp::UNIX_EPOCH;

--- a/src/tz/offset.rs
+++ b/src/tz/offset.rs
@@ -1945,7 +1945,7 @@ impl OffsetConflict {
     /// sub-minute precision. In that case, exact equality is used:
     ///
     /// ```
-    /// use jiff::{tz::Offset, Zoned};
+    /// use jiff::Zoned;
     ///
     /// let result = "1970-06-01T00-00:45:00[Africa/Monrovia]".parse::<Zoned>();
     /// assert_eq!(

--- a/src/tz/timezone.rs
+++ b/src/tz/timezone.rs
@@ -753,7 +753,7 @@ impl TimeZone {
     /// As mentioned above, consider using `Zoned` instead:
     ///
     /// ```
-    /// use jiff::{tz::TimeZone, Timestamp};
+    /// use jiff::Timestamp;
     ///
     /// let zdt = Timestamp::UNIX_EPOCH.in_tz("Europe/Rome")?;
     /// assert_eq!(zdt.datetime().to_string(), "1970-01-01T01:00:00");
@@ -782,7 +782,7 @@ impl TimeZone {
     /// # Example
     ///
     /// ```
-    /// use jiff::{tz::{self, Dst, TimeZone}, Timestamp};
+    /// use jiff::{tz::{self, TimeZone}, Timestamp};
     ///
     /// let tz = TimeZone::get("America/New_York")?;
     ///
@@ -2420,11 +2420,6 @@ mod repr {
     /// The strict provenance APIs in `core` were stabilized in Rust 1.84,
     /// but it will likely be a while before Jiff can use them. (At time of
     /// writing, 2025-02-24, Jiff's MSRV is Rust 1.70.)
-    ///
-    /// The `const` requirement is also why these are non-generic free
-    /// functions and not defined via an extension trait. It's also why we
-    /// don't have the useful `map_addr` routine (which is directly relevant to
-    /// our pointer tagging use case).
     mod polyfill {
         pub(super) const fn without_provenance(addr: usize) -> *const u8 {
             // SAFETY: Every valid `usize` is also a valid pointer (but not
@@ -2433,7 +2428,10 @@ mod repr {
             // MSRV(1.84): We *really* ought to be using
             // `core::ptr::without_provenance` here, but Jiff's MSRV prevents
             // us.
-            unsafe { core::mem::transmute(addr) }
+            #[allow(integer_to_ptr_transmutes)]
+            unsafe {
+                core::mem::transmute(addr)
+            }
         }
 
         // On Rust 1.84+, `StrictProvenancePolyfill` isn't actually used.


### PR DESCRIPTION
Mostly these were just unused imports in doc tests. Such warnings are
practically invisible, so they tend to sneak by.
