### PR TITLE
deps: allow windows-sys 0.61

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -577,6 +577,7 @@ jobs:
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: stable
+        components: rustfmt
     - name: Install jiff-cli
       run: cargo install -f --path crates/jiff-cli
     - name: Generate code shared between jiff and jiff-static

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,7 +206,7 @@ jiff-static = { version = "=0.2.15", path = "crates/jiff-static" }
 jiff-tzdb-platform = { version = "0.1.3", path = "crates/jiff-tzdb-platform", optional = true }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = ">=0.52.0, <=0.59.*"
+version = ">=0.52.0, <=0.61.*"
 default-features = false
 features = ["Win32_Foundation", "Win32_System_Time"]
 optional = true


### PR DESCRIPTION
This updates the allowed version range for `windows-sys` to include the
`0.61.x` release.

This also fixes CI by ensuring `rustfmt` is available when running the
`jiff-cli generate` commands. I'm unclear on why this was only failing
intermittently.
