### PR TITLE
fmt: fix panic in `strftime` for `%2s`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Enhancements:
 * [#491](https://github.com/BurntSushi/jiff/issues/491):
 Avoid cloning `TimeZone` for consuming operations on `Zoned`.
 
+Bug fixes:
+
+* [#497](https://github.com/BurntSushi/jiff/issues/497):
+Fix a panic in `timestamp.strftime("%2s")`.
+
 
 0.2.18 (2026-01-05)
 ===================


### PR DESCRIPTION
Specifically, there was an optimization added recently to use faster
integer formatting when padding to 2 or 4 digits (a common case in
`strftime`). But the optimization path requires that the given integer
is itself limited to 2 or 4 digits. We didn't always check this, and
this assumption in particular can be violated by timestamp integers,
which are often much longer than 2 or 4 digits.

So guard the optimization path by an additional check on the maximum
value of the integer being formatted.

Fixes #497
