### PR TITLE
deps: bump jiff-tzdb to 0.1.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,7 +179,7 @@ perf-inline = []
 
 [dependencies]
 jiff-static = { version = "0.2", path = "crates/jiff-static", optional = true }
-jiff-tzdb = { version = "0.1.4", path = "crates/jiff-tzdb", optional = true }
+jiff-tzdb = { version = "0.1.5", path = "crates/jiff-tzdb", optional = true }
 log = { version = "0.4.21", optional = true, default-features = false }
 serde_core = { version = "1.0.221", optional = true, default-features = false }
 


### PR DESCRIPTION
This includes an updated to the tzdb 2025c release.
