### PR TITLE
readme: update note about Jiff 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,15 +108,14 @@ documentation lists the full set of supported features.
 
 ### Future plans
 
-With `jiff 0.2` out about 6 months after the `jiff 0.1` initial release, my
-plan remains roughly the same as it started. That is, I'd still like to get a
-`jiff 1.0` release out this summer 2025 (in about 6 months) and then commit to
-it indefinitely. This plan may change if something critically wrong is found
-with the current API.
+My original plan was to release Jiff 1.0 in Summer 2025. It is now Winter 2026,
+so that deadline has clearly slipped. I've continued to make progress toward
+Jiff 1.0, but it has been more work than anticipated. My current hope is to
+have Jiff 1.0 out by Spring or Summer 2026.
 
-The purpose of this plan is to get Jiff to a 1.0 stable state as quickly as
-possible. The reason is so that others feel comfortable relying on Jiff as
-a public dependency that won't cause ecosystem churn.
+It's important to get Jiff 1.0 as "right" as possible. Namely, once it's
+released, I plan to commit to its API indefinitely. At which point, users of
+Jiff should feel comfortable using it as a stable base in public APIs.
 
 ### Performance
 


### PR DESCRIPTION
Jiff 1.0 is clearly not being released in Summer 2025, given that was
six months ago. My renewed plan is Spring or Summer 2026.
