### PR TITLE
fix: export `ZonedSeries`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -759,7 +759,10 @@ pub use crate::{
         TimestampDisplayWithOffset, TimestampRound, TimestampSeries,
     },
     util::round::mode::RoundMode,
-    zoned::{Zoned, ZonedArithmetic, ZonedDifference, ZonedRound, ZonedWith},
+    zoned::{
+        Zoned, ZonedArithmetic, ZonedDifference, ZonedRound, ZonedSeries,
+        ZonedWith,
+    },
 };
 
 #[macro_use]


### PR DESCRIPTION
@BurntSushi I noticed you added `ZonedSeries` but it was not exported from the top level library. 