### PR TITLE
fmt: slim down binary size of Temporal ISO 8601 duration printer

### DIFF
--- a/src/span.rs
+++ b/src/span.rs
@@ -5878,7 +5878,7 @@ pub(crate) struct UnitSet(u16);
 impl UnitSet {
     /// Return a bit set representing all units as zero.
     #[inline]
-    fn empty() -> UnitSet {
+    const fn empty() -> UnitSet {
         UnitSet(0)
     }
 
@@ -5887,13 +5887,25 @@ impl UnitSet {
     /// When `is_zero` is false, the unit is added to this set. Otherwise,
     /// the unit is removed from this set.
     #[inline]
-    fn set(self, unit: Unit, is_zero: bool) -> UnitSet {
+    const fn set(self, unit: Unit, is_zero: bool) -> UnitSet {
         let bit = 1 << unit as usize;
         if is_zero {
             UnitSet(self.0 & !bit)
         } else {
             UnitSet(self.0 | bit)
         }
+    }
+
+    /// Returns the set constructed from the given slice of units.
+    #[inline]
+    pub(crate) const fn from_slice(units: &[Unit]) -> UnitSet {
+        let mut set = UnitSet::empty();
+        let mut i = 0;
+        while i < units.len() {
+            set = set.set(units[i], false);
+            i += 1;
+        }
+        set
     }
 
     /// Returns true if and only if no units are in this set.
@@ -5926,6 +5938,12 @@ impl UnitSet {
     #[inline]
     pub(crate) fn only_time(self) -> UnitSet {
         UnitSet(self.0 & 0b0000_0000_0011_1111)
+    }
+
+    /// Returns the intersection of this set and the one given.
+    #[inline]
+    pub(crate) fn intersection(self, other: UnitSet) -> UnitSet {
+        UnitSet(self.0 & other.0)
     }
 
     /// Returns the largest unit in this set, or `None` if none are present.

--- a/src/util/t.rs
+++ b/src/util/t.rs
@@ -338,51 +338,6 @@ pub(crate) type FractionalNanosecond = ri32<
     { NANOS_PER_SECOND.bound() - 1 },
 >;
 
-/// The range of allowable seconds and lower in a span, in units of seconds.
-///
-/// This corresponds to when the min/max of seconds, milliseconds, microseconds
-/// and nanoseconds are added together in a span. This is useful for describing
-/// the limit on the total number of possible seconds when all of these units
-/// are combined. This is necessary as part of printing/parsing spans because
-/// the ISO 8601 duration format doesn't support individual millisecond,
-/// microsecond and nanosecond components. So they all need to be smushed into
-/// seconds and a possible fractional part.
-pub(crate) type SpanSecondsOrLower = ri64<
-    {
-        SpanSeconds::MIN
-            + (SpanMilliseconds::MIN / MILLIS_PER_SECOND.bound())
-            + (SpanMicroseconds::MIN / MICROS_PER_SECOND.bound())
-            + (SpanNanoseconds::MIN / NANOS_PER_SECOND.bound())
-    },
-    {
-        SpanSeconds::MAX
-            + (SpanMilliseconds::MAX / MILLIS_PER_SECOND.bound())
-            + (SpanMicroseconds::MAX / MICROS_PER_SECOND.bound())
-            + (SpanNanoseconds::MAX / NANOS_PER_SECOND.bound())
-    },
->;
-
-/// The range of allowable seconds and lower in a span, in units of
-/// nanoseconds.
-///
-/// See `SpanSecondsOrLower`. This exists for the same reason. Namely, when
-/// serializing a `Span` to an ISO 8601 duration string, we need to combine
-/// seconds and lower into a single fractional seconds value.
-pub(crate) type SpanSecondsOrLowerNanoseconds = ri128<
-    {
-        (SpanSeconds::MIN * NANOS_PER_SECOND.bound())
-            + (SpanMilliseconds::MIN * NANOS_PER_MILLI.bound())
-            + (SpanMicroseconds::MIN * NANOS_PER_MICRO.bound())
-            + SpanNanoseconds::MIN
-    },
-    {
-        (SpanSeconds::MAX * NANOS_PER_SECOND.bound())
-            + (SpanMilliseconds::MAX * NANOS_PER_MILLI.bound())
-            + (SpanMicroseconds::MAX * NANOS_PER_MICRO.bound())
-            + SpanNanoseconds::MAX
-    },
->;
-
 /// The span of seconds permitted for expressing the offset of a time zone.
 pub(crate) type SpanZoneOffset =
     ri32<{ -SPAN_ZONE_OFFSET_TOTAL_SECONDS }, SPAN_ZONE_OFFSET_TOTAL_SECONDS>;


### PR DESCRIPTION
In a simple benchmark program that prints spans, signed and unsigned
durations using `jiff::fmt::temporal::SpanPrinter`, the total number of
LLVM lines is reduced by about 6,000.

There is also a modest improvement in runtime performance:

```
$ critcmp baseline x01 -f 'iso8601.*jiff'
group                                                       baseline                               x05
-----                                                       --------                               ---
print/display/duration/iso8601/jiff                         1.61     27.4±0.24ns        ? ?/sec    1.00     17.1±0.18ns        ? ?/sec
print/display/span/iso8601/jiff                             1.79     30.6±0.36ns        ? ?/sec    1.00     17.1±0.09ns        ? ?/sec
print/iso8601_duration/long-time/duration/buffer/jiff       1.26     24.3±0.07ns        ? ?/sec    1.00     19.3±0.07ns        ? ?/sec
print/iso8601_duration/long-time/duration/to_string/jiff    2.08     52.9±0.28ns        ? ?/sec    1.00     25.4±0.08ns        ? ?/sec
print/iso8601_duration/long-time/span/buffer/jiff           1.39     29.2±0.09ns        ? ?/sec    1.00     21.0±0.04ns        ? ?/sec
print/iso8601_duration/long-time/span/to_string/jiff        2.14     59.0±0.55ns        ? ?/sec    1.00     27.6±0.07ns        ? ?/sec
print/iso8601_duration/long/span/buffer/jiff                1.76     28.1±0.08ns        ? ?/sec    1.00     16.0±0.08ns        ? ?/sec
print/iso8601_duration/long/span/to_string/jiff             1.84     40.1±0.15ns        ? ?/sec    1.00     21.8±0.06ns        ? ?/sec
print/iso8601_duration/medium/span/buffer/jiff              1.37     17.4±0.07ns        ? ?/sec    1.00     12.8±0.08ns        ? ?/sec
print/iso8601_duration/medium/span/to_string/jiff           1.65     31.6±0.14ns        ? ?/sec    1.00     19.2±0.08ns        ? ?/sec
print/iso8601_duration/short/duration/buffer/jiff           1.18     14.7±0.03ns        ? ?/sec    1.00     12.4±0.04ns        ? ?/sec
print/iso8601_duration/short/duration/to_string/jiff        1.08     22.3±0.11ns        ? ?/sec    1.00     20.6±0.08ns        ? ?/sec
print/iso8601_duration/short/span/buffer/jiff               1.27     14.9±0.06ns        ? ?/sec    1.00     11.8±0.02ns        ? ?/sec
print/iso8601_duration/short/span/to_string/jiff            1.14     22.7±0.15ns        ? ?/sec    1.00     19.9±0.10ns        ? ?/sec
print/iso8601_duration/tiny/duration/buffer/jiff            1.00      9.2±0.03ns        ? ?/sec    1.26     11.6±0.01ns        ? ?/sec
print/iso8601_duration/tiny/duration/to_string/jiff         1.00     12.0±0.05ns        ? ?/sec    1.19     14.3±0.10ns        ? ?/sec
print/iso8601_duration/tiny/span/buffer/jiff                1.04     11.4±0.11ns        ? ?/sec    1.00     11.0±0.06ns        ? ?/sec
print/iso8601_duration/tiny/span/to_string/jiff             1.01     14.1±0.08ns        ? ?/sec    1.00     14.0±0.10ns        ? ?/sec
```

The only regression here is on a very tiny duration (`PT2S`). I'm
able to eliminate most of the regression, but only by inlining the
`print_unsigned_duration_impl` function, which increases code size by a
few hundred LLVM lines. My feeling at present is that this isn't worth
it.

The runtime improvements widen the gap between Jiff and Chrono. Before:

```
$ critcmp baseline -g '(.*/)(?:jiff|chrono)$' -f 'iso8601.*buffer'
group                                                baseline/chrono                        baseline/jiff
-----                                                ---------------                        -------------
print/iso8601_duration/long-time/duration/buffer/    1.91     46.3±0.32ns        ? ?/sec    1.00     24.3±0.07ns        ? ?/sec
print/iso8601_duration/long-time/span/buffer/                                               1.00     29.2±0.09ns        ? ?/sec
print/iso8601_duration/long/span/buffer/                                                    1.00     28.1±0.08ns        ? ?/sec
print/iso8601_duration/medium/span/buffer/                                                  1.00     17.4±0.07ns        ? ?/sec
print/iso8601_duration/short/duration/buffer/        2.19     32.1±0.29ns        ? ?/sec    1.00     14.7±0.03ns        ? ?/sec
print/iso8601_duration/short/span/buffer/                                                   1.00     14.9±0.06ns        ? ?/sec
print/iso8601_duration/tiny/duration/buffer/         3.39     31.1±0.18ns        ? ?/sec    1.00      9.2±0.03ns        ? ?/sec
print/iso8601_duration/tiny/span/buffer/                                                    1.00     11.4±0.11ns        ? ?/sec
```

After:

```
$ critcmp cmp -g '(.*/)(?:jiff|chrono)$' -f 'iso8601.*buffer'
group                                                cmp/chrono                             cmp/jiff
-----                                                ----------                             --------
print/iso8601_duration/long-time/duration/buffer/    2.41     46.5±0.23ns        ? ?/sec    1.00     19.3±0.03ns        ? ?/sec
print/iso8601_duration/long-time/span/buffer/                                               1.00     21.2±0.04ns        ? ?/sec
print/iso8601_duration/long/span/buffer/                                                    1.00     16.2±0.05ns        ? ?/sec
print/iso8601_duration/medium/span/buffer/                                                  1.00     12.7±0.03ns        ? ?/sec
print/iso8601_duration/short/duration/buffer/        2.60     31.7±0.15ns        ? ?/sec    1.00     12.2±0.04ns        ? ?/sec
print/iso8601_duration/short/span/buffer/                                                   1.00     11.6±0.04ns        ? ?/sec
print/iso8601_duration/tiny/duration/buffer/         4.09     31.3±0.12ns        ? ?/sec    1.00      7.7±0.07ns        ? ?/sec
print/iso8601_duration/tiny/span/buffer/                                                    1.00      7.1±0.05ns        ? ?/sec
```
