### PR TITLE
serde: switch serde dependency to serde_core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,9 +48,9 @@ default = [
   "tzdb-concatenated",
   "perf-inline",
 ]
-std = ["alloc", "log?/std", "serde?/std"]
-alloc = ["serde?/alloc", "portable-atomic-util/alloc"]
-serde = ["dep:serde"]
+std = ["alloc", "log?/std", "serde_core?/std"]
+alloc = ["serde_core?/alloc", "portable-atomic-util/alloc"]
+serde = ["dep:serde_core"]
 logging = ["dep:log"]
 
 # When enabled, Jiff will include code that attempts to determine the "system"
@@ -181,7 +181,7 @@ perf-inline = []
 jiff-static = { version = "0.2", path = "crates/jiff-static", optional = true }
 jiff-tzdb = { version = "0.1.4", path = "crates/jiff-tzdb", optional = true }
 log = { version = "0.4.21", optional = true, default-features = false }
-serde = { version = "1.0.203", optional = true, default-features = false }
+serde_core = { version = "1.0.221", optional = true, default-features = false }
 
 # This ensures that `jiff-static` is always used with a compatible version
 # of `jiff`. Namely, since `jiff-static` emits code that relies on internal

--- a/src/civil/date.rs
+++ b/src/civil/date.rs
@@ -2476,9 +2476,9 @@ impl core::ops::SubAssign<UnsignedDuration> for Date {
 }
 
 #[cfg(feature = "serde")]
-impl serde::Serialize for Date {
+impl serde_core::Serialize for Date {
     #[inline]
-    fn serialize<S: serde::Serializer>(
+    fn serialize<S: serde_core::Serializer>(
         &self,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -2487,12 +2487,12 @@ impl serde::Serialize for Date {
 }
 
 #[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for Date {
+impl<'de> serde_core::Deserialize<'de> for Date {
     #[inline]
-    fn deserialize<D: serde::Deserializer<'de>>(
+    fn deserialize<D: serde_core::Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Date, D::Error> {
-        use serde::de;
+        use serde_core::de;
 
         struct DateVisitor;
 

--- a/src/civil/datetime.rs
+++ b/src/civil/datetime.rs
@@ -2786,9 +2786,9 @@ impl core::ops::SubAssign<UnsignedDuration> for DateTime {
 }
 
 #[cfg(feature = "serde")]
-impl serde::Serialize for DateTime {
+impl serde_core::Serialize for DateTime {
     #[inline]
-    fn serialize<S: serde::Serializer>(
+    fn serialize<S: serde_core::Serializer>(
         &self,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -2797,12 +2797,12 @@ impl serde::Serialize for DateTime {
 }
 
 #[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for DateTime {
+impl<'de> serde_core::Deserialize<'de> for DateTime {
     #[inline]
-    fn deserialize<D: serde::Deserializer<'de>>(
+    fn deserialize<D: serde_core::Deserializer<'de>>(
         deserializer: D,
     ) -> Result<DateTime, D::Error> {
-        use serde::de;
+        use serde_core::de;
 
         struct DateTimeVisitor;
 

--- a/src/civil/time.rs
+++ b/src/civil/time.rs
@@ -2117,9 +2117,9 @@ impl<'a> From<&'a Zoned> for Time {
 }
 
 #[cfg(feature = "serde")]
-impl serde::Serialize for Time {
+impl serde_core::Serialize for Time {
     #[inline]
-    fn serialize<S: serde::Serializer>(
+    fn serialize<S: serde_core::Serializer>(
         &self,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -2128,12 +2128,12 @@ impl serde::Serialize for Time {
 }
 
 #[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for Time {
+impl<'de> serde_core::Deserialize<'de> for Time {
     #[inline]
-    fn deserialize<D: serde::Deserializer<'de>>(
+    fn deserialize<D: serde_core::Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Time, D::Error> {
-        use serde::de;
+        use serde_core::de;
 
         struct TimeVisitor;
 

--- a/src/fmt/serde.rs
+++ b/src/fmt/serde.rs
@@ -244,7 +244,7 @@ pub mod duration {
             /// Serialize a required `SignedDuration` in the [`friendly`]
             /// duration format using compact designators.
             #[inline]
-            pub fn required<S: serde::Serializer>(
+            pub fn required<S: serde_core::Serializer>(
                 duration: &crate::SignedDuration,
                 se: S,
             ) -> Result<S::Ok, S::Error> {
@@ -254,7 +254,7 @@ pub mod duration {
             /// Serialize an optional `SignedDuration` in the [`friendly`]
             /// duration format using compact designators.
             #[inline]
-            pub fn optional<S: serde::Serializer>(
+            pub fn optional<S: serde_core::Serializer>(
                 duration: &Option<crate::SignedDuration>,
                 se: S,
             ) -> Result<S::Ok, S::Error> {
@@ -388,7 +388,7 @@ pub mod span {
             /// Serialize a required `Span` in the [`friendly`] duration format
             /// using compact designators.
             #[inline]
-            pub fn required<S: serde::Serializer>(
+            pub fn required<S: serde_core::Serializer>(
                 span: &crate::Span,
                 se: S,
             ) -> Result<S::Ok, S::Error> {
@@ -398,7 +398,7 @@ pub mod span {
             /// Serialize an optional `Span` in the [`friendly`] duration
             /// format using compact designators.
             #[inline]
-            pub fn optional<S: serde::Serializer>(
+            pub fn optional<S: serde_core::Serializer>(
                 span: &Option<crate::Span>,
                 se: S,
             ) -> Result<S::Ok, S::Error> {
@@ -428,7 +428,7 @@ pub mod span {
 /// include the time zone, then using [`Zoned`](crate::Zoned) directly will
 /// work as well by utilizing the RFC 9557 extension to RFC 3339.)
 pub mod timestamp {
-    use serde::de;
+    use serde_core::de;
 
     /// A generic visitor for `Option<Timestamp>`.
     struct OptionalVisitor<V>(V);
@@ -465,7 +465,7 @@ pub mod timestamp {
 
     /// (De)serialize an integer number of seconds from the Unix epoch.
     pub mod second {
-        use serde::de;
+        use serde_core::de;
 
         struct Visitor;
 
@@ -584,7 +584,7 @@ pub mod timestamp {
             /// Serialize a required integer number of seconds since the Unix
             /// epoch.
             #[inline]
-            pub fn serialize<S: serde::Serializer>(
+            pub fn serialize<S: serde_core::Serializer>(
                 timestamp: &crate::Timestamp,
                 se: S,
             ) -> Result<S::Ok, S::Error> {
@@ -594,7 +594,7 @@ pub mod timestamp {
             /// Deserialize a required integer number of seconds since the
             /// Unix epoch.
             #[inline]
-            pub fn deserialize<'de, D: serde::Deserializer<'de>>(
+            pub fn deserialize<'de, D: serde_core::Deserializer<'de>>(
                 de: D,
             ) -> Result<crate::Timestamp, D::Error> {
                 de.deserialize_i64(super::Visitor)
@@ -607,7 +607,7 @@ pub mod timestamp {
             /// Serialize an optional integer number of seconds since the Unix
             /// epoch.
             #[inline]
-            pub fn serialize<S: serde::Serializer>(
+            pub fn serialize<S: serde_core::Serializer>(
                 timestamp: &Option<crate::Timestamp>,
                 se: S,
             ) -> Result<S::Ok, S::Error> {
@@ -620,7 +620,7 @@ pub mod timestamp {
             /// Deserialize an optional integer number of seconds since the
             /// Unix epoch.
             #[inline]
-            pub fn deserialize<'de, D: serde::Deserializer<'de>>(
+            pub fn deserialize<'de, D: serde_core::Deserializer<'de>>(
                 de: D,
             ) -> Result<Option<crate::Timestamp>, D::Error> {
                 de.deserialize_option(super::super::OptionalVisitor(
@@ -632,7 +632,7 @@ pub mod timestamp {
 
     /// (De)serialize an integer number of milliseconds from the Unix epoch.
     pub mod millisecond {
-        use serde::de;
+        use serde_core::de;
 
         struct Visitor;
 
@@ -754,7 +754,7 @@ pub mod timestamp {
             /// Serialize a required integer number of milliseconds since the
             /// Unix epoch.
             #[inline]
-            pub fn serialize<S: serde::Serializer>(
+            pub fn serialize<S: serde_core::Serializer>(
                 timestamp: &crate::Timestamp,
                 se: S,
             ) -> Result<S::Ok, S::Error> {
@@ -764,7 +764,7 @@ pub mod timestamp {
             /// Deserialize a required integer number of milliseconds since the
             /// Unix epoch.
             #[inline]
-            pub fn deserialize<'de, D: serde::Deserializer<'de>>(
+            pub fn deserialize<'de, D: serde_core::Deserializer<'de>>(
                 de: D,
             ) -> Result<crate::Timestamp, D::Error> {
                 de.deserialize_i64(super::Visitor)
@@ -777,7 +777,7 @@ pub mod timestamp {
             /// Serialize an optional integer number of milliseconds since the
             /// Unix epoch.
             #[inline]
-            pub fn serialize<S: serde::Serializer>(
+            pub fn serialize<S: serde_core::Serializer>(
                 timestamp: &Option<crate::Timestamp>,
                 se: S,
             ) -> Result<S::Ok, S::Error> {
@@ -790,7 +790,7 @@ pub mod timestamp {
             /// Deserialize an optional integer number of milliseconds since
             /// the Unix epoch.
             #[inline]
-            pub fn deserialize<'de, D: serde::Deserializer<'de>>(
+            pub fn deserialize<'de, D: serde_core::Deserializer<'de>>(
                 de: D,
             ) -> Result<Option<crate::Timestamp>, D::Error> {
                 de.deserialize_option(super::super::OptionalVisitor(
@@ -802,7 +802,7 @@ pub mod timestamp {
 
     /// (De)serialize an integer number of microseconds from the Unix epoch.
     pub mod microsecond {
-        use serde::de;
+        use serde_core::de;
 
         struct Visitor;
 
@@ -924,7 +924,7 @@ pub mod timestamp {
             /// Serialize a required integer number of microseconds since the
             /// Unix epoch.
             #[inline]
-            pub fn serialize<S: serde::Serializer>(
+            pub fn serialize<S: serde_core::Serializer>(
                 timestamp: &crate::Timestamp,
                 se: S,
             ) -> Result<S::Ok, S::Error> {
@@ -934,7 +934,7 @@ pub mod timestamp {
             /// Deserialize a required integer number of microseconds since the
             /// Unix epoch.
             #[inline]
-            pub fn deserialize<'de, D: serde::Deserializer<'de>>(
+            pub fn deserialize<'de, D: serde_core::Deserializer<'de>>(
                 de: D,
             ) -> Result<crate::Timestamp, D::Error> {
                 de.deserialize_i64(super::Visitor)
@@ -947,7 +947,7 @@ pub mod timestamp {
             /// Serialize an optional integer number of microseconds since the
             /// Unix epoch.
             #[inline]
-            pub fn serialize<S: serde::Serializer>(
+            pub fn serialize<S: serde_core::Serializer>(
                 timestamp: &Option<crate::Timestamp>,
                 se: S,
             ) -> Result<S::Ok, S::Error> {
@@ -960,7 +960,7 @@ pub mod timestamp {
             /// Deserialize an optional integer number of microseconds since
             /// the Unix epoch.
             #[inline]
-            pub fn deserialize<'de, D: serde::Deserializer<'de>>(
+            pub fn deserialize<'de, D: serde_core::Deserializer<'de>>(
                 de: D,
             ) -> Result<Option<crate::Timestamp>, D::Error> {
                 de.deserialize_option(super::super::OptionalVisitor(
@@ -972,7 +972,7 @@ pub mod timestamp {
 
     /// (De)serialize an integer number of nanoseconds from the Unix epoch.
     pub mod nanosecond {
-        use serde::de;
+        use serde_core::de;
 
         struct Visitor;
 
@@ -1033,7 +1033,7 @@ pub mod timestamp {
             /// Serialize a required integer number of nanoseconds since the
             /// Unix epoch.
             #[inline]
-            pub fn serialize<S: serde::Serializer>(
+            pub fn serialize<S: serde_core::Serializer>(
                 timestamp: &crate::Timestamp,
                 se: S,
             ) -> Result<S::Ok, S::Error> {
@@ -1043,7 +1043,7 @@ pub mod timestamp {
             /// Deserialize a required integer number of nanoseconds since the
             /// Unix epoch.
             #[inline]
-            pub fn deserialize<'de, D: serde::Deserializer<'de>>(
+            pub fn deserialize<'de, D: serde_core::Deserializer<'de>>(
                 de: D,
             ) -> Result<crate::Timestamp, D::Error> {
                 de.deserialize_i128(super::Visitor)
@@ -1056,7 +1056,7 @@ pub mod timestamp {
             /// Serialize an optional integer number of nanoseconds since the
             /// Unix epoch.
             #[inline]
-            pub fn serialize<S: serde::Serializer>(
+            pub fn serialize<S: serde_core::Serializer>(
                 timestamp: &Option<crate::Timestamp>,
                 se: S,
             ) -> Result<S::Ok, S::Error> {
@@ -1069,7 +1069,7 @@ pub mod timestamp {
             /// Deserialize an optional integer number of nanoseconds since the
             /// Unix epoch.
             #[inline]
-            pub fn deserialize<'de, D: serde::Deserializer<'de>>(
+            pub fn deserialize<'de, D: serde_core::Deserializer<'de>>(
                 de: D,
             ) -> Result<Option<crate::Timestamp>, D::Error> {
                 de.deserialize_option(super::super::OptionalVisitor(
@@ -1169,7 +1169,7 @@ pub mod timestamp {
 /// `Etc/Unknown` identifier for this case, it still surfaces the fact that
 /// something has gone wrong.
 pub mod tz {
-    use serde::de;
+    use serde_core::de;
 
     use crate::fmt::{temporal, StdFmtWrite};
 
@@ -1268,12 +1268,12 @@ pub mod tz {
         /// derived from a system `/etc/localtime` for which no IANA time zone
         /// identifier could be found.
         #[inline]
-        pub fn serialize<S: serde::Serializer>(
+        pub fn serialize<S: serde_core::Serializer>(
             tz: &crate::tz::TimeZone,
             se: S,
         ) -> Result<S::Ok, S::Error> {
             if !tz.has_succinct_serialization() {
-                return Err(<S::Error as serde::ser::Error>::custom(
+                return Err(<S::Error as serde_core::ser::Error>::custom(
                     "time zones without IANA identifiers that aren't either \
                      fixed offsets or a POSIX time zone can't be serialized \
                      (this typically occurs when this is a system time zone \
@@ -1289,7 +1289,7 @@ pub mod tz {
         /// This will attempt to parse an IANA time zone identifier, a fixed
         /// offset or a POSIX time zone string.
         #[inline]
-        pub fn deserialize<'de, D: serde::Deserializer<'de>>(
+        pub fn deserialize<'de, D: serde_core::Deserializer<'de>>(
             de: D,
         ) -> Result<crate::tz::TimeZone, D::Error> {
             de.deserialize_str(super::Visitor)
@@ -1308,7 +1308,7 @@ pub mod tz {
         /// derived from a system `/etc/localtime` for which no IANA time zone
         /// identifier could be found.
         #[inline]
-        pub fn serialize<S: serde::Serializer>(
+        pub fn serialize<S: serde_core::Serializer>(
             tz: &Option<crate::tz::TimeZone>,
             se: S,
         ) -> Result<S::Ok, S::Error> {
@@ -1323,7 +1323,7 @@ pub mod tz {
         /// This will attempt to parse an IANA time zone identifier, a fixed
         /// offset or a POSIX time zone string.
         #[inline]
-        pub fn deserialize<'de, D: serde::Deserializer<'de>>(
+        pub fn deserialize<'de, D: serde_core::Deserializer<'de>>(
             de: D,
         ) -> Result<Option<crate::tz::TimeZone>, D::Error> {
             de.deserialize_option(super::OptionalVisitor(super::Visitor))

--- a/src/signed_duration.rs
+++ b/src/signed_duration.rs
@@ -2259,9 +2259,9 @@ impl core::ops::DivAssign<i32> for SignedDuration {
 }
 
 #[cfg(feature = "serde")]
-impl serde::Serialize for SignedDuration {
+impl serde_core::Serialize for SignedDuration {
     #[inline]
-    fn serialize<S: serde::Serializer>(
+    fn serialize<S: serde_core::Serializer>(
         &self,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -2270,12 +2270,12 @@ impl serde::Serialize for SignedDuration {
 }
 
 #[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for SignedDuration {
+impl<'de> serde_core::Deserialize<'de> for SignedDuration {
     #[inline]
-    fn deserialize<D: serde::Deserializer<'de>>(
+    fn deserialize<D: serde_core::Deserializer<'de>>(
         deserializer: D,
     ) -> Result<SignedDuration, D::Error> {
-        use serde::de;
+        use serde_core::de;
 
         struct SignedDurationVisitor;
 

--- a/src/span.rs
+++ b/src/span.rs
@@ -3596,9 +3596,9 @@ impl TryFrom<SignedDuration> for Span {
 }
 
 #[cfg(feature = "serde")]
-impl serde::Serialize for Span {
+impl serde_core::Serialize for Span {
     #[inline]
-    fn serialize<S: serde::Serializer>(
+    fn serialize<S: serde_core::Serializer>(
         &self,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -3607,12 +3607,12 @@ impl serde::Serialize for Span {
 }
 
 #[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for Span {
+impl<'de> serde_core::Deserialize<'de> for Span {
     #[inline]
-    fn deserialize<D: serde::Deserializer<'de>>(
+    fn deserialize<D: serde_core::Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Span, D::Error> {
-        use serde::de;
+        use serde_core::de;
 
         struct SpanVisitor;
 

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -2852,9 +2852,9 @@ impl TryFrom<std::time::SystemTime> for Timestamp {
 }
 
 #[cfg(feature = "serde")]
-impl serde::Serialize for Timestamp {
+impl serde_core::Serialize for Timestamp {
     #[inline]
-    fn serialize<S: serde::Serializer>(
+    fn serialize<S: serde_core::Serializer>(
         &self,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -2863,12 +2863,12 @@ impl serde::Serialize for Timestamp {
 }
 
 #[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for Timestamp {
+impl<'de> serde_core::Deserialize<'de> for Timestamp {
     #[inline]
-    fn deserialize<D: serde::Deserializer<'de>>(
+    fn deserialize<D: serde_core::Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Timestamp, D::Error> {
-        use serde::de;
+        use serde_core::de;
 
         struct TimestampVisitor;
 

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -3522,9 +3522,9 @@ impl core::ops::SubAssign<UnsignedDuration> for Zoned {
 }
 
 #[cfg(feature = "serde")]
-impl serde::Serialize for Zoned {
+impl serde_core::Serialize for Zoned {
     #[inline]
-    fn serialize<S: serde::Serializer>(
+    fn serialize<S: serde_core::Serializer>(
         &self,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
@@ -3533,12 +3533,12 @@ impl serde::Serialize for Zoned {
 }
 
 #[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for Zoned {
+impl<'de> serde_core::Deserialize<'de> for Zoned {
     #[inline]
-    fn deserialize<D: serde::Deserializer<'de>>(
+    fn deserialize<D: serde_core::Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Zoned, D::Error> {
-        use serde::de;
+        use serde_core::de;
 
         struct ZonedVisitor;
 


### PR DESCRIPTION
[serde_core](https://crates.io/crates/serde_core) has just been released. Crates that don't depend on serde derive macros should use it instead of `serde`, as it speeds up compile times by having the build for the crate itself be independent from `serde-derive` (in case it were to be enabled by some other crate). See the serde_core docs for more info.

On my Ryzen 5 5500U, building this repo with `cargo build --release --features serde` went from 10.83s to 8.76s.