### PR TITLE
fix: correct padding with negative values in strftime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Enable some non-default features for the Rust Playground deployment.
 
 Bug fixes:
 
+* [#485](https://github.com/BurntSushi/jiff/issues/485):
+Fix bug with padding for negative integers in `strftime`.
 * [#486](https://github.com/BurntSushi/jiff/issues/486):
 Make `%^c` result in uppercase strings where appropriate.
 


### PR DESCRIPTION
This is a proposed fix for https://github.com/BurntSushi/jiff/issues/485 where the padding values when using a space as the padding byte adds the '-' sign before the spaces. This approach tried to separate the logic for adding the padding from the happy path since there has been a bunch of optimization work done to make this faster and its a rare case to have negative numbers. 

The overarching purpose of this fix is to use it in uutils coreutils: https://github.com/uutils/coreutils/issues/10242