### PR TITLE
rangeint: switch `/` and `%` operators to match std

### DIFF
--- a/src/civil/date.rs
+++ b/src/civil/date.rs
@@ -3654,8 +3654,8 @@ fn month_add_overflowing(
 ) -> (t::Month, t::SpanYears) {
     let month = t::SpanMonths::rfrom(month);
     let total = month - C(1) + span;
-    let years = total / C(12);
-    let month = (total % C(12)) + C(1);
+    let years = total.div_floor(C(12));
+    let month = total.rem_floor(C(12)) + C(1);
     (month.rinto(), years.rinto())
 }
 
@@ -3759,6 +3759,23 @@ mod tests {
     #[cfg(not(miri))]
     fn all_date_to_iso_week_date_roundtrip() {
         let year_range = 2000..=2500;
+        for year in year_range {
+            let year = Year::new(year).unwrap();
+            for month in [1, 2, 4] {
+                let month = Month::new(month).unwrap();
+                for day in 20..=days_in_month(year, month).get() {
+                    let date = date(year.get(), month.get(), day);
+                    let wd = date.iso_week_date();
+                    let got = wd.date();
+                    assert_eq!(
+                        date, got,
+                        "for date {date:?}, and ISO week date {wd:?}"
+                    );
+                }
+            }
+        }
+
+        let year_range = -9999..=-9500;
         for year in year_range {
             let year = Year::new(year).unwrap();
             for month in [1, 2, 4] {

--- a/src/civil/time.rs
+++ b/src/civil/time.rs
@@ -749,7 +749,7 @@ impl Time {
                 .wrapping_mul(t::NANOS_PER_MICRO),
         );
         sum = sum.wrapping_add(span.get_nanoseconds_ranged().without_bounds());
-        let civil_day_nanosecond = sum % t::NANOS_PER_CIVIL_DAY;
+        let civil_day_nanosecond = sum.rem_floor(t::NANOS_PER_CIVIL_DAY);
         Time::from_nanosecond(civil_day_nanosecond.rinto())
     }
 
@@ -757,7 +757,8 @@ impl Time {
     fn wrapping_add_signed_duration(self, duration: SignedDuration) -> Time {
         let start = t::NoUnits128::rfrom(self.to_nanosecond());
         let duration = t::NoUnits128::new_unchecked(duration.as_nanos());
-        let end = start.wrapping_add(duration) % t::NANOS_PER_CIVIL_DAY;
+        let end =
+            start.wrapping_add(duration).rem_floor(t::NANOS_PER_CIVIL_DAY);
         Time::from_nanosecond(end.rinto())
     }
 
@@ -825,7 +826,8 @@ impl Time {
         // OK because 96-bit unsigned integer can't overflow i128.
         let duration = i128::try_from(duration.as_nanos()).unwrap();
         let duration = t::NoUnits128::new_unchecked(duration);
-        let end = start.wrapping_sub(duration) % t::NANOS_PER_CIVIL_DAY;
+        let end =
+            start.wrapping_sub(duration).rem_floor(t::NANOS_PER_CIVIL_DAY);
         Time::from_nanosecond(end.rinto())
     }
 

--- a/src/civil/weekday.rs
+++ b/src/civil/weekday.rs
@@ -174,6 +174,8 @@ impl Weekday {
     /// ```
     /// use jiff::civil::Weekday;
     ///
+    /// let weekday = Weekday::from_sunday_zero_offset(0)?;
+    /// assert_eq!(weekday, Weekday::Sunday);
     /// let weekday = Weekday::from_sunday_zero_offset(4)?;
     /// assert_eq!(weekday, Weekday::Thursday);
     ///
@@ -413,7 +415,7 @@ impl Weekday {
         let start = t::NoUnits::rfrom(self.to_monday_zero_offset_ranged());
         // OK because all i64 values fit in a NoUnits.
         let rhs = t::NoUnits::new(days.into()).unwrap();
-        let end = start.wrapping_add(rhs) % C(7);
+        let end = start.wrapping_add(rhs).rem_floor(C(7));
         Weekday::from_monday_zero_offset_ranged(end)
     }
 
@@ -551,7 +553,7 @@ impl Weekday {
     pub(crate) fn from_sunday_zero_offset_ranged(
         offset: impl RInto<t::WeekdayZero>,
     ) -> Weekday {
-        let offset_sunday = (offset.rinto() - C(1)) % C(7);
+        let offset_sunday = (offset.rinto() - C(1)).rem_floor(C(7));
         Weekday::from_monday_zero_offset_ranged(offset_sunday)
     }
 
@@ -589,7 +591,7 @@ impl Weekday {
 
     #[inline]
     pub(crate) fn to_sunday_zero_offset_ranged(self) -> t::WeekdayZero {
-        (self.to_monday_zero_offset_ranged() + C(1)) % C(7)
+        (self.to_monday_zero_offset_ranged() + C(1)).rem_floor(C(7))
     }
 
     #[inline]
@@ -606,7 +608,7 @@ impl Weekday {
     pub(crate) fn since_ranged(self, other: Weekday) -> t::WeekdayZero {
         (self.to_monday_zero_offset_ranged()
             - other.to_monday_zero_offset_ranged())
-            % C(7)
+        .rem_floor(C(7))
     }
 
     #[inline]

--- a/src/util/rangeint.rs
+++ b/src/util/rangeint.rs
@@ -1797,25 +1797,25 @@ macro_rules! define_ranged {
             fn div(self, rhs: $name<MIN2, MAX2>) -> Self::Output {
                 #[cfg(not(debug_assertions))]
                 {
-                    let val = self.val.wrapping_div_euclid(rhs.val);
+                    let val = self.val.wrapping_div(rhs.val);
                     Self { val }
                 }
                 #[cfg(debug_assertions)]
                 {
                     let val =
-                        self.val.checked_div_euclid(rhs.val).expect(concat!(
+                        self.val.checked_div(rhs.val).expect(concat!(
                             "dividing ",
                             stringify!($name),
                             " values overflowed"
                         ));
                     let min =
-                        self.min.checked_div_euclid(rhs.min).expect(concat!(
+                        self.min.checked_div(rhs.min).expect(concat!(
                             "dividing ",
                             stringify!($name),
                             " minimums overflowed"
                         ));
                     let max =
-                        self.max.checked_div_euclid(rhs.max).expect(concat!(
+                        self.max.checked_div(rhs.max).expect(concat!(
                             "dividing ",
                             stringify!($name),
                             " maximums overflowed"
@@ -1849,25 +1849,25 @@ macro_rules! define_ranged {
             fn rem(self, rhs: $name<MIN2, MAX2>) -> Self::Output {
                 #[cfg(not(debug_assertions))]
                 {
-                    let val = self.val.wrapping_rem_euclid(rhs.val);
+                    let val = self.val.wrapping_rem(rhs.val);
                     Self { val }
                 }
                 #[cfg(debug_assertions)]
                 {
                     let val =
-                        self.val.checked_rem_euclid(rhs.val).expect(concat!(
+                        self.val.checked_rem(rhs.val).expect(concat!(
                             "modulo ",
                             stringify!($name),
                             " values overflowed"
                         ));
                     let min =
-                        self.min.checked_rem_euclid(rhs.min).expect(concat!(
+                        self.min.checked_rem(rhs.min).expect(concat!(
                             "modulo ",
                             stringify!($name),
                             " minimums overflowed"
                         ));
                     let max =
-                        self.max.checked_rem_euclid(rhs.max).expect(concat!(
+                        self.max.checked_rem(rhs.max).expect(concat!(
                             "modulo ",
                             stringify!($name),
                             " maximums overflowed"

--- a/src/util/round/mode.rs
+++ b/src/util/round/mode.rs
@@ -164,7 +164,9 @@ impl RoundMode {
                     }
                 }
                 RoundMode::HalfEven => {
-                    if expand_is_nearer || (tie && quotient % C(2) == C(1)) {
+                    if expand_is_nearer
+                        || (tie && quotient.rem_floor(C(2)) == C(1))
+                    {
                         quotient += sign;
                     }
                 }


### PR DESCRIPTION
When I first devised the rangeint abstraction, I somewhat unwisely made
its `/` and `%` operators use eucilidean division instead of matching
what `std` does (which always rounds the result toward zero). I did
this because I thought it was going to be overwhelmingly common in
a datetime library. But it ended up not being that common, and it's
probably better to require explicitness.

Anyway, I'm considering ripping out the ranged integer abstraction
inside of Jiff, and this is probably the first step toward making that
not-totally-insane.
