### PR TITLE
signed_duration: expose fallible constructor APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Enhancements:
 Improve runtime performance and binary size of RFC 2822 printer.
 * [#461](https://github.com/BurntSushi/jiff/pull/461):
 Tweak behavior of printing min/max offsets in RFC 2822 and Temporal printers.
+* [#462](https://github.com/BurntSushi/jiff/pull/462):
+Export fallible constructors for `jiff::SignedDuration`.
 
 
 0.2.17 (2025-12-24)


### PR DESCRIPTION
Unbelievably, I just learned that I had accidentally exported
`SignedDuration::try_from_{hours,mins}`. I had never meant to do that
because I hadn't settled on the precise API. Namely, see #439 for some
uncertainty about whether to return an `Option` or a `Result`. And if a
`Result`, whether we should use a more specific error type.

In any case, since these two were exported, I decided to just double
down and export the other fallible constructors as well. Hopefully
we can settle on the return type in Jiff 1.0. (Although if we use a
`Result`, then I think making it `const` will be more difficult.)
