### PR TITLE
added `FromStr` and `Display` impls for ISOWeekDate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+0.2.17 (TBD)
+============
+TODO
+
+Enhancements:
+
+* [#412](https://github.com/BurntSushi/jiff/issues/412):
+Add `Display`, `FromStr`, `Serialize` and `Deserialize` trait implementations
+for `jiff::civil::ISOWeekDate`. These all use the ISO 8601 week date format.
+
+
 0.2.16 (2025-11-07)
 ===================
 This release contains a number of enhancements and bug fixes that have accrued


### PR DESCRIPTION
Makes progress on #412

### changes
- Added `Display` and `FromStr` impls for `ISOWeekDate`
- Added `iso_week_date` module in fmt, kept the structure similar to `fmt::rfc2822`
### Issues
I copied over `parse_year`, `parse_year_sign`, and `parse_date_separator` from `fmt::temporal::parser` since the logic is identical and I was not sure how to keep it DRY

with these changes implementing `Deserialize` and `Serialize` will be straightforward so I can do that once this PR is greenlit