### PR TITLE
fmt: fix panic bug in `strptime` when using `%C`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ is a fallback for `TimeZone::system()` (instead of the `jiff 0.1` behavior of
 using `TimeZone::UTC`).
 * [#423](https://github.com/BurntSushi/jiff/issues/423):
 Fix a panicking bug when reading malformed TZif data.
+* [#426](https://github.com/BurntSushi/jiff/issues/426):
+Fix a panicking bug when parsing century (`%C`) via `strptime`.
 
 
 0.2.15 (2025-06-13)


### PR DESCRIPTION
The code previously assumed that `%C` could never parse more than 2
digits. I believe this restriction was relaxed at some point, but the
assumption was never revisited in this part of the code.

This fixes the panic by forcefully restricting the absolute value of the
parsed century to be in the range `0..=99`.

Fixes #426
