### PR TITLE
jiff-diesel: Allow using Timestamp with diesel::sql_types::Timestamp

### DIFF
--- a/crates/jiff-diesel/src/nullable.rs
+++ b/crates/jiff-diesel/src/nullable.rs
@@ -21,6 +21,10 @@ use crate::ToDiesel;
 )]
 #[cfg_attr(
     feature = "postgres",
+    diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Timestamp>),
+)]
+#[cfg_attr(
+    feature = "postgres",
     diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Timestamptz>),
 )]
 #[cfg_attr(

--- a/crates/jiff-diesel/src/wrappers.rs
+++ b/crates/jiff-diesel/src/wrappers.rs
@@ -43,6 +43,10 @@ pub trait ToDiesel {
 )]
 #[cfg_attr(
     feature = "postgres",
+    diesel(sql_type = diesel::sql_types::Timestamp),
+)]
+#[cfg_attr(
+    feature = "postgres",
     diesel(sql_type = diesel::sql_types::Timestamptz),
 )]
 #[cfg_attr(


### PR DESCRIPTION
This should be correct for PostgreSQL, regardless of the timezone set at the database level.

> Timestamps are represented in Postgres as a 64 bit signed integer representing the number of microseconds since January 1st 2000.

https://docs.rs/diesel/latest/diesel/pg/data_types/struct.PgTimestamp.html

(And the same reason why `diesel::sql_types::Timestamp` can be converted to/from `SystemTime` on Postgres.)