### PR TITLE
Using positive offset bias for to_datetime calculation

### DIFF
--- a/src/shared/util/itime.rs
+++ b/src/shared/util/itime.rs
@@ -47,9 +47,19 @@ impl ITimestamp {
     #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) const fn to_datetime(&self, offset: IOffset) -> IDateTime {
         let ITimestamp { mut second, mut nanosecond } = *self;
-        second += offset.second as i64;
-        let mut epoch_day = second.div_euclid(86_400) as i32;
-        second = second.rem_euclid(86_400);
+
+        // Shift second comfortably into the postive domain
+        // so that division and remainder can use unsigned math
+        // which is much faster.
+        // 30 * 400 years: 12,000 yr range > [-9,999..1970]
+        // (146097 being the number of days per 400 years).
+        const DAY_SHIFT: i32 = 30 * 146097;
+        const SEC_SHIFT: i64 = (DAY_SHIFT as i64) * 86_400;
+
+        let pos_sec = (second + (offset.second as i64) + SEC_SHIFT) as u64;
+        let mut epoch_day = (pos_sec / 86_400) as i32;
+        second = (pos_sec % 86_400) as i64;
+
         if nanosecond < 0 {
             if second > 0 {
                 second -= 1;
@@ -60,6 +70,8 @@ impl ITimestamp {
                 nanosecond += 1_000_000_000;
             }
         }
+
+        epoch_day -= DAY_SHIFT;
 
         let date = IEpochDay { epoch_day }.to_date();
         let mut time = ITimeSecond { second: second as i32 }.to_time();
@@ -960,6 +972,69 @@ mod tests {
         assert_eq!(
             IDate::from_day_of_year(9999, 366),
             Err(RangeError::DayOfYear),
+        );
+    }
+
+    #[test]
+    fn timestamp_to_datetime() {
+        let ts = ITimestamp { second: 0, nanosecond: 1 };
+        let dt = ts.to_datetime(IOffset { second: 1 });
+        assert_eq!(
+            dt,
+            IDateTime {
+                date: IDate { year: 1970, month: 1, day: 1 },
+                time: ITime {
+                    hour: 0,
+                    minute: 0,
+                    second: 1,
+                    subsec_nanosecond: 1
+                },
+            }
+        );
+
+        let ts = ITimestamp { second: 0, nanosecond: 1 };
+        let dt = ts.to_datetime(IOffset { second: -1 });
+        assert_eq!(
+            dt,
+            IDateTime {
+                date: IDate { year: 1969, month: 12, day: 31 },
+                time: ITime {
+                    hour: 23,
+                    minute: 59,
+                    second: 59,
+                    subsec_nanosecond: 1,
+                },
+            }
+        );
+
+        let ts = ITimestamp { second: 0, nanosecond: -1 };
+        let dt = ts.to_datetime(IOffset { second: 1 });
+        assert_eq!(
+            dt,
+            IDateTime {
+                date: IDate { year: 1970, month: 1, day: 1 },
+                time: ITime {
+                    hour: 0,
+                    minute: 0,
+                    second: 0,
+                    subsec_nanosecond: 999_999_999
+                },
+            }
+        );
+
+        let ts = ITimestamp { second: 0, nanosecond: -1 };
+        let dt = ts.to_datetime(IOffset { second: -1 });
+        assert_eq!(
+            dt,
+            IDateTime {
+                date: IDate { year: 1969, month: 12, day: 31 },
+                time: ITime {
+                    hour: 23,
+                    minute: 59,
+                    second: 58,
+                    subsec_nanosecond: 999_999_999,
+                },
+            }
         );
     }
 }


### PR DESCRIPTION
Hi,

While trying to figure out why the rata-die to YMD algorithm is not running fast, I have noticed another area that could potentially unlock much greater speed gains.

Essentially, division and remainder operations are a lot slower when dealing with signed integers than unsigned.
By using a positive offset bias in the ITimestamp to_datetime function, to convert the seconds to unsigned, I have found that the `timestamp/to_civil_datetime_offset_conversion` benchmark improves by more than 10%, perhaps closer to 20% on many computers.

I don't understand why the code is duplicated in the crates/jiff-static directory, and assume that's part of some CI tool that does that, but if you want me to duplicate the changes there I'm happy to.

I'm curious to see what speed gains you achieve with this. If I am not mistaken, I believe that there are many places throughout the Jiff codebase where signed ints could be changed to unsigned for speed gains. Some of the gains will be platform dependent, so not necessarily easily measurable, but I've never heard of an instance where changing signed to unsigned has the opposite effect of slowing it down.

This is the first time I have ever made a pull request in rust, or on github at all, so I apologise if I'm not following the standard conventions for these things. I'm happy to amend if/as required.