### PR TITLE
tz: clarify that `TimeZone::system()` falls back to `TimeZone::unknown()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+0.2.16 (TBD)
+============
+TODO
+
+Bug fixes:
+
+* [#414](https://github.com/BurntSushi/jiff/pull/414):
+Update some parts of the documentation to indicate that `TimeZone::unknown()`
+is a fallback for `TimeZone::system()` (instead of the `jiff 0.1` behavior of
+using `TimeZone::UTC`).
+
+
 0.2.15 (2025-06-13)
 ===================
 This release fixes a bug where error values were being constructed during

--- a/src/tz/timezone.rs
+++ b/src/tz/timezone.rs
@@ -83,14 +83,15 @@ use self::repr::Repr;
 ///
 /// The system time zone can be retrieved via [`TimeZone::system`]. If it
 /// couldn't be detected or if the `tz-system` crate feature is not enabled,
-/// then [`TimeZone::UTC`] is returned. `TimeZone::system` is what's used
+/// then [`TimeZone::unknown`] is returned. `TimeZone::system` is what's used
 /// internally for retrieving the current zoned datetime via [`Zoned::now`].
 ///
 /// While there is no platform independent way to detect your system's
 /// "default" time zone, Jiff employs best-effort heuristics to determine it.
-/// (For example, by examining `/etc/localtime` on Unix systems.) When the
-/// heuristics fail, Jiff will emit a `WARN` level log. It can be viewed by
-/// installing a `log` compatible logger, such as [`env_logger`].
+/// (For example, by examining `/etc/localtime` on Unix systems or the `TZ`
+/// environment variable.) When the heuristics fail, Jiff will emit a `WARN`
+/// level log. It can be viewed by installing a `log` compatible logger, such
+/// as [`env_logger`].
 ///
 /// # Custom time zones
 ///

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -382,11 +382,11 @@ struct ZonedInner {
 impl Zoned {
     /// Returns the current system time in this system's time zone.
     ///
-    /// If the system's time zone could not be found, then [`TimeZone::UTC`]
-    /// is used instead. When this happens, a `WARN` level log message will
-    /// be emitted. (To see it, one will need to install a logger that is
-    /// compatible with the `log` crate and enable Jiff's `logging` Cargo
-    /// feature.)
+    /// If the system's time zone could not be found, then
+    /// [`TimeZone::unknown`] is used instead. When this happens, a `WARN`
+    /// level log message will be emitted. (To see it, one will need to install
+    /// a logger that is compatible with the `log` crate and enable Jiff's
+    /// `logging` Cargo feature.)
     ///
     /// To create a `Zoned` value for the current time in a particular
     /// time zone other than the system default time zone, use


### PR DESCRIPTION
In `jiff 0.1`, the fallback was to `TimeZone::UTC`, but this changed to
`TimeZone::unknown()` in `jiff 0.2`. The documentation on
`TimeZone::system()` is correct, but the docs on `TimeZone` weren't
updated.

(This change was made so that there was an error "sentinel" to indicate
something has gone wrong. This keeps routines like `Zoned::now()`
infallible.)
