### PR TITLE
fmt: fix time zone offset rounding at the boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Enhancements:
 
 * [#460](https://github.com/BurntSushi/jiff/pull/460):
 Improve runtime performance and binary size of RFC 2822 printer.
+* [#461](https://github.com/BurntSushi/jiff/pull/461):
+Tweak behavior of printing min/max offsets in RFC 2822 and Temporal printers.
 
 
 0.2.17 (2025-12-24)

--- a/src/error/fmt/rfc2822.rs
+++ b/src/error/fmt/rfc2822.rs
@@ -29,7 +29,6 @@ pub(crate) enum Error {
     InvalidWeekday { got_non_digit: u8 },
     InvalidYear,
     NegativeYear,
-    OffsetOverflow,
     ParseDay,
     ParseHour,
     ParseMinute,
@@ -153,11 +152,6 @@ impl core::fmt::Display for Error {
             NegativeYear => f.write_str(
                 "datetime has negative year, \
                  which cannot be formatted with RFC 2822",
-            ),
-            OffsetOverflow => f.write_str(
-                "datetime has offset with non-zero second component, \
-                 and rounding it would result in an offset that exceeds \
-                 Jiff's minimum or maximum offset limit",
             ),
             ParseDay => f.write_str("failed to parse day"),
             ParseHour => f.write_str(


### PR DESCRIPTION
Like Temporal, Jiff will round time zone offsets to the nearest minute
when printing datetimes in the RFC 2822 or RFC 9557 formats. For
example, using Temporal:

```
>> Temporal.ZonedDateTime.from("1970-01-01T00:00:00-00:44:30[Africa/Monrovia]").toString()
"1970-01-01T00:00:00-00:45[Africa/Monrovia]"
```

And Jiff has the same behavior:

```
let string = "1970-01-01T00:00:00-00:44:30[Africa/Monrovia]";
println!("{}", string.parse::<jiff::Zoned>().unwrap());
```

Will print:

```
1970-01-01T00:00:00-00:45[Africa/Monrovia]
```

This is because none of RFCs 2822, 3339 or 9557 support sub-minute
precision in time zone offsets.

This all remains unchanged, but there was an edge case I hadn't
considered: what if a `jiff::Zoned` had a minimal or maximal offset?
Those offsets are `-25:59:59` and `+25:59:59`, respectively. These will
result in rounding to `-26:00:00` and `+26:00:00`, respectively. The
rounded offset prints successfully, but this will fail to parse because
they exceed Jiff's limits. This is bad juju. So instead, we truncate
to `-25:59:00` and `+25:59:00`, respectively.

While theoretically possible, this will never happen with a real time
zone. No real time zone has offsets this far from GMT. Which means that
this case can only happen with a peculiar and specific fixed offset.

(In a previous but unreleased commit, I had changed the behavior of the
RFC 2822 printer to return an error in this case. But doing this for the
Temporal printer is not really feasible because it is expected to be
infallible. And in particular this would result in a panic when using
`Zoned`'s `Display` impl via `Zoned::to_string()`. That's no good. So we
can't error here. And since having different behavior in this
pathological case from the RFC 2822 printer is madness, we make the RFC
2822 printer behave the same and remove that error case.)

Another possibility here is to change the minimum and maximum supported
offset values to `-26:00:00` and `+26:00:00`, respectively. In that
case, rounding the minimum and maximum values to the nearest minute
_and_ truncation would result in the same value. It's not clear that
it's really worth making that change for this very peculiar edge case.
