### PR TITLE
cargo: enable more features in the Rust Playground environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Enhancements:
 
 * [#500](https://github.com/BurntSushi/jiff/issues/500):
 Update comparison with the `time` crate in the Jiff documentation.
+* [#502](https://github.com/BurntSushi/jiff/issues/502):
+Enable some non-default features for the Rust Playground deployment.
 
 
 0.2.19 (2026-02-05)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,9 +79,9 @@ tz-system = ["std", "dep:windows-sys"]
 # find the offset for a timestamp in a particular time zone before 2037, you
 # just need to do one very fast binary search on the explicit transitions.
 #
-# However, these explicit transitions up through 2037 aren't, strictly speaking,
-# required. For example, the DST transition rule in the United States is
-# perfectly described by a single POSIX time zone string:
+# However, these explicit transitions up through 2037 aren't, strictly
+# speaking, required. For example, the DST transition rule in the United States
+# (as of 2026-02-07) is perfectly described by a single POSIX time zone string:
 #
 #     EST5EDT,M3.2.0,M11.1.0
 #
@@ -287,6 +287,11 @@ all-features = true
 # feature, they sometimes break. By using our "own" `cfg` knob, we are closer
 # to being masters of our own destiny.
 rustdoc-args = ["--cfg", "docsrs_jiff"]
+
+# Ref: https://github.com/BurntSushi/jiff/issues/502
+[package.metadata.playground]
+default-features = true
+features = ["logging", "serde", "static", "tzdb-bundle-always"]
 
 # This squashes the (AFAIK) erroneous warning that `docsrs_jiff` is not a
 # valid `cfg` knob.


### PR DESCRIPTION
It's nicer to provide "everything." Here we include not only support for
`log` and `serde`, but we also enable the `jiff::tz::get!` proc macro
and always bundle the time zone database. This should hopefully provide
seamless time zone support inside the playground.

Interestingly, if one does this on the playground (as of 2026-02-07):

```
println!("{}", jiff::tz::TimeZone::try_system().unwrap_err());
```

Then you'll get an error saying that `tz-system` is not enabled. But it
*is* enabled by default. So this suggests something is already putting
Jiff into a non-default configuration.

Fixes #502
