### PR TITLE
zoned: add arithmetic impls for `Zoned`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,7 +369,7 @@ use jiff::civil::date;
 
 let zdt1 = date(2020, 8, 26).at(6, 27, 0, 0).in_tz("America/New_York")?;
 let zdt2 = date(2023, 12, 31).at(18, 30, 0, 0).in_tz("America/New_York")?;
-let span = &zdt2 - &zdt1;
+let span = zdt2 - zdt1;
 assert_eq!(format!("{span:#}"), "29341h 3m");
 
 # Ok::<(), Box<dyn std::error::Error>>(())


### PR DESCRIPTION
Previously, we only had impls for `&Zoned`. These impls are a little
weird because `Zoned` isn't `Copy`. So using them will result in
consuming the `Zoned` value. But if that's okay, then having these impls
is a nice quality of life improvement instead of a papercut. In the
worst case, Rust programmers will need to add a `&` to avoid consuming
the `Zoned` value. But I think Rust programmers are pretty used to that.

Fixes #396
