### PR TITLE
replace serde_yaml 0.9 to yaml_serde 0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 0.2.21 (TBD)
 ============
-TODO
+
+
+removes the dev-dependency on deprecated `serde_yaml`.
+It has been replaced with `yaml_serde`. See
+[company that now supports yaml-serde which is fork of serde-yaml](https://yaml.com/projects/yaml-serde/)
+for why this was done. Note that this was only a dev-dependency and thus doesn't
+impact folks using Jiff.
 
 Performance:
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jiff"
-version = "0.2.20"  #:version
+version = "0.2.21"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 license = "Unlicense OR MIT"
 repository = "https://github.com/BurntSushi/jiff"
@@ -238,7 +238,7 @@ jiff = { path = "./", default-features = false, features = ["serde", "static"] }
 quickcheck = { version = "1.0.3", default-features = false }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
-serde_yaml = "0.9.34"
+yaml_serde = "0.10.3"
 tabwriter = "1.4.0"
 time = { version = "0.3.36", features = ["local-offset", "macros", "parsing"] }
 time-tz = "2.0.0"

--- a/src/civil/date.rs
+++ b/src/civil/date.rs
@@ -3933,17 +3933,17 @@ mod tests {
     fn civil_date_deserialize_yaml() {
         let expected = date(2024, 10, 31);
 
-        let deserialized: Date = serde_yaml::from_str("2024-10-31").unwrap();
+        let deserialized: Date = yaml_serde::from_str("2024-10-31").unwrap();
 
         assert_eq!(deserialized, expected);
 
         let deserialized: Date =
-            serde_yaml::from_slice("2024-10-31".as_bytes()).unwrap();
+            yaml_serde::from_slice("2024-10-31".as_bytes()).unwrap();
 
         assert_eq!(deserialized, expected);
 
         let cursor = Cursor::new(b"2024-10-31");
-        let deserialized: Date = serde_yaml::from_reader(cursor).unwrap();
+        let deserialized: Date = yaml_serde::from_reader(cursor).unwrap();
 
         assert_eq!(deserialized, expected);
     }

--- a/src/civil/datetime.rs
+++ b/src/civil/datetime.rs
@@ -4520,18 +4520,18 @@ mod tests {
         let expected = datetime(2024, 10, 31, 16, 33, 53, 123456789);
 
         let deserialized: DateTime =
-            serde_yaml::from_str("2024-10-31 16:33:53.123456789").unwrap();
+            yaml_serde::from_str("2024-10-31 16:33:53.123456789").unwrap();
 
         assert_eq!(deserialized, expected);
 
         let deserialized: DateTime =
-            serde_yaml::from_slice("2024-10-31 16:33:53.123456789".as_bytes())
+            yaml_serde::from_slice("2024-10-31 16:33:53.123456789".as_bytes())
                 .unwrap();
 
         assert_eq!(deserialized, expected);
 
         let cursor = Cursor::new(b"2024-10-31 16:33:53.123456789");
-        let deserialized: DateTime = serde_yaml::from_reader(cursor).unwrap();
+        let deserialized: DateTime = yaml_serde::from_reader(cursor).unwrap();
 
         assert_eq!(deserialized, expected);
     }

--- a/src/civil/time.rs
+++ b/src/civil/time.rs
@@ -3533,17 +3533,17 @@ mod tests {
         let expected = time(16, 35, 4, 987654321);
 
         let deserialized: Time =
-            serde_yaml::from_str("16:35:04.987654321").unwrap();
+            yaml_serde::from_str("16:35:04.987654321").unwrap();
 
         assert_eq!(deserialized, expected);
 
         let deserialized: Time =
-            serde_yaml::from_slice("16:35:04.987654321".as_bytes()).unwrap();
+            yaml_serde::from_slice("16:35:04.987654321".as_bytes()).unwrap();
 
         assert_eq!(deserialized, expected);
 
         let cursor = Cursor::new(b"16:35:04.987654321");
-        let deserialized: Time = serde_yaml::from_reader(cursor).unwrap();
+        let deserialized: Time = yaml_serde::from_reader(cursor).unwrap();
 
         assert_eq!(deserialized, expected);
     }

--- a/src/signed_duration.rs
+++ b/src/signed_duration.rs
@@ -3040,18 +3040,18 @@ mod tests {
         let expected = SignedDuration::from_secs(123456789);
 
         let deserialized: SignedDuration =
-            serde_yaml::from_str("PT34293h33m9s").unwrap();
+            yaml_serde::from_str("PT34293h33m9s").unwrap();
 
         assert_eq!(deserialized, expected);
 
         let deserialized: SignedDuration =
-            serde_yaml::from_slice("PT34293h33m9s".as_bytes()).unwrap();
+            yaml_serde::from_slice("PT34293h33m9s".as_bytes()).unwrap();
 
         assert_eq!(deserialized, expected);
 
         let cursor = Cursor::new(b"PT34293h33m9s");
         let deserialized: SignedDuration =
-            serde_yaml::from_reader(cursor).unwrap();
+            yaml_serde::from_reader(cursor).unwrap();
 
         assert_eq!(deserialized, expected);
     }

--- a/src/span.rs
+++ b/src/span.rs
@@ -6932,17 +6932,17 @@ mod tests {
             .seconds(7);
 
         let deserialized: Span =
-            serde_yaml::from_str("P1y2m3w4dT5h6m7s").unwrap();
+            yaml_serde::from_str("P1y2m3w4dT5h6m7s").unwrap();
 
         span_eq!(deserialized, expected);
 
         let deserialized: Span =
-            serde_yaml::from_slice("P1y2m3w4dT5h6m7s".as_bytes()).unwrap();
+            yaml_serde::from_slice("P1y2m3w4dT5h6m7s".as_bytes()).unwrap();
 
         span_eq!(deserialized, expected);
 
         let cursor = Cursor::new(b"P1y2m3w4dT5h6m7s");
-        let deserialized: Span = serde_yaml::from_reader(cursor).unwrap();
+        let deserialized: Span = yaml_serde::from_reader(cursor).unwrap();
 
         span_eq!(deserialized, expected);
     }

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -3699,12 +3699,12 @@ mod tests {
             .timestamp();
 
         let deserialized: Timestamp =
-            serde_yaml::from_str("2024-10-31T16:33:53.123456789+00:00")
+            yaml_serde::from_str("2024-10-31T16:33:53.123456789+00:00")
                 .unwrap();
 
         assert_eq!(deserialized, expected);
 
-        let deserialized: Timestamp = serde_yaml::from_slice(
+        let deserialized: Timestamp = yaml_serde::from_slice(
             "2024-10-31T16:33:53.123456789+00:00".as_bytes(),
         )
         .unwrap();
@@ -3712,7 +3712,7 @@ mod tests {
         assert_eq!(deserialized, expected);
 
         let cursor = Cursor::new(b"2024-10-31T16:33:53.123456789+00:00");
-        let deserialized: Timestamp = serde_yaml::from_reader(cursor).unwrap();
+        let deserialized: Timestamp = yaml_serde::from_reader(cursor).unwrap();
 
         assert_eq!(deserialized, expected);
     }

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -5919,12 +5919,12 @@ mod tests {
             .unwrap();
 
         let deserialized: Zoned =
-            serde_yaml::from_str("2024-10-31T16:33:53.123456789+00:00[UTC]")
+            yaml_serde::from_str("2024-10-31T16:33:53.123456789+00:00[UTC]")
                 .unwrap();
 
         assert_eq!(deserialized, expected);
 
-        let deserialized: Zoned = serde_yaml::from_slice(
+        let deserialized: Zoned = yaml_serde::from_slice(
             "2024-10-31T16:33:53.123456789+00:00[UTC]".as_bytes(),
         )
         .unwrap();
@@ -5932,7 +5932,7 @@ mod tests {
         assert_eq!(deserialized, expected);
 
         let cursor = Cursor::new(b"2024-10-31T16:33:53.123456789+00:00[UTC]");
-        let deserialized: Zoned = serde_yaml::from_reader(cursor).unwrap();
+        let deserialized: Zoned = yaml_serde::from_reader(cursor).unwrap();
 
         assert_eq!(deserialized, expected);
     }


### PR DESCRIPTION
Now yaml organization forked serde_yaml and officially supports this new yaml_serde.

https://yaml.org/ have link to
https://yaml.com/ on main page link to
https://yaml.com/projects/yaml-serde/
and then it links to https://github.com/yaml/yaml-serde
which is now part of the yaml project https://github.com/yaml/
So we should use this new crate https://crates.io/crates/yaml_serde