### PR TITLE
api: add `Zoned::series`

### DIFF
--- a/src/civil/date.rs
+++ b/src/civil/date.rs
@@ -2548,8 +2548,10 @@ impl quickcheck::Arbitrary for Date {
 
 /// An iterator over periodic dates, created by [`Date::series`].
 ///
-/// It is exhausted when the next value would exceed a [`Span`] or [`Date`]
-/// value.
+/// It is exhausted when the next value would exceed the limits of a [`Span`]
+/// or [`Date`] value.
+///
+/// This iterator is created by [`Date::series`].
 #[derive(Clone, Debug)]
 pub struct DateSeries {
     start: Date,
@@ -2568,6 +2570,8 @@ impl Iterator for DateSeries {
         Some(date)
     }
 }
+
+impl core::iter::FusedIterator for DateSeries {}
 
 /// Options for [`Date::checked_add`] and [`Date::checked_sub`].
 ///

--- a/src/civil/datetime.rs
+++ b/src/civil/datetime.rs
@@ -2858,8 +2858,10 @@ impl quickcheck::Arbitrary for DateTime {
 
 /// An iterator over periodic datetimes, created by [`DateTime::series`].
 ///
-/// It is exhausted when the next value would exceed a [`Span`] or [`DateTime`]
-/// value.
+/// It is exhausted when the next value would exceed the limits of a [`Span`]
+/// or [`DateTime`] value.
+///
+/// This iterator is created by [`DateTime::series`].
 #[derive(Clone, Debug)]
 pub struct DateTimeSeries {
     start: DateTime,
@@ -2878,6 +2880,8 @@ impl Iterator for DateTimeSeries {
         Some(date)
     }
 }
+
+impl core::iter::FusedIterator for DateTimeSeries {}
 
 /// Options for [`DateTime::checked_add`] and [`DateTime::checked_sub`].
 ///

--- a/src/civil/time.rs
+++ b/src/civil/time.rs
@@ -2202,8 +2202,10 @@ impl quickcheck::Arbitrary for Time {
 
 /// An iterator over periodic times, created by [`Time::series`].
 ///
-/// It is exhausted when the next value would exceed a [`Span`] or [`Time`]
-/// value.
+/// It is exhausted when the next value would exceed the limits of a [`Span`]
+/// or [`Time`] value.
+///
+/// This iterator is created by [`Time::series`].
 #[derive(Clone, Debug)]
 pub struct TimeSeries {
     start: Time,
@@ -2222,6 +2224,8 @@ impl Iterator for TimeSeries {
         Some(time)
     }
 }
+
+impl core::iter::FusedIterator for TimeSeries {}
 
 /// Options for [`Time::checked_add`] and [`Time::checked_sub`].
 ///

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -3000,8 +3000,10 @@ impl core::fmt::Display for TimestampDisplayWithOffset {
 
 /// An iterator over periodic timestamps, created by [`Timestamp::series`].
 ///
-/// It is exhausted when the next value would exceed a [`Span`] or
-/// [`Timestamp`] value.
+/// It is exhausted when the next value would exceed the limits of a [`Span`]
+/// or [`Timestamp`] value.
+///
+/// This iterator is created by [`Timestamp::series`].
 #[derive(Clone, Debug)]
 pub struct TimestampSeries {
     ts: Timestamp,
@@ -3027,6 +3029,8 @@ impl Iterator for TimestampSeries {
         Some(this)
     }
 }
+
+impl core::iter::FusedIterator for TimestampSeries {}
 
 /// Options for [`Timestamp::checked_add`] and [`Timestamp::checked_sub`].
 ///

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -2984,7 +2984,6 @@ impl Zoned {
         options.round(self)
     }
 
-    /*
     /// Return an iterator of periodic zoned datetimes determined by the given
     /// span.
     ///
@@ -2993,11 +2992,17 @@ impl Zoned {
     /// itself overflows, or it would otherwise exceed the minimum or maximum
     /// `Zoned` value.
     ///
+    /// When the given span is positive, the zoned datetimes yielded are
+    /// monotonically increasing. When the given span is negative, the zoned
+    /// datetimes yielded as monotonically decreasing. When the given span is
+    /// zero, then all values yielded are identical and the time series is
+    /// infinite.
+    ///
     /// # Example: when to check a glucose monitor
     ///
     /// When my cat had diabetes, my veterinarian installed a glucose monitor
     /// and instructed me to scan it about every 5 hours. This example lists
-    /// all of the times I need to scan it for the 2 days following its
+    /// all of the times I needed to scan it for the 2 days following its
     /// installation:
     ///
     /// ```
@@ -3025,28 +3030,188 @@ impl Zoned {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     ///
-    /// # Example
+    /// # Example: behavior during daylight saving time transitions
     ///
-    /// BREADCRUMBS: Maybe just remove ZonedSeries for now..?
+    /// Even when there is a daylight saving time transition, the time series
+    /// returned handles it correctly by continuing to move forward.
+    ///
+    /// This first example shows what happens when there is a gap in time (it
+    /// is automatically skipped):
+    ///
+    /// ```
+    /// use jiff::{civil::date, ToSpan};
+    ///
+    /// let zdt = date(2025, 3, 9).at(1, 0, 0, 0).in_tz("America/New_York")?;
+    /// let mut it = zdt.series(30.minutes());
+    ///
+    /// assert_eq!(
+    ///     it.next().map(|zdt| zdt.to_string()),
+    ///     Some("2025-03-09T01:00:00-05:00[America/New_York]".to_string()),
+    /// );
+    /// assert_eq!(
+    ///     it.next().map(|zdt| zdt.to_string()),
+    ///     Some("2025-03-09T01:30:00-05:00[America/New_York]".to_string()),
+    /// );
+    /// assert_eq!(
+    ///     it.next().map(|zdt| zdt.to_string()),
+    ///     Some("2025-03-09T03:00:00-04:00[America/New_York]".to_string()),
+    /// );
+    /// assert_eq!(
+    ///     it.next().map(|zdt| zdt.to_string()),
+    ///     Some("2025-03-09T03:30:00-04:00[America/New_York]".to_string()),
+    /// );
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// And similarly, when there is a fold in time, the fold is repeated:
+    ///
+    /// ```
+    /// use jiff::{civil::date, ToSpan};
+    ///
+    /// let zdt = date(2025, 11, 2).at(0, 30, 0, 0).in_tz("America/New_York")?;
+    /// let mut it = zdt.series(30.minutes());
+    ///
+    /// assert_eq!(
+    ///     it.next().map(|zdt| zdt.to_string()),
+    ///     Some("2025-11-02T00:30:00-04:00[America/New_York]".to_string()),
+    /// );
+    /// assert_eq!(
+    ///     it.next().map(|zdt| zdt.to_string()),
+    ///     Some("2025-11-02T01:00:00-04:00[America/New_York]".to_string()),
+    /// );
+    /// assert_eq!(
+    ///     it.next().map(|zdt| zdt.to_string()),
+    ///     Some("2025-11-02T01:30:00-04:00[America/New_York]".to_string()),
+    /// );
+    /// assert_eq!(
+    ///     it.next().map(|zdt| zdt.to_string()),
+    ///     Some("2025-11-02T01:00:00-05:00[America/New_York]".to_string()),
+    /// );
+    /// assert_eq!(
+    ///     it.next().map(|zdt| zdt.to_string()),
+    ///     Some("2025-11-02T01:30:00-05:00[America/New_York]".to_string()),
+    /// );
+    /// assert_eq!(
+    ///     it.next().map(|zdt| zdt.to_string()),
+    ///     Some("2025-11-02T02:00:00-05:00[America/New_York]".to_string()),
+    /// );
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// # Example: ensures values are monotonically increasing (or decreasing)
+    ///
+    /// Because of odd time zone transitions, it's possible that adding
+    /// different calendar units to the same zoned datetime will yield the
+    /// same result. For example, `2011-12-30` did not exist on the clocks
+    /// in the `Pacific/Apia` time zone. (Because Samoa switched sides of the
+    /// International Date Line.) This means that adding `1 day` to
+    /// `2011-12-29` yields the same result as adding `2 days`:
+    ///
+    /// ```
+    /// use jiff::{civil, ToSpan};
+    ///
+    /// let zdt = civil::date(2011, 12, 29).in_tz("Pacific/Apia")?;
+    /// assert_eq!(
+    ///     zdt.checked_add(1.day())?.to_string(),
+    ///     "2011-12-31T00:00:00+14:00[Pacific/Apia]",
+    /// );
+    /// assert_eq!(
+    ///     zdt.checked_add(2.days())?.to_string(),
+    ///     "2011-12-31T00:00:00+14:00[Pacific/Apia]",
+    /// );
+    /// assert_eq!(
+    ///     zdt.checked_add(3.days())?.to_string(),
+    ///     "2012-01-01T00:00:00+14:00[Pacific/Apia]",
+    /// );
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// This might lead one to believe that `Zoned::series` could emit the
+    /// same instant twice. But it takes this into account and ensures all
+    /// values occur after the previous value (or before if the `Span` given
+    /// is negative):
     ///
     /// ```
     /// use jiff::{civil::date, ToSpan};
     ///
     /// let zdt = date(2011, 12, 28).in_tz("Pacific/Apia")?;
     /// let mut it = zdt.series(1.day());
-    /// assert_eq!(it.next(), Some(date(2011, 12, 28).in_tz("Pacific/Apia")?));
-    /// assert_eq!(it.next(), Some(date(2011, 12, 29).in_tz("Pacific/Apia")?));
-    /// assert_eq!(it.next(), Some(date(2011, 12, 30).in_tz("Pacific/Apia")?));
-    /// assert_eq!(it.next(), Some(date(2011, 12, 31).in_tz("Pacific/Apia")?));
-    /// assert_eq!(it.next(), Some(date(2012, 01, 01).in_tz("Pacific/Apia")?));
+    ///
+    /// assert_eq!(
+    ///     it.next().map(|zdt| zdt.to_string()),
+    ///     Some("2011-12-28T00:00:00-10:00[Pacific/Apia]".to_string()),
+    /// );
+    /// assert_eq!(
+    ///     it.next().map(|zdt| zdt.to_string()),
+    ///     Some("2011-12-29T00:00:00-10:00[Pacific/Apia]".to_string()),
+    /// );
+    /// assert_eq!(
+    ///     it.next().map(|zdt| zdt.to_string()),
+    ///     Some("2011-12-31T00:00:00+14:00[Pacific/Apia]".to_string()),
+    /// );
+    /// assert_eq!(
+    ///     it.next().map(|zdt| zdt.to_string()),
+    ///     Some("2012-01-01T00:00:00+14:00[Pacific/Apia]".to_string()),
+    /// );
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// And similarly for a negative `Span`:
+    ///
+    /// ```
+    /// use jiff::{civil::date, ToSpan};
+    ///
+    /// let zdt = date(2012, 1, 1).in_tz("Pacific/Apia")?;
+    /// let mut it = zdt.series(-1.day());
+    ///
+    /// assert_eq!(
+    ///     it.next().map(|zdt| zdt.to_string()),
+    ///     Some("2012-01-01T00:00:00+14:00[Pacific/Apia]".to_string()),
+    /// );
+    /// assert_eq!(
+    ///     it.next().map(|zdt| zdt.to_string()),
+    ///     Some("2011-12-31T00:00:00+14:00[Pacific/Apia]".to_string()),
+    /// );
+    /// assert_eq!(
+    ///     it.next().map(|zdt| zdt.to_string()),
+    ///     Some("2011-12-29T00:00:00-10:00[Pacific/Apia]".to_string()),
+    /// );
+    /// assert_eq!(
+    ///     it.next().map(|zdt| zdt.to_string()),
+    ///     Some("2011-12-28T00:00:00-10:00[Pacific/Apia]".to_string()),
+    /// );
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// An exception to this is if a zero `Span` is provided. Then all values
+    /// emitted are necessarily equivalent:
+    ///
+    /// ```
+    /// use jiff::{civil::date, ToSpan};
+    ///
+    /// let zdt = date(2011, 12, 28).in_tz("Pacific/Apia")?;
+    /// let mut it = zdt.series(0.days());
+    ///
+    /// assert_eq!(
+    ///     it.next().map(|zdt| zdt.to_string()),
+    ///     Some("2011-12-28T00:00:00-10:00[Pacific/Apia]".to_string()),
+    /// );
+    /// assert_eq!(
+    ///     it.next().map(|zdt| zdt.to_string()),
+    ///     Some("2011-12-28T00:00:00-10:00[Pacific/Apia]".to_string()),
+    /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[inline]
-    pub fn series(self, period: Span) -> ZonedSeries {
-        ZonedSeries { start: self, period, step: 0 }
+    pub fn series(&self, period: Span) -> ZonedSeries {
+        ZonedSeries { start: self.clone(), prev: None, period, step: 0 }
     }
-    */
 
     #[inline]
     fn into_parts(self) -> (Timestamp, DateTime, Offset, TimeZone) {
@@ -3590,14 +3755,16 @@ impl quickcheck::Arbitrary for Zoned {
     }
 }
 
-/*
 /// An iterator over periodic zoned datetimes, created by [`Zoned::series`].
 ///
-/// It is exhausted when the next value would exceed a [`Span`] or [`Zoned`]
-/// value.
+/// It is exhausted when the next value would exceed the limits of a [`Span`]
+/// or [`Zoned`] value.
+///
+/// This iterator is created by [`Zoned::series`].
 #[derive(Clone, Debug)]
 pub struct ZonedSeries {
     start: Zoned,
+    prev: Option<Timestamp>,
     period: Span,
     step: i64,
 }
@@ -3607,26 +3774,52 @@ impl Iterator for ZonedSeries {
 
     #[inline]
     fn next(&mut self) -> Option<Zoned> {
-        // let this = self.start.clone();
-        // self.start = self.start.checked_add(self.period).ok()?;
-        // Some(this)
-        // This is how civil::DateTime series works. But this has a problem
-        // for Zoned when there are time zone transitions that skip an entire
-        // day. For example, Pacific/Api doesn't have a December 30, 2011.
-        // For that case, the code above works better. But if you do it that
-        // way, then you get the `jan31 + 1 month = feb28` and
-        // `feb28 + 1 month = march28` problem. Where you would instead
-        // expect jan31, feb28, mar31... I think.
+        // This loop is necessary because adding, e.g., `N * 1 day` may not
+        // always result in a timestamp that is strictly greater than
+        // `(N-1) * 1 day`. For example, `Pacific/Apia` never had `2011-12-30`
+        // on their clocks. So adding `1 day` to `2011-12-29` yields the same
+        // value as adding `2 days` (that is, `2011-12-31`).
         //
-        // So I'm not quite sure how to resolve this particular conundrum.
-        // And this is why ZonedSeries is currently not available.
-        let span = self.period.checked_mul(self.step).ok()?;
-        self.step = self.step.checked_add(1)?;
-        let zdt = self.start.checked_add(span).ok()?;
-        Some(zdt)
+        // This may seem odd, but Temporal has the same behavior (as of
+        // 2025-10-15):
+        //
+        //   >>> zdt = Temporal.ZonedDateTime.from("2011-12-29[Pacific/Apia]")
+        //   Object { … }
+        //   >>> zdt.toString()
+        //   "2011-12-29T00:00:00-10:00[Pacific/Apia]"
+        //   >>> zdt.add({days: 1}).toString()
+        //   "2011-12-31T00:00:00+14:00[Pacific/Apia]"
+        //   >>> zdt.add({days: 2}).toString()
+        //   "2011-12-31T00:00:00+14:00[Pacific/Apia]"
+        //
+        // Since we are generating a time series specifically here, it seems
+        // weird to yield two results that are equivalent instants in time.
+        // So we use a loop here to guarantee that every instant yielded is
+        // always strictly *after* the previous instant yielded.
+        loop {
+            let span = self.period.checked_mul(self.step).ok()?;
+            self.step = self.step.checked_add(1)?;
+            let zdt = self.start.checked_add(span).ok()?;
+            if self.prev.map_or(true, |prev| {
+                if self.period.is_positive() {
+                    prev < zdt.timestamp()
+                } else if self.period.is_negative() {
+                    prev > zdt.timestamp()
+                } else {
+                    assert!(self.period.is_zero());
+                    // In the case of a zero span, the caller has clearly
+                    // opted into an infinite repeating sequence.
+                    true
+                }
+            }) {
+                self.prev = Some(zdt.timestamp());
+                return Some(zdt);
+            }
+        }
     }
 }
-*/
+
+impl core::iter::FusedIterator for ZonedSeries {}
 
 /// Options for [`Timestamp::checked_add`] and [`Timestamp::checked_sub`].
 ///


### PR DESCRIPTION
I had been uncertain about how this should be implemented in the face of
truly aberrant time zone transitions (like 2011-12-30 being missing from
`Pacific/Apia`). But this particular method is incredibly useful _and_
is present on all of the other datetime types. So I think it's important
enough to add, even if it may have somewhat odd semantics in some cases.

The thing that tipped me over the edge to add this is that users will want this operation in one form or another. And if Jiff doesn't provide it, then they are just going to code it themselves. And while this operation has a pretty simple implementation, there are some easy to make mistakes that the implementation avoids. (Like adding `1.month()` to March 31 and getting `March 31`, `April 30`, `May 30` instead of `May 31`.)

Another problem, albeit rare, is if we implement `Zoned::series` like we do
`civil::DateTime::series`, then a time series over spans of `1 day`
starting on `2011-12-29` in `Pacific/Apia` will result in yielding
`2011-12-31` twice. This is because `2011-12-29 + 1 day` and
`2011-12-29 + 2 days` are equivalent (i.e., `2011-12-30`) in
`Pacific/Apia`. Indeed, this behavior is copied from Temporal which
behaves the same:

    >>> zdt = Temporal.ZonedDateTime.from("2011-12-29[Pacific/Apia]")
    Object { … }
    >>> zdt.toString()
    "2011-12-29T00:00:00-10:00[Pacific/Apia]"
    >>> zdt.add({days: 1}).toString()
    "2011-12-31T00:00:00+14:00[Pacific/Apia]"
    >>> zdt.add({days: 2}).toString()
    "2011-12-31T00:00:00+14:00[Pacific/Apia]"

I think yielding the same instant twice in a row is perhaps very odd and
unexpected. Instead, the iterator guarantees that each item yielded by
the iterator is strictly greater (or strictly less for negative spans)
than the one that precedes it. This fixes the `Pacific/Apia` case while
preserving the same kind of semantics we get with
`civil::DateTime::series`.
