### PR TITLE
fmt: simplfy and reduce size of integer formatting

### DIFF
--- a/src/fmt/friendly/printer.rs
+++ b/src/fmt/friendly/printer.rs
@@ -1,6 +1,6 @@
 use crate::{
     fmt::{
-        util::{DecimalFormatter, FractionalFormatter},
+        util::{FractionalFormatter, IntegerFormatter},
         Write, WriteExt,
     },
     Error, SignedDuration, Span, Unit,
@@ -1310,7 +1310,7 @@ impl SpanPrinter {
         span_time = span_time.abs();
 
         let fmtint =
-            DecimalFormatter::new().padding(self.padding.unwrap_or(2));
+            IntegerFormatter::new().padding(self.padding.unwrap_or(2));
         let fmtfraction = FractionalFormatter::new().precision(self.precision);
         wtr.wtr.write_int(&fmtint, span_time.get_hours_ranged().get())?;
         wtr.wtr.write_str(":")?;
@@ -1488,7 +1488,7 @@ impl SpanPrinter {
         // bigger.
 
         let fmtint =
-            DecimalFormatter::new().padding(self.padding.unwrap_or(2));
+            IntegerFormatter::new().padding(self.padding.unwrap_or(2));
         let fmtfraction = FractionalFormatter::new().precision(self.precision);
 
         let mut secs = udur.as_secs();
@@ -1618,7 +1618,7 @@ struct DesignatorWriter<'p, 'w, W> {
     wtr: &'w mut W,
     desig: Designators,
     sign: Option<DirectionSign>,
-    fmtint: DecimalFormatter,
+    fmtint: IntegerFormatter,
     fmtfraction: FractionalFormatter,
     written_non_zero_unit: bool,
 }
@@ -1633,7 +1633,7 @@ impl<'p, 'w, W: Write> DesignatorWriter<'p, 'w, W> {
         let desig = Designators::new(printer.designator);
         let sign = printer.direction.sign(printer, has_calendar, signum);
         let fmtint =
-            DecimalFormatter::new().padding(printer.padding.unwrap_or(0));
+            IntegerFormatter::new().padding(printer.padding.unwrap_or(0));
         let fmtfraction =
             FractionalFormatter::new().precision(printer.precision);
         DesignatorWriter {
@@ -1733,7 +1733,7 @@ impl<'p, 'w, W: Write> DesignatorWriter<'p, 'w, W> {
 struct FractionalPrinter {
     integer: u64,
     fraction: u32,
-    fmtint: DecimalFormatter,
+    fmtint: IntegerFormatter,
     fmtfraction: FractionalFormatter,
 }
 
@@ -1750,7 +1750,7 @@ impl FractionalPrinter {
     fn from_span(
         span: &Span,
         unit: FractionalUnit,
-        fmtint: DecimalFormatter,
+        fmtint: IntegerFormatter,
         fmtfraction: FractionalFormatter,
     ) -> FractionalPrinter {
         debug_assert!(span.largest_unit() <= Unit::from(unit));
@@ -1762,7 +1762,7 @@ impl FractionalPrinter {
     fn from_duration(
         dur: &core::time::Duration,
         unit: FractionalUnit,
-        fmtint: DecimalFormatter,
+        fmtint: IntegerFormatter,
         fmtfraction: FractionalFormatter,
     ) -> FractionalPrinter {
         match unit {

--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -170,7 +170,7 @@ use crate::{
     util::escape,
 };
 
-use self::util::{Decimal, DecimalFormatter, Fractional, FractionalFormatter};
+use self::util::{Fractional, FractionalFormatter, Integer, IntegerFormatter};
 
 pub mod friendly;
 mod offset;
@@ -434,7 +434,7 @@ trait WriteExt: Write {
     #[inline]
     fn write_int(
         &mut self,
-        formatter: &DecimalFormatter,
+        formatter: &IntegerFormatter,
         n: impl Into<i64>,
     ) -> Result<(), Error> {
         self.write_decimal(&formatter.format_signed(n.into()))
@@ -445,7 +445,7 @@ trait WriteExt: Write {
     #[inline]
     fn write_uint(
         &mut self,
-        formatter: &DecimalFormatter,
+        formatter: &IntegerFormatter,
         n: impl Into<u64>,
     ) -> Result<(), Error> {
         self.write_decimal(&formatter.format_unsigned(n.into()))
@@ -464,7 +464,7 @@ trait WriteExt: Write {
 
     /// Write the given decimal number to this buffer.
     #[inline]
-    fn write_decimal(&mut self, decimal: &Decimal) -> Result<(), Error> {
+    fn write_decimal(&mut self, decimal: &Integer) -> Result<(), Error> {
         self.write_str(decimal.as_str())
     }
 

--- a/src/fmt/rfc2822.rs
+++ b/src/fmt/rfc2822.rs
@@ -44,7 +44,7 @@ general interchange format for new applications.
 use crate::{
     civil::{Date, DateTime, Time, Weekday},
     error::{fmt::rfc2822::Error as E, ErrorContext},
-    fmt::{util::DecimalFormatter, Parsed, Write, WriteExt},
+    fmt::{util::IntegerFormatter, Parsed, Write, WriteExt},
     tz::{Offset, TimeZone},
     util::{
         parse,
@@ -1292,10 +1292,10 @@ impl DateTimePrinter {
         offset: Option<Offset>,
         mut wtr: W,
     ) -> Result<(), Error> {
-        static FMT_DAY: DecimalFormatter = DecimalFormatter::new();
-        static FMT_YEAR: DecimalFormatter = DecimalFormatter::new().padding(4);
-        static FMT_TIME_UNIT: DecimalFormatter =
-            DecimalFormatter::new().padding(2);
+        static FMT_DAY: IntegerFormatter = IntegerFormatter::new();
+        static FMT_YEAR: IntegerFormatter = IntegerFormatter::new().padding(4);
+        static FMT_TIME_UNIT: IntegerFormatter =
+            IntegerFormatter::new().padding(2);
 
         if dt.year() < 0 {
             // RFC 2822 actually says the year must be at least 1900, but
@@ -1349,10 +1349,10 @@ impl DateTimePrinter {
         timestamp: &Timestamp,
         mut wtr: W,
     ) -> Result<(), Error> {
-        static FMT_DAY: DecimalFormatter = DecimalFormatter::new().padding(2);
-        static FMT_YEAR: DecimalFormatter = DecimalFormatter::new().padding(4);
-        static FMT_TIME_UNIT: DecimalFormatter =
-            DecimalFormatter::new().padding(2);
+        static FMT_DAY: IntegerFormatter = IntegerFormatter::new().padding(2);
+        static FMT_YEAR: IntegerFormatter = IntegerFormatter::new().padding(4);
+        static FMT_TIME_UNIT: IntegerFormatter =
+            IntegerFormatter::new().padding(2);
 
         let dt = TimeZone::UTC.to_datetime(*timestamp);
         if dt.year() < 0 {

--- a/src/fmt/strtime/format.rs
+++ b/src/fmt/strtime/format.rs
@@ -9,7 +9,7 @@ use crate::{
             weekday_name_full, BrokenDownTime, Config, Custom, Extension,
             Flag,
         },
-        util::{DecimalFormatter, FractionalFormatter},
+        util::{FractionalFormatter, IntegerFormatter},
         Write, WriteExt,
     },
     tz::Offset,
@@ -850,7 +850,7 @@ fn write_offset<W: Write>(
     second: bool,
     wtr: &mut W,
 ) -> Result<(), Error> {
-    static FMT_TWO: DecimalFormatter = DecimalFormatter::new().padding(2);
+    static FMT_TWO: IntegerFormatter = IntegerFormatter::new().padding(2);
 
     let hours = offset.part_hours_ranged().abs().get();
     let minutes = offset.part_minutes_ranged().abs().get();
@@ -946,7 +946,7 @@ impl Extension {
             self.width.or(pad_width)
         };
 
-        let mut formatter = DecimalFormatter::new().padding_byte(pad_byte);
+        let mut formatter = IntegerFormatter::new().padding_byte(pad_byte);
         if let Some(width) = pad_width {
             formatter = formatter.padding(width);
         }

--- a/src/fmt/temporal/printer.rs
+++ b/src/fmt/temporal/printer.rs
@@ -3,7 +3,7 @@ use crate::{
     error::{fmt::temporal::Error as E, Error},
     fmt::{
         temporal::{Pieces, PiecesOffset, TimeZoneAnnotationKind},
-        util::{DecimalFormatter, FractionalFormatter},
+        util::{FractionalFormatter, IntegerFormatter},
         Write, WriteExt,
     },
     span::Span,
@@ -108,11 +108,11 @@ impl DateTimePrinter {
         date: &Date,
         mut wtr: W,
     ) -> Result<(), Error> {
-        static FMT_YEAR_POSITIVE: DecimalFormatter =
-            DecimalFormatter::new().padding(4);
-        static FMT_YEAR_NEGATIVE: DecimalFormatter =
-            DecimalFormatter::new().padding(6);
-        static FMT_TWO: DecimalFormatter = DecimalFormatter::new().padding(2);
+        static FMT_YEAR_POSITIVE: IntegerFormatter =
+            IntegerFormatter::new().padding(4);
+        static FMT_YEAR_NEGATIVE: IntegerFormatter =
+            IntegerFormatter::new().padding(6);
+        static FMT_TWO: IntegerFormatter = IntegerFormatter::new().padding(2);
 
         if date.year() >= 0 {
             wtr.write_int(&FMT_YEAR_POSITIVE, date.year())?;
@@ -132,7 +132,7 @@ impl DateTimePrinter {
         time: &Time,
         mut wtr: W,
     ) -> Result<(), Error> {
-        static FMT_TWO: DecimalFormatter = DecimalFormatter::new().padding(2);
+        static FMT_TWO: IntegerFormatter = IntegerFormatter::new().padding(2);
         static FMT_FRACTION: FractionalFormatter = FractionalFormatter::new();
 
         wtr.write_int(&FMT_TWO, time.hour())?;
@@ -254,12 +254,12 @@ impl DateTimePrinter {
         iso_week_date: &ISOWeekDate,
         mut wtr: W,
     ) -> Result<(), Error> {
-        static FMT_YEAR_POSITIVE: DecimalFormatter =
-            DecimalFormatter::new().padding(4);
-        static FMT_YEAR_NEGATIVE: DecimalFormatter =
-            DecimalFormatter::new().padding(6);
-        static FMT_TWO: DecimalFormatter = DecimalFormatter::new().padding(2);
-        static FMT_ONE: DecimalFormatter = DecimalFormatter::new().padding(1);
+        static FMT_YEAR_POSITIVE: IntegerFormatter =
+            IntegerFormatter::new().padding(4);
+        static FMT_YEAR_NEGATIVE: IntegerFormatter =
+            IntegerFormatter::new().padding(6);
+        static FMT_TWO: IntegerFormatter = IntegerFormatter::new().padding(2);
+        static FMT_ONE: IntegerFormatter = IntegerFormatter::new().padding(1);
 
         if iso_week_date.year() >= 0 {
             wtr.write_int(&FMT_YEAR_POSITIVE, iso_week_date.year())?;
@@ -304,7 +304,7 @@ impl DateTimePrinter {
         offset: &Offset,
         mut wtr: W,
     ) -> Result<(), Error> {
-        static FMT_TWO: DecimalFormatter = DecimalFormatter::new().padding(2);
+        static FMT_TWO: IntegerFormatter = IntegerFormatter::new().padding(2);
 
         wtr.write_str(if offset.is_negative() { "-" } else { "+" })?;
         let mut hours = offset.part_hours_ranged().abs().get();
@@ -339,7 +339,7 @@ impl DateTimePrinter {
         offset: &Offset,
         mut wtr: W,
     ) -> Result<(), Error> {
-        static FMT_TWO: DecimalFormatter = DecimalFormatter::new().padding(2);
+        static FMT_TWO: IntegerFormatter = IntegerFormatter::new().padding(2);
 
         wtr.write_str(if offset.is_negative() { "-" } else { "+" })?;
         let hours = offset.part_hours_ranged().abs().get();
@@ -427,7 +427,7 @@ impl SpanPrinter {
         span: &Span,
         mut wtr: W,
     ) -> Result<(), Error> {
-        static FMT_INT: DecimalFormatter = DecimalFormatter::new();
+        static FMT_INT: IntegerFormatter = IntegerFormatter::new();
         static FMT_FRACTION: FractionalFormatter = FractionalFormatter::new();
 
         if span.is_negative() {
@@ -541,7 +541,7 @@ impl SpanPrinter {
         dur: &SignedDuration,
         mut wtr: W,
     ) -> Result<(), Error> {
-        static FMT_INT: DecimalFormatter = DecimalFormatter::new();
+        static FMT_INT: IntegerFormatter = IntegerFormatter::new();
         static FMT_FRACTION: FractionalFormatter = FractionalFormatter::new();
 
         let mut non_zero_greater_than_second = false;
@@ -590,7 +590,7 @@ impl SpanPrinter {
         dur: &core::time::Duration,
         mut wtr: W,
     ) -> Result<(), Error> {
-        static FMT_INT: DecimalFormatter = DecimalFormatter::new();
+        static FMT_INT: IntegerFormatter = IntegerFormatter::new();
         static FMT_FRACTION: FractionalFormatter = FractionalFormatter::new();
 
         let mut non_zero_greater_than_second = false;


### PR DESCRIPTION
This more completely unifies unsigned and signed integer
formatting. It also removes an unused option (to force the
printing of the sign) and an unused field.

Interestingly, these changes result in quite a substantial
(relatively speaking) decrease in LLVM lines. In my Biff
benchmark, prior to this PR, we were getting 753,181 LLVM
lines. But with this PR, we get 745,928 LLVM lines.

For compile times on my Biff benchmark (which is just doing
a `cargo build` and a `cargo build --release` after a
`cargo clean` for each), it seems like there's basically
no change. With maybe the release build being a hair faster.

Before this PR:

```
Benchmark 1: cargo b
  Time (mean ± σ):      4.659 s ±  0.023 s    [User: 15.631 s, System: 2.070 s]
  Range (min … max):    4.618 s …  4.694 s    10 runs

Benchmark 2: cargo b -r
  Time (mean ± σ):      7.770 s ±  0.076 s    [User: 65.860 s, System: 2.556 s]
  Range (min … max):    7.656 s …  7.886 s    10 runs
```

After this PR:

```
Benchmark 1: cargo b
  Time (mean ± σ):      4.654 s ±  0.033 s    [User: 15.521 s, System: 2.079 s]
  Range (min … max):    4.606 s …  4.717 s    10 runs

Benchmark 2: cargo b -r
  Time (mean ± σ):      7.651 s ±  0.053 s    [User: 65.295 s, System: 2.560 s]
  Range (min … max):    7.575 s …  7.711 s    10 runs
```
