### PR TITLE
fmt: some minor clean-ups to uninit buffer abstraction

### DIFF
--- a/src/fmt/buffer.rs
+++ b/src/fmt/buffer.rs
@@ -243,7 +243,8 @@ impl<'data> BorrowedBuffer<'data> {
     /// When the available space is insufficient to encode the number of
     /// digits in the decimal representation of `n`.
     #[cfg_attr(feature = "perf-inline", inline(always))]
-    pub(crate) fn write_int(&mut self, mut n: u64) {
+    pub(crate) fn write_int(&mut self, n: impl Into<u64>) {
+        let mut n = n.into();
         let digits = digits(n);
         let mut remaining_digits = usize::from(digits);
         let available = self
@@ -278,7 +279,8 @@ impl<'data> BorrowedBuffer<'data> {
     ///
     /// This also panics when `pad_byte` is not ASCII.
     #[cfg_attr(feature = "perf-inline", inline(always))]
-    pub(crate) fn write_int_pad0(&mut self, mut n: u64, pad_len: u8) {
+    pub(crate) fn write_int_pad0(&mut self, n: impl Into<u64>, pad_len: u8) {
+        let mut n = n.into();
         let pad_len = pad_len.min(MAX_INTEGER_LEN);
         let digits = pad_len.max(digits(n));
         let mut remaining_digits = usize::from(digits);
@@ -314,12 +316,13 @@ impl<'data> BorrowedBuffer<'data> {
     #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) fn write_int_pad(
         &mut self,
-        mut n: u64,
+        n: impl Into<u64>,
         pad_byte: u8,
         pad_len: u8,
     ) {
         assert!(pad_byte.is_ascii(), "padding byte must be ASCII");
 
+        let mut n = n.into();
         let pad_len = pad_len.min(MAX_INTEGER_LEN);
         let digits = pad_len.max(digits(n));
         let mut remaining_digits = usize::from(digits);
@@ -358,7 +361,8 @@ impl<'data> BorrowedBuffer<'data> {
     ///
     /// When the available space is shorter than 1 or if `n > 9`.
     #[cfg_attr(feature = "perf-inline", inline(always))]
-    pub(crate) fn write_int1(&mut self, n: u64) {
+    pub(crate) fn write_int1(&mut self, n: impl Into<u64>) {
+        let n = n.into();
         // This is required for correctness. When `n > 9`, then the
         // `n as u8` below could result in writing an invalid UTF-8
         // byte. We don't mind incorrect results, but writing invalid
@@ -375,7 +379,8 @@ impl<'data> BorrowedBuffer<'data> {
     ///
     /// When the available space is shorter than 2 or if `n > 99`.
     #[cfg_attr(feature = "perf-inline", inline(always))]
-    pub(crate) fn write_int_pad2(&mut self, n: u64) {
+    pub(crate) fn write_int_pad2(&mut self, n: impl Into<u64>) {
+        let n = n.into();
         // This is required for correctness. When `n > 99`, then the
         // last `n as u8` below could result in writing an invalid UTF-8
         // byte. We don't mind incorrect results, but writing invalid
@@ -411,7 +416,8 @@ impl<'data> BorrowedBuffer<'data> {
     ///
     /// When the available space is shorter than 2 or if `n > 99`.
     #[cfg_attr(feature = "perf-inline", inline(always))]
-    pub(crate) fn write_int_pad2_space(&mut self, n: u64) {
+    pub(crate) fn write_int_pad2_space(&mut self, n: impl Into<u64>) {
+        let n = n.into();
         // This is required for correctness. When `n > 99`, then the
         // last `n as u8` below could result in writing an invalid UTF-8
         // byte. We don't mind incorrect results, but writing invalid
@@ -447,7 +453,8 @@ impl<'data> BorrowedBuffer<'data> {
     ///
     /// When the available space is shorter than 4 or if `n > 9999`.
     #[cfg_attr(feature = "perf-inline", inline(always))]
-    pub(crate) fn write_int_pad4(&mut self, mut n: u64) {
+    pub(crate) fn write_int_pad4(&mut self, n: impl Into<u64>) {
+        let mut n = n.into();
         // This is required for correctness. When `n > 9999`, then the
         // last `n as u8` below could result in writing an invalid UTF-8
         // byte. We don't mind incorrect results, but writing invalid
@@ -768,20 +775,13 @@ impl<'buffer, 'data, 'write> BorrowedWriter<'buffer, 'data, 'write> {
     }
 
     #[cfg_attr(feature = "perf-inline", inline(always))]
-    #[allow(dead_code)]
-    pub(crate) fn write_int(&mut self, n: u64) -> Result<(), Error> {
-        self.if_will_fill_then_flush(digits(n))?;
-        self.bbuf.write_int(n);
-        Ok(())
-    }
-
-    #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) fn write_int_pad(
         &mut self,
-        n: u64,
+        n: impl Into<u64>,
         pad_byte: u8,
         pad_len: u8,
     ) -> Result<(), Error> {
+        let n = n.into();
         let pad_len = pad_len.min(MAX_INTEGER_LEN);
         let digits = pad_len.max(digits(n));
         self.if_will_fill_then_flush(digits)?;
@@ -790,7 +790,10 @@ impl<'buffer, 'data, 'write> BorrowedWriter<'buffer, 'data, 'write> {
     }
 
     #[cfg_attr(feature = "perf-inline", inline(always))]
-    pub(crate) fn write_int_pad2(&mut self, n: u64) -> Result<(), Error> {
+    pub(crate) fn write_int_pad2(
+        &mut self,
+        n: impl Into<u64>,
+    ) -> Result<(), Error> {
         self.if_will_fill_then_flush(2usize)?;
         self.bbuf.write_int_pad2(n);
         Ok(())
@@ -799,7 +802,7 @@ impl<'buffer, 'data, 'write> BorrowedWriter<'buffer, 'data, 'write> {
     #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) fn write_int_pad2_space(
         &mut self,
-        n: u64,
+        n: impl Into<u64>,
     ) -> Result<(), Error> {
         self.if_will_fill_then_flush(2usize)?;
         self.bbuf.write_int_pad2_space(n);
@@ -807,7 +810,10 @@ impl<'buffer, 'data, 'write> BorrowedWriter<'buffer, 'data, 'write> {
     }
 
     #[cfg_attr(feature = "perf-inline", inline(always))]
-    pub(crate) fn write_int_pad4(&mut self, n: u64) -> Result<(), Error> {
+    pub(crate) fn write_int_pad4(
+        &mut self,
+        n: impl Into<u64>,
+    ) -> Result<(), Error> {
         self.if_will_fill_then_flush(4usize)?;
         self.bbuf.write_int_pad4(n);
         Ok(())
@@ -884,28 +890,28 @@ mod tests {
         let mut buf = ArrayBuffer::<100>::default();
         let mut bbuf = buf.as_borrowed();
 
-        bbuf.write_int(0);
+        bbuf.write_int(0u64);
         {
             let buf = bbuf.filled();
             assert_eq!(buf, "0");
         }
 
         bbuf.clear();
-        bbuf.write_int(1);
+        bbuf.write_int(1u64);
         {
             let buf = bbuf.filled();
             assert_eq!(buf, "1");
         }
 
         bbuf.clear();
-        bbuf.write_int(10);
+        bbuf.write_int(10u64);
         {
             let buf = bbuf.filled();
             assert_eq!(buf, "10");
         }
 
         bbuf.clear();
-        bbuf.write_int(100);
+        bbuf.write_int(100u64);
         {
             let buf = bbuf.filled();
             assert_eq!(buf, "100");
@@ -924,28 +930,28 @@ mod tests {
         let mut buf = ArrayBuffer::<100>::default();
         let mut bbuf = buf.as_borrowed();
 
-        bbuf.write_int_pad2(0);
+        bbuf.write_int_pad2(0u64);
         {
             let buf = bbuf.filled();
             assert_eq!(buf, "00");
         }
 
         bbuf.clear();
-        bbuf.write_int_pad2(1);
+        bbuf.write_int_pad2(1u64);
         {
             let buf = bbuf.filled();
             assert_eq!(buf, "01");
         }
 
         bbuf.clear();
-        bbuf.write_int_pad2(10);
+        bbuf.write_int_pad2(10u64);
         {
             let buf = bbuf.filled();
             assert_eq!(buf, "10");
         }
 
         bbuf.clear();
-        bbuf.write_int_pad2(99);
+        bbuf.write_int_pad2(99u64);
         {
             let buf = bbuf.filled();
             assert_eq!(buf, "99");
@@ -959,7 +965,7 @@ mod tests {
         let mut bbuf = buf.as_borrowed();
         // technically unspecified behavior,
         // but should not result in undefined behavior.
-        bbuf.write_int_pad4(u64::MAX);
+        bbuf.write_int_pad2(u64::MAX);
     }
 
     #[test]
@@ -967,42 +973,42 @@ mod tests {
         let mut buf = ArrayBuffer::<100>::default();
         let mut bbuf = buf.as_borrowed();
 
-        bbuf.write_int_pad4(0);
+        bbuf.write_int_pad4(0u64);
         {
             let buf = bbuf.filled();
             assert_eq!(buf, "0000");
         }
 
         bbuf.clear();
-        bbuf.write_int_pad4(1);
+        bbuf.write_int_pad4(1u64);
         {
             let buf = bbuf.filled();
             assert_eq!(buf, "0001");
         }
 
         bbuf.clear();
-        bbuf.write_int_pad4(10);
+        bbuf.write_int_pad4(10u64);
         {
             let buf = bbuf.filled();
             assert_eq!(buf, "0010");
         }
 
         bbuf.clear();
-        bbuf.write_int_pad4(99);
+        bbuf.write_int_pad4(99u64);
         {
             let buf = bbuf.filled();
             assert_eq!(buf, "0099");
         }
 
         bbuf.clear();
-        bbuf.write_int_pad4(999);
+        bbuf.write_int_pad4(999u64);
         {
             let buf = bbuf.filled();
             assert_eq!(buf, "0999");
         }
 
         bbuf.clear();
-        bbuf.write_int_pad4(9999);
+        bbuf.write_int_pad4(9999u64);
         {
             let buf = bbuf.filled();
             assert_eq!(buf, "9999");
@@ -1024,28 +1030,28 @@ mod tests {
         let mut buf = ArrayBuffer::<100>::default();
         let mut bbuf = buf.as_borrowed();
 
-        bbuf.write_int_pad(0, b'0', 0);
+        bbuf.write_int_pad(0u64, b'0', 0);
         {
             let buf = bbuf.filled();
             assert_eq!(buf, "0");
         }
 
         bbuf.clear();
-        bbuf.write_int_pad(0, b'0', 1);
+        bbuf.write_int_pad(0u64, b'0', 1);
         {
             let buf = bbuf.filled();
             assert_eq!(buf, "0");
         }
 
         bbuf.clear();
-        bbuf.write_int_pad(0, b'0', 2);
+        bbuf.write_int_pad(0u64, b'0', 2);
         {
             let buf = bbuf.filled();
             assert_eq!(buf, "00");
         }
 
         bbuf.clear();
-        bbuf.write_int_pad(0, b'0', 20);
+        bbuf.write_int_pad(0u64, b'0', 20);
         {
             let buf = bbuf.filled();
             assert_eq!(buf, "00000000000000000000");
@@ -1053,14 +1059,14 @@ mod tests {
 
         bbuf.clear();
         // clamped to 20
-        bbuf.write_int_pad(0, b'0', 21);
+        bbuf.write_int_pad(0u64, b'0', 21);
         {
             let buf = bbuf.filled();
             assert_eq!(buf, "00000000000000000000");
         }
 
         bbuf.clear();
-        bbuf.write_int_pad(0, b' ', 2);
+        bbuf.write_int_pad(0u64, b' ', 2);
         {
             let buf = bbuf.filled();
             assert_eq!(buf, " 0");
@@ -1072,28 +1078,28 @@ mod tests {
         let mut buf = ArrayBuffer::<100>::default();
         let mut bbuf = buf.as_borrowed();
 
-        bbuf.write_int_pad(1, b'0', 0);
+        bbuf.write_int_pad(1u64, b'0', 0);
         {
             let buf = bbuf.filled();
             assert_eq!(buf, "1");
         }
 
         bbuf.clear();
-        bbuf.write_int_pad(1, b'0', 1);
+        bbuf.write_int_pad(1u64, b'0', 1);
         {
             let buf = bbuf.filled();
             assert_eq!(buf, "1");
         }
 
         bbuf.clear();
-        bbuf.write_int_pad(1, b'0', 2);
+        bbuf.write_int_pad(1u64, b'0', 2);
         {
             let buf = bbuf.filled();
             assert_eq!(buf, "01");
         }
 
         bbuf.clear();
-        bbuf.write_int_pad(1, b'0', 20);
+        bbuf.write_int_pad(1u64, b'0', 20);
         {
             let buf = bbuf.filled();
             assert_eq!(buf, "00000000000000000001");
@@ -1101,14 +1107,14 @@ mod tests {
 
         bbuf.clear();
         // clamped to 20
-        bbuf.write_int_pad(1, b'0', 21);
+        bbuf.write_int_pad(1u64, b'0', 21);
         {
             let buf = bbuf.filled();
             assert_eq!(buf, "00000000000000000001");
         }
 
         bbuf.clear();
-        bbuf.write_int_pad(1, b' ', 2);
+        bbuf.write_int_pad(1u64, b' ', 2);
         {
             let buf = bbuf.filled();
             assert_eq!(buf, " 1");
@@ -1168,7 +1174,7 @@ mod tests {
     fn write_int_pad_non_ascii_panic() {
         let mut buf = ArrayBuffer::<100>::default();
         let mut bbuf = buf.as_borrowed();
-        bbuf.write_int_pad(0, 0xFF, 0);
+        bbuf.write_int_pad(0u64, 0xFF, 0);
     }
 
     #[test]
@@ -1176,7 +1182,7 @@ mod tests {
     fn write_int_pad_insufficient_capacity_panic() {
         let mut buf = ArrayBuffer::<19>::default();
         let mut bbuf = buf.as_borrowed();
-        bbuf.write_int_pad(0, b'0', 20);
+        bbuf.write_int_pad(0u64, b'0', 20);
     }
 
     #[test]

--- a/src/fmt/friendly/printer.rs
+++ b/src/fmt/friendly/printer.rs
@@ -1415,7 +1415,7 @@ impl SpanPrinter {
 
         let padding = self.padding.unwrap_or(2);
         wtr.bbuf.write_int_pad(
-            span.get_hours_ranged().get().unsigned_abs().into(),
+            span.get_hours_ranged().get().unsigned_abs(),
             b'0',
             padding,
         );
@@ -1748,7 +1748,7 @@ impl<'p, 'w, 'd> DesignatorWriter<'p, 'w, 'd> {
         #[cold]
         #[inline(never)]
         fn imp(wtr: &mut DesignatorWriter<'_, '_, '_>) {
-            wtr.bbuf.write_int_pad(0, b'0', wtr.padding);
+            wtr.bbuf.write_int_pad(0u64, b'0', wtr.padding);
             if let Some(byte) =
                 wtr.printer.spacing.between_units_and_designators()
             {

--- a/src/fmt/offset.rs
+++ b/src/fmt/offset.rs
@@ -253,17 +253,17 @@ impl core::fmt::Display for Numeric {
         let mut bbuf = buf.as_borrowed();
 
         bbuf.write_ascii_char(if self.sign == C(-1) { b'-' } else { b'+' });
-        bbuf.write_int_pad2(self.hours.get().unsigned_abs().into());
+        bbuf.write_int_pad2(self.hours.get().unsigned_abs());
         if let Some(minutes) = self.minutes {
             bbuf.write_ascii_char(b':');
-            bbuf.write_int_pad2(minutes.get().unsigned_abs().into());
+            bbuf.write_int_pad2(minutes.get().unsigned_abs());
         }
         if let Some(seconds) = self.seconds {
             if self.minutes.is_none() {
                 bbuf.write_str(":00");
             }
             bbuf.write_ascii_char(b':');
-            bbuf.write_int_pad2(seconds.get().unsigned_abs().into());
+            bbuf.write_int_pad2(seconds.get().unsigned_abs());
         }
         if let Some(nanos) = self.nanoseconds {
             if nanos != C(0) {
@@ -274,7 +274,7 @@ impl core::fmt::Display for Numeric {
                     bbuf.write_str(":00");
                 }
                 bbuf.write_ascii_char(b'.');
-                bbuf.write_fraction(None, nanos.get().unsigned_abs().into());
+                bbuf.write_fraction(None, nanos.get().unsigned_abs());
             }
         }
         f.write_str(bbuf.filled())

--- a/src/fmt/rfc2822.rs
+++ b/src/fmt/rfc2822.rs
@@ -1338,17 +1338,17 @@ impl DateTimePrinter {
 
         buf.write_str(weekday_abbrev(dt.weekday()));
         buf.write_str(", ");
-        buf.write_int(dt.day().unsigned_abs().into());
+        buf.write_int(dt.day().unsigned_abs());
         buf.write_ascii_char(b' ');
         buf.write_str(month_name(dt.month()));
         buf.write_ascii_char(b' ');
-        buf.write_int_pad4(dt.year().unsigned_abs().into());
+        buf.write_int_pad4(dt.year().unsigned_abs());
         buf.write_ascii_char(b' ');
-        buf.write_int_pad2(dt.hour().unsigned_abs().into());
+        buf.write_int_pad2(dt.hour().unsigned_abs());
         buf.write_ascii_char(b':');
-        buf.write_int_pad2(dt.minute().unsigned_abs().into());
+        buf.write_int_pad2(dt.minute().unsigned_abs());
         buf.write_ascii_char(b':');
-        buf.write_int_pad2(dt.second().unsigned_abs().into());
+        buf.write_int_pad2(dt.second().unsigned_abs());
         buf.write_ascii_char(b' ');
 
         let Some(offset) = offset else {
@@ -1357,8 +1357,8 @@ impl DateTimePrinter {
         };
         buf.write_ascii_char(if offset.is_negative() { b'-' } else { b'+' });
         let (offset_hours, offset_minutes) = offset.round_to_nearest_minute();
-        buf.write_int_pad2(offset_hours.into());
-        buf.write_int_pad2(offset_minutes.into());
+        buf.write_int_pad2(offset_hours);
+        buf.write_int_pad2(offset_minutes);
 
         Ok(())
     }
@@ -1378,17 +1378,17 @@ impl DateTimePrinter {
 
         buf.write_str(weekday_abbrev(dt.weekday()));
         buf.write_str(", ");
-        buf.write_int_pad2(dt.day().unsigned_abs().into());
+        buf.write_int_pad2(dt.day().unsigned_abs());
         buf.write_str(" ");
         buf.write_str(month_name(dt.month()));
         buf.write_str(" ");
-        buf.write_int_pad4(dt.year().unsigned_abs().into());
+        buf.write_int_pad4(dt.year().unsigned_abs());
         buf.write_str(" ");
-        buf.write_int_pad2(dt.hour().unsigned_abs().into());
+        buf.write_int_pad2(dt.hour().unsigned_abs());
         buf.write_str(":");
-        buf.write_int_pad2(dt.minute().unsigned_abs().into());
+        buf.write_int_pad2(dt.minute().unsigned_abs());
         buf.write_str(":");
-        buf.write_int_pad2(dt.second().unsigned_abs().into());
+        buf.write_int_pad2(dt.second().unsigned_abs());
         buf.write_str(" ");
         buf.write_str("GMT");
         Ok(())

--- a/src/fmt/strtime/format.rs
+++ b/src/fmt/strtime/format.rs
@@ -955,17 +955,17 @@ fn write_offset(
     let seconds = (total_seconds % 60) as u8;
 
     wtr.write_ascii_char(if offset.is_negative() { b'-' } else { b'+' })?;
-    wtr.write_int_pad2(hours.into())?;
+    wtr.write_int_pad2(hours)?;
     if minute || minutes != 0 || seconds != 0 {
         if colon {
             wtr.write_ascii_char(b':')?;
         }
-        wtr.write_int_pad2(minutes.into())?;
+        wtr.write_int_pad2(minutes)?;
         if second || seconds != 0 {
             if colon {
                 wtr.write_ascii_char(b':')?;
             }
-            wtr.write_int_pad2(seconds.into())?;
+            wtr.write_int_pad2(seconds)?;
         }
     }
     Ok(())

--- a/src/fmt/temporal/printer.rs
+++ b/src/fmt/temporal/printer.rs
@@ -359,11 +359,11 @@ impl DateTimePrinter {
         if year < 0 {
             bbuf.write_str("-00");
         }
-        bbuf.write_int_pad4(year.unsigned_abs().into());
+        bbuf.write_int_pad4(year.unsigned_abs());
         bbuf.write_ascii_char(b'-');
-        bbuf.write_int_pad2(date.month().unsigned_abs().into());
+        bbuf.write_int_pad2(date.month().unsigned_abs());
         bbuf.write_ascii_char(b'-');
-        bbuf.write_int_pad2(date.day().unsigned_abs().into());
+        bbuf.write_int_pad2(date.day().unsigned_abs());
     }
 
     fn print_date_wtr(
@@ -375,11 +375,11 @@ impl DateTimePrinter {
         if year < 0 {
             wtr.write_str("-00")?;
         }
-        wtr.write_int_pad4(year.unsigned_abs().into())?;
+        wtr.write_int_pad4(year.unsigned_abs())?;
         wtr.write_ascii_char(b'-')?;
-        wtr.write_int_pad2(date.month().unsigned_abs().into())?;
+        wtr.write_int_pad2(date.month().unsigned_abs())?;
         wtr.write_ascii_char(b'-')?;
-        wtr.write_int_pad2(date.day().unsigned_abs().into())?;
+        wtr.write_int_pad2(date.day().unsigned_abs())?;
         Ok(())
     }
 
@@ -401,11 +401,11 @@ impl DateTimePrinter {
     }
 
     fn print_time_buf(&self, time: &Time, bbuf: &mut BorrowedBuffer<'_>) {
-        bbuf.write_int_pad2(time.hour().unsigned_abs().into());
+        bbuf.write_int_pad2(time.hour().unsigned_abs());
         bbuf.write_ascii_char(b':');
-        bbuf.write_int_pad2(time.minute().unsigned_abs().into());
+        bbuf.write_int_pad2(time.minute().unsigned_abs());
         bbuf.write_ascii_char(b':');
-        bbuf.write_int_pad2(time.second().unsigned_abs().into());
+        bbuf.write_int_pad2(time.second().unsigned_abs());
         let fractional_nanosecond = time.subsec_nanosecond();
         if self.precision.map_or(fractional_nanosecond != 0, |p| p > 0) {
             bbuf.write_ascii_char(b'.');
@@ -421,11 +421,11 @@ impl DateTimePrinter {
         time: &Time,
         wtr: &mut BorrowedWriter<'_, '_, '_>,
     ) -> Result<(), Error> {
-        wtr.write_int_pad2(time.hour().unsigned_abs().into())?;
+        wtr.write_int_pad2(time.hour().unsigned_abs())?;
         wtr.write_ascii_char(b':')?;
-        wtr.write_int_pad2(time.minute().unsigned_abs().into())?;
+        wtr.write_int_pad2(time.minute().unsigned_abs())?;
         wtr.write_ascii_char(b':')?;
-        wtr.write_int_pad2(time.second().unsigned_abs().into())?;
+        wtr.write_int_pad2(time.second().unsigned_abs())?;
         let fractional_nanosecond = time.subsec_nanosecond();
         if self.precision.map_or(fractional_nanosecond != 0, |p| p > 0) {
             wtr.write_ascii_char(b'.')?;
@@ -583,17 +583,13 @@ impl DateTimePrinter {
         if year < 0 {
             bbuf.write_str("-00");
         }
-        bbuf.write_int_pad4(year.unsigned_abs().into());
+        bbuf.write_int_pad4(year.unsigned_abs());
         bbuf.write_ascii_char(b'-');
         bbuf.write_ascii_char(if self.lowercase { b'w' } else { b'W' });
-        bbuf.write_int_pad2(iso_week_date.week().unsigned_abs().into());
+        bbuf.write_int_pad2(iso_week_date.week().unsigned_abs());
         bbuf.write_ascii_char(b'-');
         bbuf.write_int1(
-            iso_week_date
-                .weekday()
-                .to_monday_one_offset()
-                .unsigned_abs()
-                .into(),
+            iso_week_date.weekday().to_monday_one_offset().unsigned_abs(),
         );
     }
 
@@ -625,9 +621,9 @@ impl DateTimePrinter {
     ) {
         bbuf.write_ascii_char(if offset.is_negative() { b'-' } else { b'+' });
         let (offset_hours, offset_minutes) = offset.round_to_nearest_minute();
-        bbuf.write_int_pad2(offset_hours.into());
+        bbuf.write_int_pad2(offset_hours);
         bbuf.write_ascii_char(b':');
-        bbuf.write_int_pad2(offset_minutes.into());
+        bbuf.write_int_pad2(offset_minutes);
     }
 
     /// Formats the given offset into the writer given.
@@ -641,9 +637,9 @@ impl DateTimePrinter {
     ) -> Result<(), Error> {
         wtr.write_ascii_char(if offset.is_negative() { b'-' } else { b'+' })?;
         let (offset_hours, offset_minutes) = offset.round_to_nearest_minute();
-        wtr.write_int_pad2(offset_hours.into())?;
+        wtr.write_int_pad2(offset_hours)?;
         wtr.write_ascii_char(b':')?;
-        wtr.write_int_pad2(offset_minutes.into())?;
+        wtr.write_int_pad2(offset_minutes)?;
         Ok(())
     }
 
@@ -661,12 +657,12 @@ impl DateTimePrinter {
         let hours = offset.part_hours_ranged().get().unsigned_abs();
         let minutes = offset.part_minutes_ranged().get().unsigned_abs();
         let seconds = offset.part_seconds_ranged().get().unsigned_abs();
-        bbuf.write_int_pad2(hours.into());
+        bbuf.write_int_pad2(hours);
         bbuf.write_ascii_char(b':');
-        bbuf.write_int_pad2(minutes.into());
+        bbuf.write_int_pad2(minutes);
         if seconds > 0 {
             bbuf.write_ascii_char(b':');
-            bbuf.write_int_pad2(seconds.into());
+            bbuf.write_int_pad2(seconds);
         }
     }
 
@@ -797,27 +793,19 @@ impl SpanPrinter {
 
         let units = span.units();
         if units.contains(Unit::Year) {
-            bbuf.write_int(
-                span.get_years_unsigned().get().unsigned_abs().into(),
-            );
+            bbuf.write_int(span.get_years_unsigned().get().unsigned_abs());
             bbuf.write_ascii_char(self.label(Unit::Year));
         }
         if units.contains(Unit::Month) {
-            bbuf.write_int(
-                span.get_months_unsigned().get().unsigned_abs().into(),
-            );
+            bbuf.write_int(span.get_months_unsigned().get().unsigned_abs());
             bbuf.write_ascii_char(self.label(Unit::Month));
         }
         if units.contains(Unit::Week) {
-            bbuf.write_int(
-                span.get_weeks_unsigned().get().unsigned_abs().into(),
-            );
+            bbuf.write_int(span.get_weeks_unsigned().get().unsigned_abs());
             bbuf.write_ascii_char(self.label(Unit::Week));
         }
         if units.contains(Unit::Day) {
-            bbuf.write_int(
-                span.get_days_unsigned().get().unsigned_abs().into(),
-            );
+            bbuf.write_int(span.get_days_unsigned().get().unsigned_abs());
             bbuf.write_ascii_char(self.label(Unit::Day));
         }
 
@@ -833,15 +821,11 @@ impl SpanPrinter {
         bbuf.write_ascii_char(b'T');
 
         if units.contains(Unit::Hour) {
-            bbuf.write_int(
-                span.get_hours_unsigned().get().unsigned_abs().into(),
-            );
+            bbuf.write_int(span.get_hours_unsigned().get().unsigned_abs());
             bbuf.write_ascii_char(self.label(Unit::Hour));
         }
         if units.contains(Unit::Minute) {
-            bbuf.write_int(
-                span.get_minutes_unsigned().get().unsigned_abs().into(),
-            );
+            bbuf.write_int(span.get_minutes_unsigned().get().unsigned_abs());
             bbuf.write_ascii_char(self.label(Unit::Minute));
         }
 
@@ -851,9 +835,7 @@ impl SpanPrinter {
         // seconds. But we only want to do that work if we need to.
         let has_subsecond = !units.intersection(SUBSECOND).is_empty();
         if units.contains(Unit::Second) && !has_subsecond {
-            bbuf.write_int(
-                span.get_seconds_unsigned().get().unsigned_abs().into(),
-            );
+            bbuf.write_int(span.get_seconds_unsigned().get().unsigned_abs());
             bbuf.write_ascii_char(self.label(Unit::Second));
         } else if has_subsecond {
             // We want to combine our seconds, milliseconds, microseconds and


### PR DESCRIPTION
Specifically, we:

- Use `MaybeUninit::write` in lieu of `MaybeUninit::new`
- Improve SAFETY comments
- Use `impl Into<u64>` for some routines on `BorrowedBuffer`

This PR doesn't impact LLVM line count or runtie performance.
