### PR TITLE
Add panic/crash fuzzers for TimeZone constructors accepting bytes/strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
   "crates/jiff-static",
   "crates/jiff-tzdb",
   "crates/jiff-tzdb-platform",
+  "fuzz",
 ]
 
 # Features are documented in the "Crate features" section of the crate docs:

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "jiff-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.jiff]
+path = ".."
+
+[[bin]]
+name = "time_zone_posix"
+path = "fuzz_targets/time_zone_posix.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "time_zone_get"
+path = "fuzz_targets/time_zone_get.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "time_zone_tzif"
+path = "fuzz_targets/time_zone_tzif.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/time_zone_get.rs
+++ b/fuzz/fuzz_targets/time_zone_get.rs
@@ -1,0 +1,9 @@
+#![no_main]
+
+use jiff::tz::TimeZone;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|time_zone_name: &str| {
+    // This function should never panic.
+    _ = TimeZone::get(time_zone_name);
+});

--- a/fuzz/fuzz_targets/time_zone_posix.rs
+++ b/fuzz/fuzz_targets/time_zone_posix.rs
@@ -1,0 +1,9 @@
+#![no_main]
+
+use jiff::tz::TimeZone;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|posix_tz_string: &str| {
+    // This function should never panic.
+    _ = TimeZone::posix(posix_tz_string);
+});

--- a/fuzz/fuzz_targets/time_zone_tzif.rs
+++ b/fuzz/fuzz_targets/time_zone_tzif.rs
@@ -1,0 +1,10 @@
+#![no_main]
+
+use jiff::tz::TimeZone;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|input: (&str, &[u8])| {
+    let (name, data) = input;
+    // This function should never panic.
+    _ = TimeZone::tzif(name, data);
+});


### PR DESCRIPTION
Part of #14.

`time_zone_posix` and `time_zone_tzif` both found panic-inducing inputs. The former is tracked in #407. An example of the latter is https://gist.github.com/apasel422/7b0d69b6fd8f325d4213dc81ca2e4923.

I've omitted CI support (compare to #57) while they're resolved.