### PR TITLE
error: 3-4% faster builds via macro instead of trivial '?'

### DIFF
--- a/crates/jiff-static/src/lib.rs
+++ b/crates/jiff-static/src/lib.rs
@@ -41,6 +41,17 @@ this crate. Everything should be managed through the `jiff` crate.
 extern crate alloc;
 extern crate proc_macro;
 
+// Simplified try operator that bypasses Try and From traits, used to reduce
+// compile times.
+macro_rules! rtry {
+    ($($tt:tt)*) => {
+        match $($tt)* {
+            Ok(ok) => ok,
+            Err(err) => return Err(err),
+        }
+    };
+}
+
 use proc_macro::TokenStream;
 use quote::quote;
 

--- a/crates/jiff-static/src/shared/posix.rs
+++ b/crates/jiff-static/src/shared/posix.rs
@@ -333,13 +333,13 @@ impl<ABBREV: AsRef<str> + Debug> PosixTimeZone<ABBREV> {
 
 impl<ABBREV: AsRef<str>> core::fmt::Display for PosixTimeZone<ABBREV> {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        core::fmt::Display::fmt(
+        rtry!(core::fmt::Display::fmt(
             &AbbreviationDisplay(self.std_abbrev.as_ref()),
             f,
-        )?;
-        core::fmt::Display::fmt(&self.std_offset, f)?;
+        ));
+        rtry!(core::fmt::Display::fmt(&self.std_offset, f));
         if let Some(ref dst) = self.dst {
-            dst.display(&self.std_offset, f)?;
+            rtry!(dst.display(&self.std_offset, f));
         }
         Ok(())
     }
@@ -351,28 +351,28 @@ impl<ABBREV: AsRef<str>> PosixDst<ABBREV> {
         std_offset: &PosixOffset,
         f: &mut core::fmt::Formatter,
     ) -> core::fmt::Result {
-        core::fmt::Display::fmt(
+        rtry!(core::fmt::Display::fmt(
             &AbbreviationDisplay(self.abbrev.as_ref()),
             f,
-        )?;
+        ));
         // The overwhelming common case is that DST is exactly one hour ahead
         // of standard time. So common that this is the default. So don't write
         // the offset if we don't need to.
         let default = PosixOffset { second: std_offset.second + 3600 };
         if self.offset != default {
-            core::fmt::Display::fmt(&self.offset, f)?;
+            rtry!(core::fmt::Display::fmt(&self.offset, f));
         }
-        f.write_str(",")?;
-        core::fmt::Display::fmt(&self.rule, f)?;
+        rtry!(f.write_str(","));
+        rtry!(core::fmt::Display::fmt(&self.rule, f));
         Ok(())
     }
 }
 
 impl core::fmt::Display for PosixRule {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        core::fmt::Display::fmt(&self.start, f)?;
-        f.write_str(",")?;
-        core::fmt::Display::fmt(&self.end, f)?;
+        rtry!(core::fmt::Display::fmt(&self.start, f));
+        rtry!(f.write_str(","));
+        rtry!(core::fmt::Display::fmt(&self.end, f));
         Ok(())
     }
 }
@@ -424,12 +424,12 @@ impl PosixDayTime {
 
 impl core::fmt::Display for PosixDayTime {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        core::fmt::Display::fmt(&self.date, f)?;
+        rtry!(core::fmt::Display::fmt(&self.date, f));
         // This is the default time, so don't write it if we
         // don't need to.
         if self.time != PosixTime::DEFAULT {
-            f.write_str("/")?;
-            core::fmt::Display::fmt(&self.time, f)?;
+            rtry!(f.write_str("/"));
+            rtry!(core::fmt::Display::fmt(&self.time, f));
         }
         Ok(())
     }
@@ -498,17 +498,17 @@ impl core::fmt::Display for PosixDay {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match *self {
             PosixDay::JulianOne(n) => {
-                f.write_str("J")?;
+                rtry!(f.write_str("J"));
                 core::fmt::Display::fmt(&n, f)
             }
             PosixDay::JulianZero(n) => core::fmt::Display::fmt(&n, f),
             PosixDay::WeekdayOfMonth { month, week, weekday } => {
-                f.write_str("M")?;
-                core::fmt::Display::fmt(&month, f)?;
-                f.write_str(".")?;
-                core::fmt::Display::fmt(&week, f)?;
-                f.write_str(".")?;
-                core::fmt::Display::fmt(&weekday, f)?;
+                rtry!(f.write_str("M"));
+                rtry!(core::fmt::Display::fmt(&month, f));
+                rtry!(f.write_str("."));
+                rtry!(core::fmt::Display::fmt(&week, f));
+                rtry!(f.write_str("."));
+                rtry!(core::fmt::Display::fmt(&weekday, f));
                 Ok(())
             }
         }
@@ -522,7 +522,7 @@ impl PosixTime {
 impl core::fmt::Display for PosixTime {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         if self.second.is_negative() {
-            f.write_str("-")?;
+            rtry!(f.write_str("-"));
             // The default is positive, so when
             // positive, we write nothing.
         }
@@ -530,11 +530,11 @@ impl core::fmt::Display for PosixTime {
         let h = second / 3600;
         let m = (second / 60) % 60;
         let s = second % 60;
-        core::fmt::Display::fmt(&h, f)?;
+        rtry!(core::fmt::Display::fmt(&h, f));
         if m != 0 || s != 0 {
-            write!(f, ":{m:02}")?;
+            rtry!(write!(f, ":{m:02}"));
             if s != 0 {
-                write!(f, ":{s:02}")?;
+                rtry!(write!(f, ":{s:02}"));
             }
         }
         Ok(())
@@ -553,17 +553,17 @@ impl core::fmt::Display for PosixOffset {
         // N.B. `+` is the default, so we don't
         // need to write that out.
         if self.second > 0 {
-            f.write_str("-")?;
+            rtry!(f.write_str("-"));
         }
         let second = self.second.unsigned_abs();
         let h = second / 3600;
         let m = (second / 60) % 60;
         let s = second % 60;
-        core::fmt::Display::fmt(&h, f)?;
+        rtry!(core::fmt::Display::fmt(&h, f));
         if m != 0 || s != 0 {
-            write!(f, ":{m:02}")?;
+            rtry!(write!(f, ":{m:02}"));
             if s != 0 {
-                write!(f, ":{s:02}")?;
+                rtry!(write!(f, ":{s:02}"));
             }
         }
         Ok(())
@@ -581,8 +581,8 @@ impl<S: AsRef<str>> core::fmt::Display for AbbreviationDisplay<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         let s = self.0.as_ref();
         if s.chars().any(|ch| ch == '+' || ch == '-') {
-            f.write_str("<")?;
-            core::fmt::Display::fmt(&s, f)?;
+            rtry!(f.write_str("<"));
+            rtry!(core::fmt::Display::fmt(&s, f));
             f.write_str(">")
         } else {
             core::fmt::Display::fmt(&s, f)
@@ -682,7 +682,7 @@ impl<'s> Parser<'s> {
     fn parse(
         &self,
     ) -> Result<PosixTimeZone<Abbreviation>, PosixTimeZoneError> {
-        let (time_zone, remaining) = self.parse_prefix()?;
+        let (time_zone, remaining) = rtry!(self.parse_prefix());
         if !remaining.is_empty() {
             return Err(ErrorKind::FoundRemaining.into());
         }
@@ -695,7 +695,7 @@ impl<'s> Parser<'s> {
         &self,
     ) -> Result<(PosixTimeZone<Abbreviation>, &'s [u8]), PosixTimeZoneError>
     {
-        let time_zone = self.parse_posix_time_zone()?;
+        let time_zone = rtry!(self.parse_posix_time_zone());
         Ok((time_zone, self.remaining()))
     }
 
@@ -717,7 +717,7 @@ impl<'s> Parser<'s> {
         if !self.is_done()
             && (self.byte().is_ascii_alphabetic() || self.byte() == b'<')
         {
-            dst = Some(self.parse_posix_dst(&std_offset)?);
+            dst = Some(rtry!(self.parse_posix_dst(&std_offset)));
         }
         Ok(PosixTimeZone { std_abbrev, std_offset, dst })
     }
@@ -813,8 +813,8 @@ impl<'s> Parser<'s> {
             }
         }
         let end = self.pos();
-        let abbrev =
-            core::str::from_utf8(&self.tz[start..end]).map_err(|_| {
+        let abbrev = rtry!(core::str::from_utf8(&self.tz[start..end])
+            .map_err(|_| {
                 // NOTE: I believe this error is technically impossible
                 // since the loop above restricts letters in an
                 // abbreviation to ASCII. So everything from `start` to
@@ -822,7 +822,7 @@ impl<'s> Parser<'s> {
                 // cost us anything to report an error here in case the
                 // code above evolves somehow.
                 UnquotedAbbreviationError::InvalidUtf8
-            })?;
+            }));
         if abbrev.len() < 3 {
             return Err(UnquotedAbbreviationError::TooShort);
         }
@@ -861,8 +861,8 @@ impl<'s> Parser<'s> {
             }
         }
         let end = self.pos();
-        let abbrev =
-            core::str::from_utf8(&self.tz[start..end]).map_err(|_| {
+        let abbrev = rtry!(core::str::from_utf8(&self.tz[start..end])
+            .map_err(|_| {
                 // NOTE: I believe this error is technically impossible
                 // since the loop above restricts letters in an
                 // abbreviation to ASCII. So everything from `start` to
@@ -870,7 +870,7 @@ impl<'s> Parser<'s> {
                 // cost us anything to report an error here in case the
                 // code above evolves somehow.
                 QuotedAbbreviationError::InvalidUtf8
-            })?;
+            }));
         if self.is_done() {
             return Err(QuotedAbbreviationError::UnexpectedEnd);
         }
@@ -937,15 +937,15 @@ impl<'s> Parser<'s> {
     /// DST transition rule. In typical cases, this corresponds to the end
     /// of the TZ string.
     fn parse_rule(&self) -> Result<PosixRule, PosixRuleError> {
-        let start = self
+        let start = rtry!(self
             .parse_posix_datetime()
-            .map_err(PosixRuleError::DateTimeStart)?;
+            .map_err(PosixRuleError::DateTimeStart));
         if self.maybe_byte() != Some(b',') || !self.bump() {
             return Err(PosixRuleError::ExpectedEnd);
         }
-        let end = self
+        let end = rtry!(self
             .parse_posix_datetime()
-            .map_err(PosixRuleError::DateTimeEnd)?;
+            .map_err(PosixRuleError::DateTimeEnd));
         Ok(PosixRule { start, end })
     }
 
@@ -1018,11 +1018,12 @@ impl<'s> Parser<'s> {
     fn parse_posix_julian_day_no_leap(
         &self,
     ) -> Result<i16, PosixJulianNoLeapError> {
-        let number = self
+        let number = rtry!(self
             .parse_number_with_upto_n_digits(3)
-            .map_err(PosixJulianNoLeapError::Parse)?;
-        let number = i16::try_from(number)
-            .map_err(|_| PosixJulianNoLeapError::Range)?;
+            .map_err(PosixJulianNoLeapError::Parse));
+        let number =
+            rtry!(i16::try_from(number)
+                .map_err(|_| PosixJulianNoLeapError::Range));
         if !(1 <= number && number <= 365) {
             return Err(PosixJulianNoLeapError::Range);
         }
@@ -1038,11 +1039,12 @@ impl<'s> Parser<'s> {
     fn parse_posix_julian_day_with_leap(
         &self,
     ) -> Result<i16, PosixJulianLeapError> {
-        let number = self
+        let number = rtry!(self
             .parse_number_with_upto_n_digits(3)
-            .map_err(PosixJulianLeapError::Parse)?;
-        let number =
-            i16::try_from(number).map_err(|_| PosixJulianLeapError::Range)?;
+            .map_err(PosixJulianLeapError::Parse));
+        let number = rtry!(
+            i16::try_from(number).map_err(|_| PosixJulianLeapError::Range)
+        );
         if !(0 <= number && number <= 365) {
             return Err(PosixJulianLeapError::Range);
         }
@@ -1127,10 +1129,11 @@ impl<'s> Parser<'s> {
     /// the parser will be positioned after the month (which may contain
     /// two digits).
     fn parse_month(&self) -> Result<i8, MonthError> {
-        let number = self
+        let number = rtry!(self
             .parse_number_with_upto_n_digits(2)
-            .map_err(MonthError::Parse)?;
-        let number = i8::try_from(number).map_err(|_| MonthError::Range)?;
+            .map_err(MonthError::Parse));
+        let number =
+            rtry!(i8::try_from(number).map_err(|_| MonthError::Range));
         if !(1 <= number && number <= 12) {
             return Err(MonthError::Range);
         }
@@ -1142,11 +1145,11 @@ impl<'s> Parser<'s> {
     /// This is expected to be positioned at the first digit. Upon success,
     /// the parser will be positioned after the week digit.
     fn parse_week(&self) -> Result<i8, WeekOfMonthError> {
-        let number = self
+        let number = rtry!(self
             .parse_number_with_exactly_n_digits(1)
-            .map_err(WeekOfMonthError::Parse)?;
+            .map_err(WeekOfMonthError::Parse));
         let number =
-            i8::try_from(number).map_err(|_| WeekOfMonthError::Range)?;
+            rtry!(i8::try_from(number).map_err(|_| WeekOfMonthError::Range));
         if !(1 <= number && number <= 5) {
             return Err(WeekOfMonthError::Range);
         }
@@ -1161,10 +1164,11 @@ impl<'s> Parser<'s> {
     /// The weekday returned is guaranteed to be in the range `0..=6`, with
     /// `0` corresponding to Sunday.
     fn parse_weekday(&self) -> Result<i8, WeekdayError> {
-        let number = self
+        let number = rtry!(self
             .parse_number_with_exactly_n_digits(1)
-            .map_err(WeekdayError::Parse)?;
-        let number = i8::try_from(number).map_err(|_| WeekdayError::Range)?;
+            .map_err(WeekdayError::Parse));
+        let number =
+            rtry!(i8::try_from(number).map_err(|_| WeekdayError::Range));
         if !(0 <= number && number <= 6) {
             return Err(WeekdayError::Range);
         }
@@ -1186,11 +1190,11 @@ impl<'s> Parser<'s> {
         // Callers should only be using this method when IANA v3+ parsing
         // is enabled.
         assert!(self.ianav3plus);
-        let number = self
+        let number = rtry!(self
             .parse_number_with_upto_n_digits(3)
-            .map_err(HourIanaError::Parse)?;
+            .map_err(HourIanaError::Parse));
         let number =
-            i16::try_from(number).map_err(|_| HourIanaError::Range)?;
+            rtry!(i16::try_from(number).map_err(|_| HourIanaError::Range));
         if !(0 <= number && number <= 167) {
             // The error message says -167 but the check above uses 0.
             // This is because the caller is responsible for parsing
@@ -1210,11 +1214,11 @@ impl<'s> Parser<'s> {
     /// first hour digit should occur. Upon success, the parser will be
     /// positioned immediately after the last hour digit.
     fn parse_hour_posix(&self) -> Result<i8, HourPosixError> {
-        let number = self
+        let number = rtry!(self
             .parse_number_with_upto_n_digits(2)
-            .map_err(HourPosixError::Parse)?;
+            .map_err(HourPosixError::Parse));
         let number =
-            i8::try_from(number).map_err(|_| HourPosixError::Range)?;
+            rtry!(i8::try_from(number).map_err(|_| HourPosixError::Range));
         if !(0 <= number && number <= 24) {
             return Err(HourPosixError::Range);
         }
@@ -1229,10 +1233,11 @@ impl<'s> Parser<'s> {
     /// first minute digit should occur. Upon success, the parser will be
     /// positioned immediately after the second minute digit.
     fn parse_minute(&self) -> Result<i8, MinuteError> {
-        let number = self
+        let number = rtry!(self
             .parse_number_with_exactly_n_digits(2)
-            .map_err(MinuteError::Parse)?;
-        let number = i8::try_from(number).map_err(|_| MinuteError::Range)?;
+            .map_err(MinuteError::Parse));
+        let number =
+            rtry!(i8::try_from(number).map_err(|_| MinuteError::Range));
         if !(0 <= number && number <= 59) {
             return Err(MinuteError::Range);
         }
@@ -1247,10 +1252,11 @@ impl<'s> Parser<'s> {
     /// first second digit should occur. Upon success, the parser will be
     /// positioned immediately after the second second digit.
     fn parse_second(&self) -> Result<i8, SecondError> {
-        let number = self
+        let number = rtry!(self
             .parse_number_with_exactly_n_digits(2)
-            .map_err(SecondError::Parse)?;
-        let number = i8::try_from(number).map_err(|_| SecondError::Range)?;
+            .map_err(SecondError::Parse));
+        let number =
+            rtry!(i8::try_from(number).map_err(|_| SecondError::Range));
         if !(0 <= number && number <= 59) {
             return Err(SecondError::Range);
         }
@@ -1288,10 +1294,10 @@ impl<'s> Parser<'s> {
                     i32::from(digit)
                 }
             };
-            number = number
+            number = rtry!(number
                 .checked_mul(10)
                 .and_then(|n| n.checked_add(digit))
-                .ok_or(NumberError::TooBig)?;
+                .ok_or(NumberError::TooBig));
             self.bump();
         }
         Ok(number)
@@ -1317,10 +1323,10 @@ impl<'s> Parser<'s> {
                 break;
             }
             let digit = i32::from(self.byte() - b'0');
-            number = number
+            number = rtry!(number
                 .checked_mul(10)
                 .and_then(|n| n.checked_add(digit))
-                .ok_or(NumberError::TooBig)?;
+                .ok_or(NumberError::TooBig));
             self.bump();
         }
         Ok(number)
@@ -1429,13 +1435,13 @@ impl core::fmt::Display for PosixTimeZoneError {
         use self::ErrorKind::*;
         match self.kind {
             AbbreviationDst(ref err) => {
-                f.write_str("failed to parse DST time zone abbreviation: ")?;
+                rtry!(f.write_str("failed to parse DST time zone abbreviation: "));
                 core::fmt::Display::fmt(err, f)
             }
             AbbreviationStd(ref err) => {
-                f.write_str(
+                rtry!(f.write_str(
                     "failed to parse standard time zone abbreviation: ",
-                )?;
+                ));
                 core::fmt::Display::fmt(err, f)
             }
             Empty => f.write_str(
@@ -1468,11 +1474,11 @@ impl core::fmt::Display for PosixTimeZoneError {
                  parsing a valid time zone transition rule",
             ),
             OffsetDst(ref err) => {
-                f.write_str("failed to parse DST offset: ")?;
+                rtry!(f.write_str("failed to parse DST offset: "));
                 core::fmt::Display::fmt(err, f)
             }
             OffsetStd(ref err) => {
-                f.write_str("failed to parse standard offset: ")?;
+                rtry!(f.write_str("failed to parse standard offset: "));
                 core::fmt::Display::fmt(err, f)
             }
             Rule(ref err) => core::fmt::Display::fmt(err, f),
@@ -1512,10 +1518,10 @@ impl core::fmt::Display for PosixOffsetError {
             Minute(ref err) => core::fmt::Display::fmt(err, f),
             Second(ref err) => core::fmt::Display::fmt(err, f),
             OptionalSign(ref err) => {
-                f.write_str(
+                rtry!(f.write_str(
                     "failed to parse sign for time offset \
                      POSIX time zone string",
-                )?;
+                ));
                 core::fmt::Display::fmt(err, f)
             }
         }
@@ -1558,11 +1564,15 @@ impl core::fmt::Display for PosixRuleError {
         use self::PosixRuleError::*;
         match *self {
             DateTimeEnd(ref err) => {
-                f.write_str("failed to parse end of DST transition rule: ")?;
+                rtry!(f.write_str(
+                    "failed to parse end of DST transition rule: "
+                ));
                 core::fmt::Display::fmt(err, f)
             }
             DateTimeStart(ref err) => {
-                f.write_str("failed to parse start of DST transition rule: ")?;
+                rtry!(f.write_str(
+                    "failed to parse start of DST transition rule: "
+                ));
                 core::fmt::Display::fmt(err, f)
             }
             ExpectedEnd => f.write_str(
@@ -1670,7 +1680,7 @@ impl core::fmt::Display for PosixJulianNoLeapError {
         use self::PosixJulianNoLeapError::*;
         match *self {
             Parse(ref err) => {
-                f.write_str("invalid one-based Julian day digits: ")?;
+                rtry!(f.write_str("invalid one-based Julian day digits: "));
                 core::fmt::Display::fmt(err, f)
             }
             Range => f.write_str(
@@ -1692,7 +1702,7 @@ impl core::fmt::Display for PosixJulianLeapError {
         use self::PosixJulianLeapError::*;
         match *self {
             Parse(ref err) => {
-                f.write_str("invalid zero-based Julian day digits: ")?;
+                rtry!(f.write_str("invalid zero-based Julian day digits: "));
                 core::fmt::Display::fmt(err, f)
             }
             Range => f.write_str(
@@ -1873,9 +1883,9 @@ impl core::fmt::Display for PosixTimeError {
             Minute(ref err) => core::fmt::Display::fmt(err, f),
             Second(ref err) => core::fmt::Display::fmt(err, f),
             OptionalSign(ref err) => {
-                f.write_str(
+                rtry!(f.write_str(
                     "failed to parse sign for time zone transition time",
-                )?;
+                ));
                 core::fmt::Display::fmt(err, f)
             }
         }
@@ -1923,7 +1933,7 @@ impl core::fmt::Display for MonthError {
         use self::MonthError::*;
         match *self {
             Parse(ref err) => {
-                f.write_str("invalid month digits: ")?;
+                rtry!(f.write_str("invalid month digits: "));
                 core::fmt::Display::fmt(err, f)
             }
             Range => f.write_str(
@@ -1945,7 +1955,7 @@ impl core::fmt::Display for WeekOfMonthError {
         use self::WeekOfMonthError::*;
         match *self {
             Parse(ref err) => {
-                f.write_str("invalid week-of-month digits: ")?;
+                rtry!(f.write_str("invalid week-of-month digits: "));
                 core::fmt::Display::fmt(err, f)
             }
             Range => f.write_str(
@@ -1967,7 +1977,7 @@ impl core::fmt::Display for WeekdayError {
         use self::WeekdayError::*;
         match *self {
             Parse(ref err) => {
-                f.write_str("invalid weekday digits: ")?;
+                rtry!(f.write_str("invalid weekday digits: "));
                 core::fmt::Display::fmt(err, f)
             }
             Range => f.write_str(
@@ -1989,7 +1999,7 @@ impl core::fmt::Display for HourIanaError {
         use self::HourIanaError::*;
         match *self {
             Parse(ref err) => {
-                f.write_str("invalid hour digits: ")?;
+                rtry!(f.write_str("invalid hour digits: "));
                 core::fmt::Display::fmt(err, f)
             }
             Range => f.write_str(
@@ -2011,7 +2021,7 @@ impl core::fmt::Display for HourPosixError {
         use self::HourPosixError::*;
         match *self {
             Parse(ref err) => {
-                f.write_str("invalid hour digits: ")?;
+                rtry!(f.write_str("invalid hour digits: "));
                 core::fmt::Display::fmt(err, f)
             }
             Range => f.write_str(
@@ -2033,7 +2043,7 @@ impl core::fmt::Display for MinuteError {
         use self::MinuteError::*;
         match *self {
             Parse(ref err) => {
-                f.write_str("invalid minute digits: ")?;
+                rtry!(f.write_str("invalid minute digits: "));
                 core::fmt::Display::fmt(err, f)
             }
             Range => f.write_str(
@@ -2055,7 +2065,7 @@ impl core::fmt::Display for SecondError {
         use self::SecondError::*;
         match *self {
             Parse(ref err) => {
-                f.write_str("invalid second digits: ")?;
+                rtry!(f.write_str("invalid second digits: "));
                 core::fmt::Display::fmt(err, f)
             }
             Range => f.write_str(

--- a/crates/jiff-static/src/shared/tzif.rs
+++ b/crates/jiff-static/src/shared/tzif.rs
@@ -84,9 +84,9 @@ impl TzifOwned {
         let (header32, rest) =
             Header::parse(4, bytes).map_err(TzifErrorKind::Header32)?;
         let (mut tzif, rest) = if header32.version == 0 {
-            TzifOwned::parse32(name, header32, rest)?
+            rtry!(TzifOwned::parse32(name, header32, rest))
         } else {
-            TzifOwned::parse64(name, header32, rest)?
+            rtry!(TzifOwned::parse64(name, header32, rest))
         };
         tzif.fatten();
         // This should come after fattening, because fattening may add new
@@ -133,11 +133,11 @@ impl TzifOwned {
                 infos: vec![],
             },
         };
-        let rest = tzif.parse_transitions(&header32, bytes)?;
+        let rest = rtry!(tzif.parse_transitions(&header32, bytes));
         let rest = tzif.parse_transition_types(&header32, rest)?;
-        let rest = tzif.parse_local_time_types(&header32, rest)?;
+        let rest = rtry!(tzif.parse_local_time_types(&header32, rest));
         let rest = tzif.parse_time_zone_designations(&header32, rest)?;
-        let rest = tzif.parse_leap_seconds(&header32, rest)?;
+        let rest = rtry!(tzif.parse_leap_seconds(&header32, rest));
         let rest = tzif.parse_indicators(&header32, rest)?;
         Ok((tzif, rest))
     }
@@ -168,11 +168,11 @@ impl TzifOwned {
                 infos: vec![],
             },
         };
-        let rest = tzif.parse_transitions(&header64, rest)?;
+        let rest = rtry!(tzif.parse_transitions(&header64, rest));
         let rest = tzif.parse_transition_types(&header64, rest)?;
-        let rest = tzif.parse_local_time_types(&header64, rest)?;
+        let rest = rtry!(tzif.parse_local_time_types(&header64, rest));
         let rest = tzif.parse_time_zone_designations(&header64, rest)?;
-        let rest = tzif.parse_leap_seconds(&header64, rest)?;
+        let rest = rtry!(tzif.parse_leap_seconds(&header64, rest));
         let rest = tzif.parse_indicators(&header64, rest)?;
         let rest = tzif.parse_footer(&header64, rest)?;
         // Note that we don't check that the TZif data is fully valid. It is
@@ -295,24 +295,24 @@ impl TzifOwned {
             bytes,
             header.time_zone_designations_len(),
         )?;
-        self.fixed.designations = String::from_utf8(bytes.to_vec())
-            .map_err(|_| TimeZoneDesignatorError::InvalidUtf8)?;
+        self.fixed.designations = rtry!(String::from_utf8(bytes.to_vec())
+            .map_err(|_| TimeZoneDesignatorError::InvalidUtf8));
         // Holy hell, this is brutal. The boundary conditions are crazy.
         for typ in self.types.iter_mut() {
             let start = usize::from(typ.designation.0);
-            let suffix = self
+            let suffix = rtry!(self
                 .fixed
                 .designations
                 .get(start..)
-                .ok_or(TimeZoneDesignatorError::InvalidStart)?;
-            let len = suffix
+                .ok_or(TimeZoneDesignatorError::InvalidStart));
+            let len = rtry!(suffix
                 .find('\x00')
-                .ok_or(TimeZoneDesignatorError::MissingNul)?;
-            let end = start
+                .ok_or(TimeZoneDesignatorError::MissingNul));
+            let end = rtry!(start
                 .checked_add(len)
-                .ok_or(TimeZoneDesignatorError::InvalidLength)?;
-            typ.designation.1 = u8::try_from(end)
-                .map_err(|_| TimeZoneDesignatorError::InvalidEnd)?;
+                .ok_or(TimeZoneDesignatorError::InvalidLength));
+            typ.designation.1 = rtry!(u8::try_from(end)
+                .map_err(|_| TimeZoneDesignatorError::InvalidEnd));
         }
         Ok(rest)
     }
@@ -426,10 +426,10 @@ impl TzifOwned {
         // Only scan up to 1KB for a NUL terminator in case we somehow got
         // passed a huge block of bytes.
         let toscan = &bytes[..bytes.len().min(1024)];
-        let nlat = toscan
+        let nlat = rtry!(toscan
             .iter()
             .position(|&b| b == b'\n')
-            .ok_or(FooterError::TerminatorNotFound)?;
+            .ok_or(FooterError::TerminatorNotFound));
         let (bytes, rest) = bytes.split_at(nlat);
         if !bytes.is_empty() {
             // We could in theory limit TZ strings to their strict POSIX
@@ -438,8 +438,8 @@ impl TzifOwned {
             // that GNU tooling allows it via the `TZ` environment variable
             // even though POSIX doesn't specify it. This all seems okay to me
             // because the V3+ extension is a strict superset of functionality.
-            let posix_tz = PosixTimeZone::parse(bytes)
-                .map_err(FooterError::InvalidPosixTz)?;
+            let posix_tz = rtry!(PosixTimeZone::parse(bytes)
+                .map_err(FooterError::InvalidPosixTz));
             self.fixed.posix_tz = Some(posix_tz);
         }
         Ok(&rest[1..])
@@ -793,30 +793,34 @@ impl Header {
         let (tzh_typecnt_bytes, rest) = rest.split_at(4);
         let (tzh_charcnt_bytes, rest) = rest.split_at(4);
 
-        let tzh_ttisutcnt =
-            from_be_bytes_u32_to_usize(tzh_ttisutcnt_bytes).map_err(|e| {
-                HeaderError::ParseCount { kind: CountKind::Ut, convert: e }
-            })?;
-        let tzh_ttisstdcnt =
-            from_be_bytes_u32_to_usize(tzh_ttisstdcnt_bytes).map_err(|e| {
-                HeaderError::ParseCount { kind: CountKind::Std, convert: e }
-            })?;
-        let tzh_leapcnt =
-            from_be_bytes_u32_to_usize(tzh_leapcnt_bytes).map_err(|e| {
+        let tzh_ttisutcnt = rtry!(from_be_bytes_u32_to_usize(
+            tzh_ttisutcnt_bytes
+        )
+        .map_err(|e| {
+            HeaderError::ParseCount { kind: CountKind::Ut, convert: e }
+        }));
+        let tzh_ttisstdcnt = rtry!(from_be_bytes_u32_to_usize(
+            tzh_ttisstdcnt_bytes
+        )
+        .map_err(|e| {
+            HeaderError::ParseCount { kind: CountKind::Std, convert: e }
+        }));
+        let tzh_leapcnt = rtry!(from_be_bytes_u32_to_usize(tzh_leapcnt_bytes)
+            .map_err(|e| {
                 HeaderError::ParseCount { kind: CountKind::Leap, convert: e }
-            })?;
-        let tzh_timecnt =
-            from_be_bytes_u32_to_usize(tzh_timecnt_bytes).map_err(|e| {
+            }));
+        let tzh_timecnt = rtry!(from_be_bytes_u32_to_usize(tzh_timecnt_bytes)
+            .map_err(|e| {
                 HeaderError::ParseCount { kind: CountKind::Time, convert: e }
-            })?;
-        let tzh_typecnt =
-            from_be_bytes_u32_to_usize(tzh_typecnt_bytes).map_err(|e| {
+            }));
+        let tzh_typecnt = rtry!(from_be_bytes_u32_to_usize(tzh_typecnt_bytes)
+            .map_err(|e| {
                 HeaderError::ParseCount { kind: CountKind::Type, convert: e }
-            })?;
-        let tzh_charcnt =
-            from_be_bytes_u32_to_usize(tzh_charcnt_bytes).map_err(|e| {
+            }));
+        let tzh_charcnt = rtry!(from_be_bytes_u32_to_usize(tzh_charcnt_bytes)
+            .map_err(|e| {
                 HeaderError::ParseCount { kind: CountKind::Char, convert: e }
-            })?;
+            }));
 
         if tzh_ttisutcnt != 0 && tzh_ttisutcnt != tzh_typecnt {
             return Err(HeaderError::MismatchUtType);
@@ -860,11 +864,11 @@ impl Header {
     /// This is useful for, e.g., skipping over the 32-bit V1 data block in
     /// V2+ TZif formatted files.
     fn data_block_len(&self) -> Result<usize, HeaderError> {
-        let a = self.transition_times_len()?;
+        let a = rtry!(self.transition_times_len());
         let b = self.transition_types_len();
-        let c = self.local_time_types_len()?;
+        let c = rtry!(self.local_time_types_len());
         let d = self.time_zone_designations_len();
-        let e = self.leap_second_len()?;
+        let e = rtry!(self.leap_second_len());
         let f = self.standard_wall_len();
         let g = self.ut_local_len();
         a.checked_add(b)
@@ -939,44 +943,46 @@ impl core::fmt::Display for TzifError {
         use self::TzifErrorKind::*;
         match self.kind {
             Footer(ref err) => {
-                f.write_str("invalid TZif footer: ")?;
+                rtry!(f.write_str("invalid TZif footer: "));
                 err.fmt(f)
             }
             Header(ref err) => {
-                f.write_str("invalid TZif header: ")?;
+                rtry!(f.write_str("invalid TZif header: "));
                 err.fmt(f)
             }
             Header32(ref err) => {
-                f.write_str("invalid 32-bit TZif header: ")?;
+                rtry!(f.write_str("invalid 32-bit TZif header: "));
                 err.fmt(f)
             }
             Header64(ref err) => {
-                f.write_str("invalid 64-bit TZif header: ")?;
+                rtry!(f.write_str("invalid 64-bit TZif header: "));
                 err.fmt(f)
             }
             InconsistentPosixTimeZone(ref err) => {
-                f.write_str(
+                rtry!(f.write_str(
                     "found inconsistency with \
                      POSIX time zone transition rule \
                      in TZif file footer: ",
-                )?;
+                ));
                 err.fmt(f)
             }
             Indicator(ref err) => {
-                f.write_str("failed to parse indicators: ")?;
+                rtry!(f.write_str("failed to parse indicators: "));
                 err.fmt(f)
             }
             LocalTimeType(ref err) => {
-                f.write_str("failed to parse local time types: ")?;
+                rtry!(f.write_str("failed to parse local time types: "));
                 err.fmt(f)
             }
             SplitAt(ref err) => err.fmt(f),
             TimeZoneDesignator(ref err) => {
-                f.write_str("failed to parse time zone designators: ")?;
+                rtry!(f.write_str("failed to parse time zone designators: "));
                 err.fmt(f)
             }
             TransitionType(ref err) => {
-                f.write_str("failed to parse time zone transition types: ")?;
+                rtry!(f.write_str(
+                    "failed to parse time zone transition types: "
+                ));
                 err.fmt(f)
             }
         }
@@ -1210,7 +1216,7 @@ impl core::fmt::Display for FooterError {
 
         match *self {
             InvalidPosixTz(ref err) => {
-                f.write_str("invalid POSIX time zone transition rule")?;
+                rtry!(f.write_str("invalid POSIX time zone transition rule"));
                 core::fmt::Display::fmt(err, f)
             }
             MismatchEnd => f.write_str(
@@ -1340,8 +1346,8 @@ impl core::fmt::Display for SplitAtError {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         use self::SplitAtError::*;
 
-        f.write_str("expected bytes for '")?;
-        f.write_str(match *self {
+        rtry!(f.write_str("expected bytes for '"));
+        rtry!(f.write_str(match *self {
             V1 => "v1 TZif",
             LeapSeconds => "leap seconds",
             LocalTimeTypes => "local time types",
@@ -1350,8 +1356,8 @@ impl core::fmt::Display for SplitAtError {
             TransitionTimes => "transition times",
             TransitionTypes => "transition types",
             UTLocalIndicators => "UT/local indicators",
-        })?;
-        f.write_str("data block', but did not find enough bytes")?;
+        }));
+        rtry!(f.write_str("data block', but did not find enough bytes"));
         Ok(())
     }
 }

--- a/crates/jiff-static/src/shared/util/itime.rs
+++ b/crates/jiff-static/src/shared/util/itime.rs
@@ -154,15 +154,15 @@ impl IDateTime {
         &self,
         seconds: i32,
     ) -> Result<IDateTime, RangeError> {
-        let day_second = self
+        let day_second = rtry!(self
             .time
             .to_second()
             .second
             .checked_add(seconds)
-            .ok_or_else(|| RangeError::DateTimeSeconds)?;
+            .ok_or_else(|| RangeError::DateTimeSeconds));
         let days = day_second.div_euclid(86400);
         let second = day_second.rem_euclid(86400);
-        let date = self.date.checked_add_days(days)?;
+        let date = rtry!(self.date.checked_add_days(days));
         let time = ITimeSecond { second }.to_time();
         Ok(IDateTime { date, time })
     }
@@ -236,9 +236,9 @@ impl IEpochDay {
         amount: i32,
     ) -> Result<IEpochDay, RangeError> {
         let epoch_day = self.epoch_day;
-        let sum = epoch_day
+        let sum = rtry!(epoch_day
             .checked_add(amount)
-            .ok_or_else(|| RangeError::EpochDayI32)?;
+            .ok_or_else(|| RangeError::EpochDayI32));
         let ret = IEpochDay { epoch_day: sum };
         if !(IEpochDay::MIN <= ret && ret <= IEpochDay::MAX) {
             return Err(RangeError::EpochDayDays);
@@ -294,11 +294,11 @@ impl IDate {
             return Err(RangeError::DateInvalidDayOfYear { year });
         }
         let start = IDate { year, month: 1, day: 1 }.to_epoch_day();
-        let end = start
+        let end = rtry!(start
             .checked_add(i32::from(day) - 1)
             // This can only happen when `year=9999` and `day=366`.
-            .map_err(|_| RangeError::DayOfYear)?
-            .to_date();
+            .map_err(|_| RangeError::DayOfYear))
+        .to_date();
         // If we overflowed into the next year, then `day` is too big.
         if year != end.year {
             // Can only happen given day=366 and this is a leap year.

--- a/src/civil/date.rs
+++ b/src/civil/date.rs
@@ -903,11 +903,9 @@ impl Date {
     ) -> Result<Date, Error> {
         let weekday = weekday.to_iweekday();
         let idate = self.to_idate_const();
-        Ok(Date::from_idate_const(
-            idate
-                .nth_weekday_of_month(nth, weekday)
-                .map_err(Error::itime_range)?,
-        ))
+        Ok(Date::from_idate_const(rtry!(idate
+            .nth_weekday_of_month(nth, weekday)
+            .map_err(Error::itime_range))))
     }
 
     /// Returns the "nth" weekday from this date, not including itself.
@@ -1064,7 +1062,7 @@ impl Date {
         } else if nth > 0 {
             let weekday_diff = i32::from(weekday.since(self.weekday().next()));
             let diff = (nth - 1) * 7 + weekday_diff;
-            let start = self.tomorrow()?.to_unix_epoch_day();
+            let start = rtry!(self.tomorrow()).to_unix_epoch_day();
             let end = b::UnixEpochDays::checked_add(start, diff)?;
             Ok(Date::from_unix_epoch_day(end))
         } else {
@@ -1073,7 +1071,7 @@ impl Date {
             // OK because of the range on `NthWeekday`.
             let nth = nth.abs();
             let diff = (nth - 1) * 7 + weekday_diff;
-            let start = self.yesterday()?.to_unix_epoch_day();
+            let start = rtry!(self.yesterday()).to_unix_epoch_day();
             let end = b::UnixEpochDays::checked_sub(start, diff)?;
             Ok(Date::from_unix_epoch_day(end))
         }
@@ -1232,7 +1230,7 @@ impl Date {
     /// ```
     #[inline]
     pub fn in_tz(self, time_zone_name: &str) -> Result<Zoned, Error> {
-        let tz = crate::tz::db().get(time_zone_name)?;
+        let tz = rtry!(crate::tz::db().get(time_zone_name));
         self.to_zoned(tz)
     }
 
@@ -1483,7 +1481,7 @@ impl Date {
             month_add_overflowing(self.month(), span.get_months());
         let year = b::Year::checked_add(self.year(), years)
             .and_then(|years| b::Year::checked_add(years, span.get_years()))?;
-        let date = Date::new_constrain(year, month, self.day())?;
+        let date = rtry!(Date::new_constrain(year, month, self.day()));
         let epoch_days = date.to_unix_epoch_day();
         let mut days =
             b::UnixEpochDays::checked_add(epoch_days, 7 * span.get_weeks())
@@ -1509,8 +1507,8 @@ impl Date {
             -1 => self.yesterday(),
             1 => self.tomorrow(),
             days => {
-                let days = b::UnixEpochDays::check(days)
-                    .context(E::OverflowDaysDuration)?;
+                let days = rtry!(b::UnixEpochDays::check(days)
+                    .context(E::OverflowDaysDuration));
                 let days = b::UnixEpochDays::checked_add(
                     days,
                     self.to_unix_epoch_day(),
@@ -1752,7 +1750,7 @@ impl Date {
         other: A,
     ) -> Result<Span, Error> {
         let args: DateDifference = other.into();
-        let span = args.since_with_largest_unit(self)?;
+        let span = rtry!(args.since_with_largest_unit(self));
         if args.rounding_may_change_span() {
             span.round(args.round.relative(self))
         } else {
@@ -1788,7 +1786,7 @@ impl Date {
         other: A,
     ) -> Result<Span, Error> {
         let args: DateDifference = other.into();
-        let span = -args.since_with_largest_unit(self)?;
+        let span = -rtry!(args.since_with_largest_unit(self));
         if args.rounding_may_change_span() {
             span.round(args.round.relative(self))
         } else {
@@ -2485,7 +2483,7 @@ pub struct DateArithmetic {
 impl DateArithmetic {
     #[inline]
     fn checked_add(self, date: Date) -> Result<Date, Error> {
-        match self.duration.to_signed()? {
+        match rtry!(self.duration.to_signed()) {
             SDuration::Span(span) => date.checked_add_span(span),
             SDuration::Absolute(sdur) => date.checked_add_duration(sdur),
         }
@@ -2493,7 +2491,7 @@ impl DateArithmetic {
 
     #[inline]
     fn checked_neg(self) -> Result<DateArithmetic, Error> {
-        let duration = self.duration.checked_neg()?;
+        let duration = rtry!(self.duration.checked_neg());
         Ok(DateArithmetic { duration })
     }
 
@@ -3080,13 +3078,13 @@ impl DateWith {
             None => self.original.day(),
             Some(DateWithDay::OfMonth(day)) => b::Day::check(day)?,
             Some(DateWithDay::OfYear(day)) => {
-                let idate = IDate::from_day_of_year(year, day)
-                    .map_err(Error::itime_range)?;
+                let idate = rtry!(IDate::from_day_of_year(year, day)
+                    .map_err(Error::itime_range));
                 return Ok(Date::from_idate_const(idate));
             }
             Some(DateWithDay::OfYearNoLeap(day)) => {
-                let idate = IDate::from_day_of_year_no_leap(year, day)
-                    .map_err(Error::itime_range)?;
+                let idate = rtry!(IDate::from_day_of_year_no_leap(year, day)
+                    .map_err(Error::itime_range));
                 return Ok(Date::from_idate_const(idate));
             }
         };

--- a/src/civil/datetime.rs
+++ b/src/civil/datetime.rs
@@ -306,8 +306,8 @@ impl DateTime {
         second: i8,
         subsec_nanosecond: i32,
     ) -> Result<DateTime, Error> {
-        let date = Date::new(year, month, day)?;
-        let time = Time::new(hour, minute, second, subsec_nanosecond)?;
+        let date = rtry!(Date::new(year, month, day));
+        let time = rtry!(Time::new(hour, minute, second, subsec_nanosecond));
         Ok(DateTime { date, time })
     }
 
@@ -963,7 +963,7 @@ impl DateTime {
     /// ```
     #[inline]
     pub fn tomorrow(self) -> Result<DateTime, Error> {
-        Ok(DateTime::from_parts(self.date().tomorrow()?, self.time()))
+        Ok(DateTime::from_parts(rtry!(self.date().tomorrow()), self.time()))
     }
 
     /// Returns the datetime with a date immediately preceding this one.
@@ -989,7 +989,7 @@ impl DateTime {
     /// ```
     #[inline]
     pub fn yesterday(self) -> Result<DateTime, Error> {
-        Ok(DateTime::from_parts(self.date().yesterday()?, self.time()))
+        Ok(DateTime::from_parts(rtry!(self.date().yesterday()), self.time()))
     }
 
     /// Returns the "nth" weekday from the beginning or end of the month in
@@ -1062,7 +1062,7 @@ impl DateTime {
         nth: i8,
         weekday: Weekday,
     ) -> Result<DateTime, Error> {
-        let date = self.date().nth_weekday_of_month(nth, weekday)?;
+        let date = rtry!(self.date().nth_weekday_of_month(nth, weekday));
         Ok(DateTime::from_parts(date, self.time()))
     }
 
@@ -1220,7 +1220,7 @@ impl DateTime {
         nth: i32,
         weekday: Weekday,
     ) -> Result<DateTime, Error> {
-        let date = self.date().nth_weekday(nth, weekday)?;
+        let date = rtry!(self.date().nth_weekday(nth, weekday));
         Ok(DateTime::from_parts(date, self.time()))
     }
 
@@ -1442,7 +1442,7 @@ impl DateTime {
     /// clock time.
     #[inline]
     pub fn in_tz(self, time_zone_name: &str) -> Result<Zoned, Error> {
-        let tz = crate::tz::db().get(time_zone_name)?;
+        let tz = rtry!(crate::tz::db().get(time_zone_name));
         self.to_zoned(tz)
     }
 
@@ -1549,17 +1549,17 @@ impl DateTime {
         let amb_ts = tz.to_ambiguous_timestamp(dt);
         let (offset, ts, dt) = match amb_ts.offset() {
             AmbiguousOffset::Unambiguous { offset } => {
-                let ts = offset.to_timestamp(dt)?;
+                let ts = rtry!(offset.to_timestamp(dt));
                 (offset, ts, dt)
             }
             AmbiguousOffset::Gap { before, .. } => {
-                let ts = before.to_timestamp(dt)?;
+                let ts = rtry!(before.to_timestamp(dt));
                 let offset = tz.to_offset(ts);
                 let dt = offset.to_datetime(ts);
                 (offset, ts, dt)
             }
             AmbiguousOffset::Fold { before, .. } => {
-                let ts = before.to_timestamp(dt)?;
+                let ts = rtry!(before.to_timestamp(dt));
                 let offset = tz.to_offset(ts);
                 let dt = offset.to_datetime(ts);
                 (offset, ts, dt)
@@ -1691,18 +1691,18 @@ impl DateTime {
         {
             (true, true) => Ok(self),
             (false, true) => {
-                let new_date = old_date
+                let new_date = rtry!(old_date
                     .checked_add(span)
-                    .context(E::FailedAddSpanDate)?;
+                    .context(E::FailedAddSpanDate));
                 Ok(DateTime::from_parts(new_date, old_time))
             }
             (true, false) => {
-                let (new_time, leftovers) = old_time
+                let (new_time, leftovers) = rtry!(old_time
                     .overflowing_add(span)
-                    .context(E::FailedAddSpanTime)?;
-                let new_date = old_date
+                    .context(E::FailedAddSpanTime));
+                let new_date = rtry!(old_date
                     .checked_add(leftovers)
-                    .context(E::FailedAddSpanOverflowing)?;
+                    .context(E::FailedAddSpanOverflowing));
                 Ok(DateTime::from_parts(new_date, new_time))
             }
             (false, false) => self.checked_add_span_general(span),
@@ -1716,14 +1716,15 @@ impl DateTime {
         let span_date = span.without_lower(Unit::Day);
         let span_time = span.only_lower(Unit::Day);
 
-        let (new_time, leftovers) = old_time
+        let (new_time, leftovers) = rtry!(old_time
             .overflowing_add(&span_time)
-            .context(E::FailedAddSpanTime)?;
-        let new_date =
-            old_date.checked_add(span_date).context(E::FailedAddSpanDate)?;
-        let new_date = new_date
+            .context(E::FailedAddSpanTime));
+        let new_date = rtry!(old_date
+            .checked_add(span_date)
+            .context(E::FailedAddSpanDate));
+        let new_date = rtry!(new_date
             .checked_add(leftovers)
-            .context(E::FailedAddSpanOverflowing)?;
+            .context(E::FailedAddSpanOverflowing));
         Ok(DateTime::from_parts(new_date, new_time))
     }
 
@@ -1733,10 +1734,11 @@ impl DateTime {
         duration: SignedDuration,
     ) -> Result<DateTime, Error> {
         let (date, time) = (self.date(), self.time());
-        let (new_time, leftovers) = time.overflowing_add_duration(duration)?;
-        let new_date = date
+        let (new_time, leftovers) =
+            rtry!(time.overflowing_add_duration(duration));
+        let new_date = rtry!(date
             .checked_add(leftovers)
-            .context(E::FailedAddDurationOverflowing)?;
+            .context(E::FailedAddDurationOverflowing));
         Ok(DateTime::from_parts(new_date, new_time))
     }
 
@@ -1995,7 +1997,7 @@ impl DateTime {
         other: A,
     ) -> Result<Span, Error> {
         let args: DateTimeDifference = other.into();
-        let span = args.until_with_largest_unit(self)?;
+        let span = rtry!(args.until_with_largest_unit(self));
         if args.rounding_may_change_span() {
             span.round(args.round.relative(self))
         } else {
@@ -2032,7 +2034,7 @@ impl DateTime {
         other: A,
     ) -> Result<Span, Error> {
         let args: DateTimeDifference = other.into();
-        let span = -args.until_with_largest_unit(self)?;
+        let span = -rtry!(args.until_with_largest_unit(self));
         if args.rounding_may_change_span() {
             span.round(args.round.relative(self))
         } else {
@@ -2904,7 +2906,7 @@ pub struct DateTimeArithmetic {
 impl DateTimeArithmetic {
     #[inline]
     fn checked_add(self, dt: DateTime) -> Result<DateTime, Error> {
-        match self.duration.to_signed()? {
+        match rtry!(self.duration.to_signed()) {
             SDuration::Span(span) => dt.checked_add_span(span),
             SDuration::Absolute(sdur) => dt.checked_add_duration(sdur),
         }
@@ -2912,7 +2914,7 @@ impl DateTimeArithmetic {
 
     #[inline]
     fn checked_neg(self) -> Result<DateTimeArithmetic, Error> {
-        let duration = self.duration.checked_neg()?;
+        let duration = rtry!(self.duration.checked_neg());
         Ok(DateTimeArithmetic { duration })
     }
 
@@ -3260,7 +3262,7 @@ impl DateTimeDifference {
             }
             time_diff += b::NANOS_PER_CIVIL_DAY * sign;
         }
-        let date_span = d1.until((largest, d2))?;
+        let date_span = rtry!(d1.until((largest, d2)));
         // Unlike in the <=Unit::Day case, this always succeeds because
         // every unit except for nanoseconds (which is not used here) can
         // represent all possible spans of time between any two civil
@@ -3535,10 +3537,10 @@ impl DateTimeRound {
         }
 
         let increment =
-            Increment::for_datetime(self.smallest, self.increment)?;
+            rtry!(Increment::for_datetime(self.smallest, self.increment));
         let time_nanos = dt.time().to_duration();
         let sign = b::Sign::from(dt.date().year());
-        let time_rounded = increment.round(self.mode, time_nanos)?;
+        let time_rounded = rtry!(increment.round(self.mode, time_nanos));
         let (days, time_nanos) = time_rounded.as_civil_days_with_remainder();
         // OK because `abs(days)` here can never be greater than 1. Namely,
         // rounding time increments are limited to values that divide evenly
@@ -3556,9 +3558,9 @@ impl DateTimeRound {
         // `abs(days)` is always <= 1, and so `days_len` should
         // always be at most 1 greater (or less) than where we started. If we
         // started at, e.g., `DateTime::MAX`, then this could overflow.
-        let date = start
+        let date = rtry!(start
             .checked_add(Span::new().days(days_len))
-            .context(E::FailedAddDays)?;
+            .context(E::FailedAddDays));
         Ok(DateTime::from_parts(date, time))
     }
 
@@ -3688,8 +3690,8 @@ impl DateTimeWith {
     /// ```
     #[inline]
     pub fn build(self) -> Result<DateTime, Error> {
-        let date = self.date_with.build()?;
-        let time = self.time_with.build()?;
+        let date = rtry!(self.date_with.build());
+        let time = rtry!(self.time_with.build());
         Ok(DateTime::from_parts(date, time))
     }
 

--- a/src/civil/time.rs
+++ b/src/civil/time.rs
@@ -943,7 +943,7 @@ impl Time {
 
     #[inline]
     fn checked_add_span(self, span: &Span) -> Result<Time, Error> {
-        let (time, span) = self.overflowing_add(span)?;
+        let (time, span) = rtry!(self.overflowing_add(span));
         if span.smallest_non_time_non_zero_unit_error().is_some() {
             return Err(Error::from(E::OverflowTimeNanoseconds));
         }
@@ -1112,7 +1112,7 @@ impl Time {
         let sum = span + time;
         let days = sum.div_euclid(i128::from(b::NANOS_PER_CIVIL_DAY)) as i64;
         let rem = sum.rem_euclid(i128::from(b::NANOS_PER_CIVIL_DAY)) as i64;
-        let span = Span::new().try_days(days)?;
+        let span = rtry!(Span::new().try_days(days));
         Ok((Time::from_nanosecond_unchecked(rem), span))
     }
 
@@ -1241,7 +1241,7 @@ impl Time {
         other: A,
     ) -> Result<Span, Error> {
         let args: TimeDifference = other.into();
-        let span = args.until_with_largest_unit(self)?;
+        let span = rtry!(args.until_with_largest_unit(self));
         if args.rounding_may_change_span() {
             span.round(args.round)
         } else {
@@ -1275,7 +1275,7 @@ impl Time {
         other: A,
     ) -> Result<Span, Error> {
         let args: TimeDifference = other.into();
-        let span = -args.until_with_largest_unit(self)?;
+        let span = -rtry!(args.until_with_largest_unit(self));
         if args.rounding_may_change_span() {
             span.round(args.round)
         } else {
@@ -2230,7 +2230,7 @@ impl TimeArithmetic {
 
     #[inline]
     fn checked_add(self, time: Time) -> Result<Time, Error> {
-        match self.duration.to_signed()? {
+        match rtry!(self.duration.to_signed()) {
             SDuration::Span(span) => time.checked_add_span(span),
             SDuration::Absolute(sdur) => time.checked_add_duration(sdur),
         }
@@ -2238,7 +2238,7 @@ impl TimeArithmetic {
 
     #[inline]
     fn checked_neg(self) -> Result<TimeArithmetic, Error> {
-        let duration = self.duration.checked_neg()?;
+        let duration = rtry!(self.duration.checked_neg());
         Ok(TimeArithmetic { duration })
     }
 
@@ -2793,8 +2793,9 @@ impl TimeRound {
 
     /// Does the actual rounding.
     fn round(&self, t: Time) -> Result<Time, Error> {
-        let increment = Increment::for_time(self.smallest, self.increment)?;
-        let rounded = increment.round(self.mode, t.to_duration())?;
+        let increment =
+            rtry!(Increment::for_time(self.smallest, self.increment));
+        let rounded = rtry!(increment.round(self.mode, t.to_duration()));
         if rounded.as_secs() == i64::from(b::CivilDaySecond::MAX + 1) {
             return Ok(Time::MIN);
         }

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -24,8 +24,8 @@ impl Duration {
             Duration::Span(ref span) => Ok(SDuration::Span(span)),
             Duration::Signed(sdur) => Ok(SDuration::Absolute(sdur)),
             Duration::Unsigned(udur) => {
-                let sdur = SignedDuration::try_from(udur)
-                    .context(E::RangeUnsignedDuration)?;
+                let sdur = rtry!(SignedDuration::try_from(udur)
+                    .context(E::RangeUnsignedDuration));
                 Ok(SDuration::Absolute(sdur))
             }
         }
@@ -87,8 +87,8 @@ impl Duration {
                     // Otherwise, this is the only failure point in this entire
                     // routine. And specifically, we fail here in precisely
                     // the cases where `udur.as_secs() > |i64::MIN|`.
-                    -SignedDuration::try_from(udur)
-                        .context(E::FailedNegateUnsignedDuration)?
+                    -rtry!(SignedDuration::try_from(udur)
+                        .context(E::FailedNegateUnsignedDuration))
                 };
                 Ok(Duration::Signed(sdur))
             }

--- a/src/error/fmt/strtime.rs
+++ b/src/error/fmt/strtime.rs
@@ -355,14 +355,14 @@ impl core::fmt::Display for ParseError {
                  to contain one",
             ),
             ExpectedChoice { available } => {
-                f.write_str(
+                rtry!(f.write_str(
                     "failed to find expected value, available choices are: ",
-                )?;
+                ));
                 for (i, choice) in available.iter().enumerate() {
                     if i > 0 {
-                        f.write_str(", ")?;
+                        rtry!(f.write_str(", "));
                     }
-                    write!(f, "{}", escape::Bytes(choice))?;
+                    rtry!(write!(f, "{}", escape::Bytes(choice)));
                 }
                 Ok(())
             }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -359,9 +359,9 @@ impl core::fmt::Display for Error {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         let mut it = self.chain().peekable();
         while let Some(err) = it.next() {
-            core::fmt::Display::fmt(err.kind(), f)?;
+            rtry!(core::fmt::Display::fmt(err.kind(), f));
             if it.peek().is_some() {
-                f.write_str(": ")?;
+                rtry!(f.write_str(": "));
             }
         }
         Ok(())
@@ -581,7 +581,7 @@ impl core::fmt::Display for CrateFeatureError {
         #[allow(unused_imports)]
         use self::CrateFeatureError::*;
 
-        f.write_str("operation failed because Jiff crate feature `")?;
+        rtry!(f.write_str("operation failed because Jiff crate feature `"));
         #[allow(unused_variables)]
         let name: &str = match *self {
             #[cfg(not(feature = "tz-system"))]
@@ -593,7 +593,7 @@ impl core::fmt::Display for CrateFeatureError {
         };
         #[allow(unreachable_code)]
         {
-            core::fmt::Display::fmt(name, f)?;
+            rtry!(core::fmt::Display::fmt(name, f));
             f.write_str("` is not enabled")
         }
     }

--- a/src/fmt/buffer.rs
+++ b/src/fmt/buffer.rs
@@ -134,8 +134,8 @@ impl<'data> BorrowedBuffer<'data> {
         }
         let mut buf = ArrayBuffer::<N>::default();
         let mut bbuf = buf.as_borrowed();
-        with(&mut bbuf)?;
-        wtr.write_str(bbuf.filled())?;
+        rtry!(with(&mut bbuf));
+        rtry!(wtr.write_str(bbuf.filled()));
         Ok(())
     }
 
@@ -721,7 +721,7 @@ impl<'buffer, 'data, 'write> BorrowedWriter<'buffer, 'data, 'write> {
 
     #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) fn finish(self) -> Result<(), Error> {
-        self.wtr.write_str(self.bbuf.filled())?;
+        rtry!(self.wtr.write_str(self.bbuf.filled()));
         self.bbuf.clear();
         Ok(())
     }
@@ -729,7 +729,7 @@ impl<'buffer, 'data, 'write> BorrowedWriter<'buffer, 'data, 'write> {
     #[cold]
     #[inline(never)]
     pub(crate) fn flush(&mut self) -> Result<(), Error> {
-        self.wtr.write_str(self.bbuf.filled())?;
+        rtry!(self.wtr.write_str(self.bbuf.filled()));
         self.bbuf.clear();
         Ok(())
     }
@@ -741,7 +741,7 @@ impl<'buffer, 'data, 'write> BorrowedWriter<'buffer, 'data, 'write> {
     ) -> Result<(), Error> {
         let n = additional.into();
         if self.bbuf.len().saturating_add(n) > self.bbuf.capacity() {
-            self.flush()?;
+            rtry!(self.flush());
         }
         Ok(())
     }
@@ -749,7 +749,7 @@ impl<'buffer, 'data, 'write> BorrowedWriter<'buffer, 'data, 'write> {
     #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) fn write_str(&mut self, string: &str) -> Result<(), Error> {
         if string.len() > self.bbuf.available_capacity() {
-            self.flush()?;
+            rtry!(self.flush());
             if string.len() > self.bbuf.available_capacity() {
                 return self.wtr.write_str(string);
             }
@@ -760,7 +760,7 @@ impl<'buffer, 'data, 'write> BorrowedWriter<'buffer, 'data, 'write> {
 
     #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) fn write_char(&mut self, ch: char) -> Result<(), Error> {
-        self.if_will_fill_then_flush(ch.len_utf8())?;
+        rtry!(self.if_will_fill_then_flush(ch.len_utf8()));
         self.bbuf.write_char(ch);
         Ok(())
     }
@@ -768,7 +768,7 @@ impl<'buffer, 'data, 'write> BorrowedWriter<'buffer, 'data, 'write> {
     #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) fn write_ascii_char(&mut self, byte: u8) -> Result<(), Error> {
         if self.bbuf.available_capacity() == 0 {
-            self.flush()?;
+            rtry!(self.flush());
         }
         self.bbuf.write_ascii_char(byte);
         Ok(())
@@ -784,7 +784,7 @@ impl<'buffer, 'data, 'write> BorrowedWriter<'buffer, 'data, 'write> {
         let n = n.into();
         let pad_len = pad_len.min(MAX_INTEGER_LEN);
         let digits = pad_len.max(digits(n));
-        self.if_will_fill_then_flush(digits)?;
+        rtry!(self.if_will_fill_then_flush(digits));
         self.bbuf.write_int_pad(n, pad_byte, pad_len);
         Ok(())
     }
@@ -794,7 +794,7 @@ impl<'buffer, 'data, 'write> BorrowedWriter<'buffer, 'data, 'write> {
         &mut self,
         n: impl Into<u64>,
     ) -> Result<(), Error> {
-        self.if_will_fill_then_flush(2usize)?;
+        rtry!(self.if_will_fill_then_flush(2usize));
         self.bbuf.write_int_pad2(n);
         Ok(())
     }
@@ -804,7 +804,7 @@ impl<'buffer, 'data, 'write> BorrowedWriter<'buffer, 'data, 'write> {
         &mut self,
         n: impl Into<u64>,
     ) -> Result<(), Error> {
-        self.if_will_fill_then_flush(2usize)?;
+        rtry!(self.if_will_fill_then_flush(2usize));
         self.bbuf.write_int_pad2_space(n);
         Ok(())
     }
@@ -814,7 +814,7 @@ impl<'buffer, 'data, 'write> BorrowedWriter<'buffer, 'data, 'write> {
         &mut self,
         n: impl Into<u64>,
     ) -> Result<(), Error> {
-        self.if_will_fill_then_flush(4usize)?;
+        rtry!(self.if_will_fill_then_flush(4usize));
         self.bbuf.write_int_pad4(n);
         Ok(())
     }
@@ -832,7 +832,7 @@ impl<'buffer, 'data, 'write> BorrowedWriter<'buffer, 'data, 'write> {
         // clear if it's worth it or not. I think in practice, for common
         // cases, our uninit buffer will be big enough anyway even when we're
         // pessimistic about the number of digits we'll print.
-        self.if_will_fill_then_flush(9usize)?;
+        rtry!(self.if_will_fill_then_flush(9usize));
         self.bbuf.write_fraction(precision, n);
         Ok(())
     }

--- a/src/fmt/friendly/parser.rs
+++ b/src/fmt/friendly/parser.rs
@@ -182,8 +182,8 @@ impl SpanParser {
         #[inline(never)]
         fn imp(span_parser: &SpanParser, input: &[u8]) -> Result<Span, Error> {
             let mut builder = DurationUnits::default();
-            let parsed = span_parser.parse(input, &mut builder)?;
-            let parsed = parsed.and_then(|_| builder.to_span())?;
+            let parsed = rtry!(span_parser.parse(input, &mut builder));
+            let parsed = rtry!(parsed.and_then(|_| builder.to_span()));
             parsed.into_full()
         }
 
@@ -237,8 +237,9 @@ impl SpanParser {
             input: &[u8],
         ) -> Result<SignedDuration, Error> {
             let mut builder = DurationUnits::default();
-            let parsed = span_parser.parse(input, &mut builder)?;
-            let parsed = parsed.and_then(|_| builder.to_signed_duration())?;
+            let parsed = rtry!(span_parser.parse(input, &mut builder));
+            let parsed =
+                rtry!(parsed.and_then(|_| builder.to_signed_duration()));
             parsed.into_full()
         }
 
@@ -294,9 +295,9 @@ impl SpanParser {
             input: &[u8],
         ) -> Result<core::time::Duration, Error> {
             let mut builder = DurationUnits::default();
-            let parsed = span_parser.parse(input, &mut builder)?;
+            let parsed = rtry!(span_parser.parse(input, &mut builder));
             let parsed =
-                parsed.and_then(|_| builder.to_unsigned_duration())?;
+                rtry!(parsed.and_then(|_| builder.to_unsigned_duration()));
             let d = parsed.value;
             parsed.into_full_with(format_args!("{d:?}"))
         }
@@ -325,20 +326,20 @@ impl SpanParser {
                 (sign, input)
             };
 
-        let Parsed { value, input } = self.parse_unit_value(input)?;
+        let Parsed { value, input } = rtry!(self.parse_unit_value(input));
         let Some(first_unit_value) = value else {
             return Err(Error::from(E::ExpectedIntegerAfterSign));
         };
 
         let Parsed { input, .. } =
-            self.parse_duration_units(input, first_unit_value, builder)?;
+            rtry!(self.parse_duration_units(input, first_unit_value, builder));
 
         // As with the prefix sign parsing, guard it to avoid calling the
         // function.
         let (sign, input) = if !input.first().map_or(false, is_whitespace) {
             (sign.unwrap_or(Sign::Positive), input)
         } else {
-            let parsed = self.parse_suffix_sign(sign, input)?;
+            let parsed = rtry!(self.parse_suffix_sign(sign, input));
             (parsed.value, parsed.input)
         };
         builder.set_sign(sign);
@@ -355,21 +356,21 @@ impl SpanParser {
         let mut parsed_any_after_comma = true;
         let mut value = first_unit_value;
         loop {
-            let parsed = self.parse_hms_maybe(input, value)?;
+            let parsed = rtry!(self.parse_hms_maybe(input, value));
             input = parsed.input;
             if let Some(hms) = parsed.value {
-                builder.set_hms(
+                rtry!(builder.set_hms(
                     hms.hour,
                     hms.minute,
                     hms.second,
                     hms.fraction,
-                )?;
+                ));
                 break;
             }
 
             let fraction =
                 if input.first().map_or(false, |&b| b == b'.' || b == b',') {
-                    let parsed = parse_temporal_fraction(input)?;
+                    let parsed = rtry!(parse_temporal_fraction(input));
                     input = parsed.input;
                     parsed.value
                 } else {
@@ -380,7 +381,7 @@ impl SpanParser {
             input = self.parse_optional_whitespace(input).input;
 
             // Parse the actual unit label/designator.
-            let parsed = self.parse_unit_designator(input)?;
+            let parsed = rtry!(self.parse_unit_designator(input));
             input = parsed.input;
             let unit = parsed.value;
 
@@ -389,13 +390,13 @@ impl SpanParser {
             // if the comma is there and only then call the function (which is
             // marked unlineable to try and keep the hot path tighter).
             if input.first().map_or(false, |&b| b == b',') {
-                input = self.parse_optional_comma(input)?.input;
+                input = rtry!(self.parse_optional_comma(input)).input;
                 parsed_any_after_comma = false;
             }
 
-            builder.set_unit_value(unit, value)?;
+            rtry!(builder.set_unit_value(unit, value));
             if let Some(fraction) = fraction {
-                builder.set_fraction(fraction)?;
+                rtry!(builder.set_fraction(fraction));
                 // Once we see a fraction, we are done. We don't permit parsing
                 // any more units. That is, a fraction can only occur on the
                 // lowest unit of time.
@@ -406,7 +407,7 @@ impl SpanParser {
             // before the next unit value. But if we don't see a unit value,
             // we don't eat the whitespace.
             let after_whitespace = self.parse_optional_whitespace(input).input;
-            let parsed = self.parse_unit_value(after_whitespace)?;
+            let parsed = rtry!(self.parse_unit_value(after_whitespace));
             value = match parsed.value {
                 None => break,
                 Some(value) => value,
@@ -437,7 +438,7 @@ impl SpanParser {
         if first != b':' {
             return Ok(Parsed { input, value: None });
         }
-        let Parsed { input, value } = self.parse_hms(tail, hour)?;
+        let Parsed { input, value } = rtry!(self.parse_hms(tail, hour));
         Ok(Parsed { input, value: Some(value) })
     }
 
@@ -456,7 +457,7 @@ impl SpanParser {
         input: &'i [u8],
         hour: u64,
     ) -> Result<Parsed<'i, HMS>, Error> {
-        let Parsed { input, value } = self.parse_unit_value(input)?;
+        let Parsed { input, value } = rtry!(self.parse_unit_value(input));
         let minute = value.ok_or(E::ExpectedMinuteAfterHour)?;
 
         let (&first, input) =
@@ -465,11 +466,11 @@ impl SpanParser {
             return Err(Error::from(E::ExpectedColonAfterMinute));
         }
 
-        let Parsed { input, value } = self.parse_unit_value(input)?;
+        let Parsed { input, value } = rtry!(self.parse_unit_value(input));
         let second = value.ok_or(E::ExpectedSecondAfterMinute)?;
         let (fraction, input) =
             if input.first().map_or(false, |&b| b == b'.' || b == b',') {
-                let parsed = parse_temporal_fraction(input)?;
+                let parsed = rtry!(parse_temporal_fraction(input));
                 (parsed.value, parsed.input)
             } else {
                 (None, input)

--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -202,7 +202,7 @@ impl<'i, V> Parsed<'i, V> {
         map: impl FnOnce(V) -> Result<U, Error>,
     ) -> Result<Parsed<'i, U>, Error> {
         let Parsed { value, input } = self;
-        Ok(Parsed { value: map(value)?, input })
+        Ok(Parsed { value: rtry!(map(value)), input })
     }
 }
 

--- a/src/fmt/offset.rs
+++ b/src/fmt/offset.rs
@@ -154,7 +154,8 @@ impl ParsedOffset {
         match self.kind {
             ParsedOffsetKind::Zulu => Ok(PiecesOffset::Zulu),
             ParsedOffsetKind::Numeric(ref numeric) => {
-                let mut off = PiecesNumericOffset::from(numeric.to_offset()?);
+                let mut off =
+                    PiecesNumericOffset::from(rtry!(numeric.to_offset()));
                 if numeric.sign.is_negative() {
                     off = off.with_negative_zero();
                 }
@@ -435,7 +436,8 @@ impl Parser {
             let value = ParsedOffset { kind: ParsedOffsetKind::Zulu };
             return Ok(Parsed { value, input });
         }
-        let Parsed { value: numeric, input } = self.parse_numeric(input)?;
+        let Parsed { value: numeric, input } =
+            rtry!(self.parse_numeric(input));
         let value = ParsedOffset { kind: ParsedOffsetKind::Numeric(numeric) };
         Ok(Parsed { value, input })
     }
@@ -456,7 +458,7 @@ impl Parser {
         if !matches!(first, b'z' | b'Z' | b'+' | b'-') {
             return Ok(Parsed { value: None, input });
         }
-        let Parsed { value, input } = self.parse(input)?;
+        let Parsed { value, input } = rtry!(self.parse(input));
         Ok(Parsed { value: Some(value), input })
     }
 
@@ -471,11 +473,11 @@ impl Parser {
     ) -> Result<Parsed<'i, Numeric>, Error> {
         // Parse sign component.
         let Parsed { value: sign, input } =
-            self.parse_sign(input).context(E::InvalidSign)?;
+            rtry!(self.parse_sign(input).context(E::InvalidSign));
 
         // Parse hours component.
         let Parsed { value: hours, input } =
-            self.parse_hours(input).context(E::InvalidHours)?;
+            rtry!(self.parse_hours(input).context(E::InvalidHours));
         let extended = match self.colon {
             Colon::Optional => input.starts_with(b":"),
             Colon::Required => {
@@ -502,9 +504,9 @@ impl Parser {
         };
 
         // Parse optional separator after hours.
-        let Parsed { value: has_minutes, input } = self
+        let Parsed { value: has_minutes, input } = rtry!(self
             .parse_separator(input, extended)
-            .context(E::SeparatorAfterHours)?;
+            .context(E::SeparatorAfterHours));
         if !has_minutes {
             return if self.require_minute
                 || (self.subminute && self.require_second)
@@ -517,7 +519,7 @@ impl Parser {
 
         // Parse minutes component.
         let Parsed { value: minutes, input } =
-            self.parse_minutes(input).context(E::InvalidMinutes)?;
+            rtry!(self.parse_minutes(input).context(E::InvalidMinutes));
         numeric.minutes = Some(minutes);
 
         // If subminute resolution is not supported, then we're done here.
@@ -536,9 +538,9 @@ impl Parser {
         }
 
         // Parse optional separator after minutes.
-        let Parsed { value: has_seconds, input } = self
+        let Parsed { value: has_seconds, input } = rtry!(self
             .parse_separator(input, extended)
-            .context(E::SeparatorAfterMinutes)?;
+            .context(E::SeparatorAfterMinutes));
         if !has_seconds {
             return if self.require_second {
                 Err(Error::from(E::MissingSecondAfterMinute))
@@ -549,7 +551,7 @@ impl Parser {
 
         // Parse seconds component.
         let Parsed { value: seconds, input } =
-            self.parse_seconds(input).context(E::InvalidSeconds)?;
+            rtry!(self.parse_seconds(input).context(E::InvalidSeconds));
         numeric.seconds = Some(seconds);
 
         // If subsecond resolution is not supported, then we're done here.
@@ -562,8 +564,8 @@ impl Parser {
 
         // Parse an optional fractional component.
         let Parsed { value: nanoseconds, input } =
-            parse_temporal_fraction(input)
-                .context(E::InvalidSecondsFractional)?;
+            rtry!(parse_temporal_fraction(input)
+                .context(E::InvalidSecondsFractional));
         // OK because `parse_temporal_fraction` guarantees `0..=999_999_999`.
         numeric.nanoseconds = nanoseconds.map(|n| i32::try_from(n).unwrap());
         Ok(Parsed { value: numeric, input })
@@ -592,7 +594,7 @@ impl Parser {
     ) -> Result<Parsed<'i, i8>, Error> {
         let (hours, input) =
             parse::split(input, 2).ok_or(E::EndOfInputHour)?;
-        let hours = b::OffsetHours::parse(hours).context(E::ParseHours)?;
+        let hours = rtry!(b::OffsetHours::parse(hours).context(E::ParseHours));
         Ok(Parsed { value: hours, input })
     }
 
@@ -604,7 +606,7 @@ impl Parser {
         let (minutes, input) =
             parse::split(input, 2).ok_or(E::EndOfInputMinute)?;
         let minutes =
-            b::OffsetMinutes::parse(minutes).context(E::ParseMinutes)?;
+            rtry!(b::OffsetMinutes::parse(minutes).context(E::ParseMinutes));
         Ok(Parsed { value: minutes, input })
     }
 
@@ -616,7 +618,7 @@ impl Parser {
         let (seconds, input) =
             parse::split(input, 2).ok_or(E::EndOfInputSecond)?;
         let seconds =
-            b::OffsetSeconds::parse(seconds).context(E::ParseSeconds)?;
+            rtry!(b::OffsetSeconds::parse(seconds).context(E::ParseSeconds));
         Ok(Parsed { value: seconds, input })
     }
 

--- a/src/fmt/rfc2822.rs
+++ b/src/fmt/rfc2822.rs
@@ -113,7 +113,7 @@ const PRINTER_MAX_BYTES_RFC9110: usize = 29;
 #[inline]
 pub fn to_string(zdt: &Zoned) -> Result<alloc::string::String, Error> {
     let mut buf = alloc::string::String::new();
-    DEFAULT_DATETIME_PRINTER.print_zoned(zdt, &mut buf)?;
+    rtry!(DEFAULT_DATETIME_PRINTER.print_zoned(zdt, &mut buf));
     Ok(buf)
 }
 
@@ -318,10 +318,10 @@ impl DateTimeParser {
         input: I,
     ) -> Result<Zoned, Error> {
         let input = input.as_ref();
-        let zdt = self
+        let zdt = rtry!(rtry!(self
             .parse_zoned_internal(input)
-            .context(E::FailedZoned)?
-            .into_full()?;
+            .context(E::FailedZoned))
+        .into_full());
         Ok(zdt)
     }
 
@@ -354,10 +354,10 @@ impl DateTimeParser {
         input: I,
     ) -> Result<Timestamp, Error> {
         let input = input.as_ref();
-        let ts = self
+        let ts = rtry!(rtry!(self
             .parse_timestamp_internal(input)
-            .context(E::FailedTimestamp)?
-            .into_full()?;
+            .context(E::FailedTimestamp))
+        .into_full());
         Ok(ts)
     }
 
@@ -371,8 +371,8 @@ impl DateTimeParser {
         input: &'i [u8],
     ) -> Result<Parsed<'i, Zoned>, Error> {
         let Parsed { value: (dt, offset), input } =
-            self.parse_datetime_offset(input)?;
-        let ts = offset.to_timestamp(dt)?;
+            rtry!(self.parse_datetime_offset(input));
+        let ts = rtry!(offset.to_timestamp(dt));
         let zdt = ts.to_zoned(TimeZone::fixed(offset));
         Ok(Parsed { value: zdt, input })
     }
@@ -387,8 +387,8 @@ impl DateTimeParser {
         input: &'i [u8],
     ) -> Result<Parsed<'i, Timestamp>, Error> {
         let Parsed { value: (dt, offset), input } =
-            self.parse_datetime_offset(input)?;
-        let ts = offset.to_timestamp(dt)?;
+            rtry!(self.parse_datetime_offset(input));
+        let ts = rtry!(offset.to_timestamp(dt));
         Ok(Parsed { value: ts, input })
     }
 
@@ -402,13 +402,13 @@ impl DateTimeParser {
         input: &'i [u8],
     ) -> Result<Parsed<'i, (DateTime, Offset)>, Error> {
         let input = input.as_ref();
-        let Parsed { value: dt, input } = self.parse_datetime(input)?;
-        let Parsed { value: offset, input } = self.parse_offset(input)?;
+        let Parsed { value: dt, input } = rtry!(self.parse_datetime(input));
+        let Parsed { value: offset, input } = rtry!(self.parse_offset(input));
         let Parsed { input, .. } = self.skip_whitespace(input);
         let input = if input.is_empty() {
             input
         } else {
-            self.skip_comment(input)?.input
+            rtry!(self.skip_comment(input)).input
         };
         Ok(Parsed { value: (dt, offset), input })
     }
@@ -432,16 +432,16 @@ impl DateTimeParser {
         if input.is_empty() {
             return Err(Error::from(E::EmptyAfterWhitespace));
         }
-        let Parsed { value: wd, input } = self.parse_weekday(input)?;
-        let Parsed { value: day, input } = self.parse_day(input)?;
-        let Parsed { value: month, input } = self.parse_month(input)?;
-        let Parsed { value: year, input } = self.parse_year(input)?;
+        let Parsed { value: wd, input } = rtry!(self.parse_weekday(input));
+        let Parsed { value: day, input } = rtry!(self.parse_day(input));
+        let Parsed { value: month, input } = rtry!(self.parse_month(input));
+        let Parsed { value: year, input } = rtry!(self.parse_year(input));
 
-        let Parsed { value: hour, input } = self.parse_hour(input)?;
+        let Parsed { value: hour, input } = rtry!(self.parse_hour(input));
         let Parsed { input, .. } = self.skip_whitespace(input);
-        let Parsed { input, .. } = self.parse_time_separator(input)?;
+        let Parsed { input, .. } = rtry!(self.parse_time_separator(input));
         let Parsed { input, .. } = self.skip_whitespace(input);
-        let Parsed { value: minute, input } = self.parse_minute(input)?;
+        let Parsed { value: minute, input } = rtry!(self.parse_minute(input));
 
         let Parsed { value: whitespace_after_minute, input } =
             self.skip_whitespace(input);
@@ -451,14 +451,15 @@ impl DateTimeParser {
             }
             (0, input)
         } else {
-            let Parsed { input, .. } = self.parse_time_separator(input)?;
+            let Parsed { input, .. } = rtry!(self.parse_time_separator(input));
             let Parsed { input, .. } = self.skip_whitespace(input);
-            let Parsed { value: second, input } = self.parse_second(input)?;
-            let Parsed { input, .. } = self.parse_whitespace(input)?;
+            let Parsed { value: second, input } =
+                rtry!(self.parse_second(input));
+            let Parsed { input, .. } = rtry!(self.parse_whitespace(input));
             (second, input)
         };
 
-        let date = Date::new(year, month, day).context(E::InvalidDate)?;
+        let date = rtry!(Date::new(year, month, day).context(E::InvalidDate));
         // OK because hour, minute and second have been verified as being
         // in bounds. And all combinations of such in-bound values are also
         // valid `Time` values.
@@ -559,9 +560,9 @@ impl DateTimeParser {
             digits = 2;
         }
         let (day, input) = input.split_at(digits);
-        let day = b::Day::parse(day).context(E::ParseDay)?;
+        let day = rtry!(b::Day::parse(day).context(E::ParseDay));
         let Parsed { input, .. } =
-            self.parse_whitespace(input).context(E::WhitespaceAfterDay)?;
+            rtry!(self.parse_whitespace(input).context(E::WhitespaceAfterDay));
         Ok(Parsed { value: day, input })
     }
 
@@ -603,9 +604,9 @@ impl DateTimeParser {
             b"dec" => 12,
             _ => return Err(Error::from(E::InvalidMonth)),
         };
-        let Parsed { input, .. } = self
+        let Parsed { input, .. } = rtry!(self
             .parse_whitespace(&input[3..])
-            .context(E::WhitespaceAfterMonth)?;
+            .context(E::WhitespaceAfterMonth));
         Ok(Parsed { value: month, input })
     }
 
@@ -644,15 +645,16 @@ impl DateTimeParser {
             }
         }
         let (year, input) = input.split_at(digits);
-        let year = b::Year::parse(year).context(E::ParseYear)?;
+        let year = rtry!(b::Year::parse(year).context(E::ParseYear));
         let year = match digits {
             2 if year <= 49 => year + 2000,
             2 | 3 => year + 1900,
             4 => year,
             _ => unreachable!("digits={digits} must be 2, 3 or 4"),
         };
-        let Parsed { input, .. } =
-            self.parse_whitespace(input).context(E::WhitespaceAfterYear)?;
+        let Parsed { input, .. } = rtry!(self
+            .parse_whitespace(input)
+            .context(E::WhitespaceAfterYear));
         Ok(Parsed { value: year, input })
     }
 
@@ -667,7 +669,7 @@ impl DateTimeParser {
         input: &'i [u8],
     ) -> Result<Parsed<'i, i8>, Error> {
         let (hour, input) = parse::split(input, 2).ok_or(E::EndOfInputHour)?;
-        let hour = b::Hour::parse(hour).context(E::ParseHour)?;
+        let hour = rtry!(b::Hour::parse(hour).context(E::ParseHour));
         Ok(Parsed { value: hour, input })
     }
 
@@ -680,7 +682,7 @@ impl DateTimeParser {
     ) -> Result<Parsed<'i, i8>, Error> {
         let (minute, input) =
             parse::split(input, 2).ok_or(E::EndOfInputMinute)?;
-        let minute = b::Minute::parse(minute).context(E::ParseMinute)?;
+        let minute = rtry!(b::Minute::parse(minute).context(E::ParseMinute));
         Ok(Parsed { value: minute, input })
     }
 
@@ -694,7 +696,7 @@ impl DateTimeParser {
         let (second, input) =
             parse::split(input, 2).ok_or(E::EndOfInputSecond)?;
         let mut second =
-            b::LeapSecond::parse(second).context(E::ParseSecond)?;
+            rtry!(b::LeapSecond::parse(second).context(E::ParseSecond));
         if second == 60 {
             second = 59;
         }
@@ -721,10 +723,12 @@ impl DateTimeParser {
         let input = &input[1..];
         let (hhmm, input) = parse::split(input, 4).ok_or(E::TooShortOffset)?;
 
-        let hh =
-            b::OffsetHours::parse(&hhmm[0..2]).context(E::ParseOffsetHour)?;
-        let mm = b::OffsetMinutes::parse(&hhmm[2..4])
-            .context(E::ParseOffsetMinute)?;
+        let hh = rtry!(
+            b::OffsetHours::parse(&hhmm[0..2]).context(E::ParseOffsetHour)
+        );
+        let mm =
+            rtry!(b::OffsetMinutes::parse(&hhmm[2..4])
+                .context(E::ParseOffsetMinute));
 
         let seconds = sign * (i32::from(hh) * 3_600 + i32::from(mm) * 60);
         // OK because we check the bounds of both hours and minutes.
@@ -1039,7 +1043,7 @@ impl DateTimePrinter {
         // to `print_zoned`.
         let mut buf =
             alloc::string::String::with_capacity(PRINTER_MAX_BYTES_RFC2822);
-        self.print_zoned(zdt, &mut buf)?;
+        rtry!(self.print_zoned(zdt, &mut buf));
         Ok(buf)
     }
 
@@ -1082,7 +1086,7 @@ impl DateTimePrinter {
     ) -> Result<alloc::string::String, Error> {
         let mut buf =
             alloc::string::String::with_capacity(PRINTER_MAX_BYTES_RFC2822);
-        self.print_timestamp(timestamp, &mut buf)?;
+        rtry!(self.print_timestamp(timestamp, &mut buf));
         Ok(buf)
     }
 
@@ -1129,7 +1133,7 @@ impl DateTimePrinter {
     ) -> Result<alloc::string::String, Error> {
         let mut buf =
             alloc::string::String::with_capacity(PRINTER_MAX_BYTES_RFC9110);
-        self.print_timestamp_rfc9110(timestamp, &mut buf)?;
+        rtry!(self.print_timestamp_rfc9110(timestamp, &mut buf));
         Ok(buf)
     }
 

--- a/src/fmt/rfc9557.rs
+++ b/src/fmt/rfc9557.rs
@@ -134,14 +134,14 @@ impl<'i> ParsedAnnotations<'i> {
         &self,
     ) -> Result<Option<TimeZoneAnnotation<'i>>, Error> {
         let Some(ref parsed) = self.time_zone else { return Ok(None) };
-        Ok(Some(parsed.to_time_zone_annotation()?))
+        Ok(Some(rtry!(parsed.to_time_zone_annotation())))
     }
 }
 
 impl<'i> core::fmt::Display for ParsedAnnotations<'i> {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         if let Some(ref tz) = self.time_zone {
-            core::fmt::Display::fmt(tz, f)?;
+            rtry!(core::fmt::Display::fmt(tz, f));
         }
         Ok(())
     }
@@ -183,7 +183,8 @@ impl<'i> ParsedTimeZone<'i> {
                 (kind, critical)
             }
             ParsedTimeZone::Offset { ref offset, critical } => {
-                let kind = TimeZoneAnnotationKind::Offset(offset.to_offset()?);
+                let kind =
+                    TimeZoneAnnotationKind::Offset(rtry!(offset.to_offset()));
                 (kind, critical)
             }
         };
@@ -195,19 +196,19 @@ impl<'i> core::fmt::Display for ParsedTimeZone<'i> {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match *self {
             ParsedTimeZone::Named { critical, name } => {
-                f.write_str("[")?;
+                rtry!(f.write_str("["));
                 if critical {
-                    f.write_str("!")?;
+                    rtry!(f.write_str("!"));
                 }
-                f.write_str(name)?;
+                rtry!(f.write_str(name));
                 f.write_str("]")
             }
             ParsedTimeZone::Offset { critical, ref offset } => {
-                f.write_str("[")?;
+                rtry!(f.write_str("["));
                 if critical {
-                    f.write_str("!")?;
+                    rtry!(f.write_str("!"));
                 }
-                core::fmt::Display::fmt(offset, f)?;
+                rtry!(core::fmt::Display::fmt(offset, f));
                 f.write_str("]")
             }
         }
@@ -240,14 +241,14 @@ impl Parser {
         input: &'i [u8],
     ) -> Result<Parsed<'i, ParsedAnnotations<'i>>, Error> {
         let Parsed { value: time_zone, mut input } =
-            self.parse_time_zone_annotation(input)?;
+            rtry!(self.parse_time_zone_annotation(input));
         loop {
             // We don't actually do anything with any annotation that isn't
             // a time zone, but we do parse them to ensure validity and to
             // be able to fail when a critical flag is set. Otherwise, we know
             // we're done if parsing an annotation doesn't consume any input.
             let Parsed { value: did_consume, input: unconsumed } =
-                self.parse_annotation(input)?;
+                rtry!(self.parse_annotation(input));
             if !did_consume {
                 break;
             }
@@ -285,9 +286,9 @@ impl Parser {
             const P: offset::Parser =
                 offset::Parser::new().zulu(false).subminute(false);
 
-            let Parsed { value: offset, input } = P.parse(input)?;
+            let Parsed { value: offset, input } = rtry!(P.parse(input));
             let Parsed { input, .. } =
-                self.parse_tz_annotation_close(input)?;
+                rtry!(self.parse_tz_annotation_close(input));
             let value = Some(ParsedTimeZone::Offset { critical, offset });
             return Ok(Parsed { value, input });
         }
@@ -300,7 +301,7 @@ impl Parser {
         // Once we stop, we can check for an `=`.
         let mkiana = parse::slicer(input);
         let Parsed { mut input, .. } =
-            self.parse_tz_annotation_iana_name(input)?;
+            rtry!(self.parse_tz_annotation_iana_name(input));
         // Now that we've parsed the first IANA name component, if this were
         // actually a generic key/value annotation, the `=` *must* appear here.
         // Otherwise, we assume we are trying to parse an IANA annotation as it
@@ -313,7 +314,7 @@ impl Parser {
         while let Some(tail) = input.strip_prefix(b"/") {
             input = tail;
             let Parsed { input: unconsumed, .. } =
-                self.parse_tz_annotation_iana_name(input)?;
+                rtry!(self.parse_tz_annotation_iana_name(input));
             input = unconsumed;
         }
         // This is OK because all bytes in a IANA TZ annotation are guaranteed
@@ -324,7 +325,8 @@ impl Parser {
         let time_zone =
             Some(ParsedTimeZone::Named { critical, name: iana_name });
         // And finally, parse the closing bracket.
-        let Parsed { input, .. } = self.parse_tz_annotation_close(input)?;
+        let Parsed { input, .. } =
+            rtry!(self.parse_tz_annotation_close(input));
         Ok(Parsed { value: time_zone, input })
     }
 
@@ -346,10 +348,11 @@ impl Parser {
             input = tail;
         }
 
-        let Parsed { input, .. } = self.parse_annotation_key(input)?;
-        let Parsed { input, .. } = self.parse_annotation_separator(input)?;
-        let Parsed { input, .. } = self.parse_annotation_values(input)?;
-        let Parsed { input, .. } = self.parse_annotation_close(input)?;
+        let Parsed { input, .. } = rtry!(self.parse_annotation_key(input));
+        let Parsed { input, .. } =
+            rtry!(self.parse_annotation_separator(input));
+        let Parsed { input, .. } = rtry!(self.parse_annotation_values(input));
+        let Parsed { input, .. } = rtry!(self.parse_annotation_close(input));
 
         // If the critical flag is set, then we automatically return an error
         // because we don't support any non-time-zone annotations. When the
@@ -368,7 +371,7 @@ impl Parser {
     ) -> Result<Parsed<'i, &'i [u8]>, Error> {
         let mkname = parse::slicer(input);
         let Parsed { mut input, .. } =
-            self.parse_tz_annotation_leading_char(input)?;
+            rtry!(self.parse_tz_annotation_leading_char(input));
         loop {
             let Parsed { value: did_consume, input: unconsumed } =
                 self.parse_tz_annotation_char(input);
@@ -386,7 +389,7 @@ impl Parser {
     ) -> Result<Parsed<'i, &'i [u8]>, Error> {
         let mkkey = parse::slicer(input);
         let Parsed { mut input, .. } =
-            self.parse_annotation_key_leading_char(input)?;
+            rtry!(self.parse_annotation_key_leading_char(input));
         loop {
             let Parsed { value: did_consume, input: unconsumed } =
                 self.parse_annotation_key_char(input);
@@ -406,11 +409,12 @@ impl Parser {
         &self,
         input: &'i [u8],
     ) -> Result<Parsed<'i, ()>, Error> {
-        let Parsed { mut input, .. } = self.parse_annotation_value(input)?;
+        let Parsed { mut input, .. } =
+            rtry!(self.parse_annotation_value(input));
         while let Some(tail) = input.strip_prefix(b"-") {
             input = tail;
             let Parsed { input: unconsumed, .. } =
-                self.parse_annotation_value(input)?;
+                rtry!(self.parse_annotation_value(input));
             input = unconsumed;
         }
         Ok(Parsed { value: (), input })
@@ -422,7 +426,7 @@ impl Parser {
     ) -> Result<Parsed<'i, &'i [u8]>, Error> {
         let mkvalue = parse::slicer(input);
         let Parsed { mut input, .. } =
-            self.parse_annotation_value_leading_char(input)?;
+            rtry!(self.parse_annotation_value_leading_char(input));
         loop {
             let Parsed { value: did_consume, input: unconsumed } =
                 self.parse_annotation_value_char(input);

--- a/src/fmt/serde.rs
+++ b/src/fmt/serde.rs
@@ -547,12 +547,12 @@ pub mod timestamp {
                 self,
                 v: u64,
             ) -> Result<crate::Timestamp, E> {
-                let v = i64::try_from(v).map_err(|_| {
+                let v = rtry!(i64::try_from(v).map_err(|_| {
                     de::Error::custom(format_args!(
                         "got unsigned integer {v} seconds, \
                          which is too big to fit in a Jiff `Timestamp`",
                     ))
-                })?;
+                }));
                 self.visit_i64(v)
             }
 
@@ -561,12 +561,12 @@ pub mod timestamp {
                 self,
                 v: i128,
             ) -> Result<crate::Timestamp, E> {
-                let v = i64::try_from(v).map_err(|_| {
+                let v = rtry!(i64::try_from(v).map_err(|_| {
                     de::Error::custom(format_args!(
                         "got signed integer {v} seconds, \
                          which is too big to fit in a Jiff `Timestamp`",
                     ))
-                })?;
+                }));
                 self.visit_i64(v)
             }
 
@@ -575,12 +575,12 @@ pub mod timestamp {
                 self,
                 v: u128,
             ) -> Result<crate::Timestamp, E> {
-                let v = i64::try_from(v).map_err(|_| {
+                let v = rtry!(i64::try_from(v).map_err(|_| {
                     de::Error::custom(format_args!(
                         "got unsigned integer {v} seconds, \
                          which is too big to fit in a Jiff `Timestamp`",
                     ))
-                })?;
+                }));
                 self.visit_i64(v)
             }
         }
@@ -717,12 +717,12 @@ pub mod timestamp {
                 self,
                 v: u64,
             ) -> Result<crate::Timestamp, E> {
-                let v = i64::try_from(v).map_err(|_| {
+                let v = rtry!(i64::try_from(v).map_err(|_| {
                     de::Error::custom(format_args!(
                         "got unsigned integer {v} milliseconds, \
                          which is too big to fit in a Jiff `Timestamp`",
                     ))
-                })?;
+                }));
                 self.visit_i64(v)
             }
 
@@ -731,12 +731,12 @@ pub mod timestamp {
                 self,
                 v: i128,
             ) -> Result<crate::Timestamp, E> {
-                let v = i64::try_from(v).map_err(|_| {
+                let v = rtry!(i64::try_from(v).map_err(|_| {
                     de::Error::custom(format_args!(
                         "got signed integer {v} milliseconds, \
                          which is too big to fit in a Jiff `Timestamp`",
                     ))
-                })?;
+                }));
                 self.visit_i64(v)
             }
 
@@ -745,12 +745,12 @@ pub mod timestamp {
                 self,
                 v: u128,
             ) -> Result<crate::Timestamp, E> {
-                let v = i64::try_from(v).map_err(|_| {
+                let v = rtry!(i64::try_from(v).map_err(|_| {
                     de::Error::custom(format_args!(
                         "got unsigned integer {v} milliseconds, \
                          which is too big to fit in a Jiff `Timestamp`",
                     ))
-                })?;
+                }));
                 self.visit_i64(v)
             }
         }
@@ -887,12 +887,12 @@ pub mod timestamp {
                 self,
                 v: u64,
             ) -> Result<crate::Timestamp, E> {
-                let v = i64::try_from(v).map_err(|_| {
+                let v = rtry!(i64::try_from(v).map_err(|_| {
                     de::Error::custom(format_args!(
                         "got unsigned integer {v} microseconds, \
                          which is too big to fit in a Jiff `Timestamp`",
                     ))
-                })?;
+                }));
                 self.visit_i64(v)
             }
 
@@ -901,12 +901,12 @@ pub mod timestamp {
                 self,
                 v: i128,
             ) -> Result<crate::Timestamp, E> {
-                let v = i64::try_from(v).map_err(|_| {
+                let v = rtry!(i64::try_from(v).map_err(|_| {
                     de::Error::custom(format_args!(
                         "got signed integer {v} microseconds, \
                          which is too big to fit in a Jiff `Timestamp`",
                     ))
-                })?;
+                }));
                 self.visit_i64(v)
             }
 
@@ -915,12 +915,12 @@ pub mod timestamp {
                 self,
                 v: u128,
             ) -> Result<crate::Timestamp, E> {
-                let v = i64::try_from(v).map_err(|_| {
+                let v = rtry!(i64::try_from(v).map_err(|_| {
                     de::Error::custom(format_args!(
                         "got unsigned integer {v} microseconds, \
                          which is too big to fit in a Jiff `Timestamp`",
                     ))
-                })?;
+                }));
                 self.visit_i64(v)
             }
         }
@@ -1024,12 +1024,12 @@ pub mod timestamp {
                 self,
                 v: u128,
             ) -> Result<crate::Timestamp, E> {
-                let v = i128::try_from(v).map_err(|_| {
+                let v = rtry!(i128::try_from(v).map_err(|_| {
                     de::Error::custom(format_args!(
                         "got unsigned integer {v} nanoseconds, \
                          which is too big to fit in a Jiff `Timestamp`",
                     ))
-                })?;
+                }));
                 self.visit_i128(v)
             }
         }
@@ -1797,13 +1797,13 @@ pub mod unsigned_duration {
             };
             first = byte;
         }
-        let dur = if first == b'P' || first == b'p' {
+        let dur = rtry!(if first == b'P' || first == b'p' {
             crate::fmt::temporal::DEFAULT_SPAN_PARSER
                 .parse_unsigned_duration(bytes)
         } else {
             crate::fmt::friendly::DEFAULT_SPAN_PARSER
                 .parse_unsigned_duration(bytes)
-        }?;
+        });
         Ok(dur)
     }
 }

--- a/src/fmt/strtime/mod.rs
+++ b/src/fmt/strtime/mod.rs
@@ -431,7 +431,7 @@ pub fn format(
 
     let format = format.as_ref();
     let mut buf = alloc::string::String::with_capacity(format.len());
-    broken_down_time.format(format, &mut buf)?;
+    rtry!(broken_down_time.format(format, &mut buf));
     Ok(buf)
 }
 
@@ -960,7 +960,7 @@ impl BrokenDownTime {
     fn parse_mono(fmt: &[u8], inp: &[u8]) -> Result<BrokenDownTime, Error> {
         let mut pieces = BrokenDownTime::default();
         let mut p = Parser { fmt, inp, tm: &mut pieces };
-        p.parse().context(E::FailedStrptime)?;
+        rtry!(p.parse().context(E::FailedStrptime));
         if !p.inp.is_empty() {
             return Err(Error::from(E::unconsumed(p.inp)));
         }
@@ -1065,7 +1065,7 @@ impl BrokenDownTime {
         let mkoffset = util::parse::offseter(inp);
         let mut pieces = BrokenDownTime::default();
         let mut p = Parser { fmt, inp, tm: &mut pieces };
-        p.parse().context(E::FailedStrptime)?;
+        rtry!(p.parse().context(E::FailedStrptime));
         let remainder = mkoffset(p.inp);
         Ok((pieces, remainder))
     }
@@ -1171,7 +1171,7 @@ impl BrokenDownTime {
         let mut bbuf = buf.as_borrowed();
         let mut wtr = BorrowedWriter::new(&mut bbuf, wtr);
         let mut formatter = Formatter { config, fmt, tm: self, wtr: &mut wtr };
-        formatter.format().context(E::FailedStrftime)?;
+        rtry!(formatter.format().context(E::FailedStrftime));
         wtr.finish()
     }
 
@@ -1218,7 +1218,7 @@ impl BrokenDownTime {
     ) -> Result<alloc::string::String, Error> {
         let format = format.as_ref();
         let mut buf = alloc::string::String::with_capacity(format.len());
-        self.format(format, &mut buf)?;
+        rtry!(self.format(format, &mut buf));
         Ok(buf)
     }
 
@@ -1271,7 +1271,7 @@ impl BrokenDownTime {
     ) -> Result<alloc::string::String, Error> {
         let format = format.as_ref();
         let mut buf = alloc::string::String::with_capacity(format.len());
-        self.format_with_config(config, format, &mut buf)?;
+        rtry!(self.format_with_config(config, format, &mut buf));
         Ok(buf)
     }
 
@@ -1455,31 +1455,31 @@ impl BrokenDownTime {
                 let ts = match self.timestamp {
                     Some(ts) => ts,
                     None => {
-                        let dt = self
+                        let dt = rtry!(self
                             .to_datetime()
-                            .context(E::RequiredDateTimeForZoned)?;
-                        let ts = offset
+                            .context(E::RequiredDateTimeForZoned));
+                        let ts = rtry!(offset
                             .to_timestamp(dt)
-                            .context(E::RangeTimestamp)?;
+                            .context(E::RangeTimestamp));
                         ts
                     }
                 };
                 Ok(ts.to_zoned(TimeZone::fixed(offset)))
             }
             (None, Some(iana)) => {
-                let tz = db.get(iana)?;
+                let tz = rtry!(db.get(iana));
                 match self.timestamp {
                     Some(ts) => Ok(ts.to_zoned(tz)),
                     None => {
-                        let dt = self
+                        let dt = rtry!(self
                             .to_datetime()
-                            .context(E::RequiredDateTimeForZoned)?;
-                        Ok(tz.to_zoned(dt)?)
+                            .context(E::RequiredDateTimeForZoned));
+                        Ok(rtry!(tz.to_zoned(dt)))
                     }
                 }
             }
             (Some(offset), Some(iana)) => {
-                let tz = db.get(iana)?;
+                let tz = rtry!(db.get(iana));
                 match self.timestamp {
                     Some(ts) => {
                         let zdt = ts.to_zoned(tz);
@@ -1492,11 +1492,12 @@ impl BrokenDownTime {
                         Ok(zdt)
                     }
                     None => {
-                        let dt = self
+                        let dt = rtry!(self
                             .to_datetime()
-                            .context(E::RequiredDateTimeForZoned)?;
-                        let azdt =
-                            OffsetConflict::Reject.resolve(dt, offset, tz)?;
+                            .context(E::RequiredDateTimeForZoned));
+                        let azdt = rtry!(
+                            OffsetConflict::Reject.resolve(dt, offset, tz)
+                        );
                         // Guaranteed that if OffsetConflict::Reject doesn't
                         // reject, then we get back an unambiguous zoned
                         // datetime.
@@ -1599,7 +1600,7 @@ impl BrokenDownTime {
             return Ok(timestamp);
         }
         let dt =
-            self.to_datetime().context(E::RequiredDateTimeForTimestamp)?;
+            rtry!(self.to_datetime().context(E::RequiredDateTimeForTimestamp));
         let offset = self.offset.ok_or(E::RequiredOffsetForTimestamp)?;
         offset.to_timestamp(dt).context(E::RangeTimestamp)
     }
@@ -1631,8 +1632,8 @@ impl BrokenDownTime {
     /// ```
     #[inline]
     pub fn to_datetime(&self) -> Result<DateTime, Error> {
-        let date = self.to_date().context(E::RequiredDateForDateTime)?;
-        let time = self.to_time().context(E::RequiredTimeForDateTime)?;
+        let date = rtry!(self.to_date().context(E::RequiredDateForDateTime));
+        let time = rtry!(self.to_time().context(E::RequiredTimeForDateTime));
         Ok(DateTime::from_parts(date, time))
     }
 
@@ -1684,23 +1685,23 @@ impl BrokenDownTime {
                 // separately. That is, they are two different fields. So if
                 // the Gregorian year is absent, we might still have an ISO
                 // 8601 week date.
-                if let Some(date) = tm.to_date_from_iso()? {
+                if let Some(date) = rtry!(tm.to_date_from_iso()) {
                     return Ok(date);
                 }
                 return Err(Error::from(E::RequiredYearForDate));
             };
-            let mut date = tm.to_date_from_gregorian(year)?;
+            let mut date = rtry!(tm.to_date_from_gregorian(year));
             if date.is_none() {
-                date = tm.to_date_from_iso()?;
+                date = rtry!(tm.to_date_from_iso());
             }
             if date.is_none() {
-                date = tm.to_date_from_day_of_year(year)?;
+                date = rtry!(tm.to_date_from_day_of_year(year));
             }
             if date.is_none() {
-                date = tm.to_date_from_week_sun(year)?;
+                date = rtry!(tm.to_date_from_week_sun(year));
             }
             if date.is_none() {
-                date = tm.to_date_from_week_mon(year)?;
+                date = rtry!(tm.to_date_from_week_mon(year));
             }
             let Some(date) = date else {
                 return Err(Error::from(E::RequiredSomeDayForDate));
@@ -1724,7 +1725,7 @@ impl BrokenDownTime {
         else {
             return to_date(self);
         };
-        let date = Date::new(year, month, day).context(E::InvalidDate)?;
+        let date = rtry!(Date::new(year, month, day).context(E::InvalidDate));
         if let Some(weekday) = self.weekday {
             if weekday != date.weekday() {
                 return Err(Error::from(E::MismatchWeekday {
@@ -1744,7 +1745,7 @@ impl BrokenDownTime {
         let (Some(month), Some(day)) = (self.month, self.day) else {
             return Ok(None);
         };
-        Ok(Some(Date::new(year, month, day).context(E::InvalidDate)?))
+        Ok(Some(rtry!(Date::new(year, month, day).context(E::InvalidDate))))
     }
 
     #[inline]
@@ -1755,7 +1756,11 @@ impl BrokenDownTime {
         let Some(doy) = self.day_of_year else { return Ok(None) };
         Ok(Some({
             let first = Date::new(year, 1, 1).unwrap();
-            first.with().day_of_year(doy).build().context(E::InvalidDate)?
+            rtry!(first
+                .with()
+                .day_of_year(doy)
+                .build()
+                .context(E::InvalidDate))
         }))
     }
 
@@ -1766,7 +1771,8 @@ impl BrokenDownTime {
         else {
             return Ok(None);
         };
-        let wd = ISOWeekDate::new(y, w, d).context(E::InvalidISOWeekDate)?;
+        let wd =
+            rtry!(ISOWeekDate::new(y, w, d).context(E::InvalidISOWeekDate));
         Ok(Some(wd.date()))
     }
 
@@ -1777,11 +1783,12 @@ impl BrokenDownTime {
         };
         let week = i16::from(week);
         let wday = i16::from(weekday.to_sunday_zero_offset());
-        let first_of_year = Date::new(year, 1, 1).context(E::InvalidDate)?;
-        let first_sunday = first_of_year
+        let first_of_year =
+            rtry!(Date::new(year, 1, 1).context(E::InvalidDate));
+        let first_sunday = rtry!(first_of_year
             .nth_weekday_of_month(1, Weekday::Sunday)
             .map(|d| d.day_of_year())
-            .context(E::InvalidDate)?;
+            .context(E::InvalidDate));
         let doy = if week == 0 {
             let days_before_first_sunday = 7 - wday;
             let doy = first_sunday
@@ -1798,11 +1805,11 @@ impl BrokenDownTime {
             let doy = first_sunday + days_since_first_sunday;
             doy
         };
-        let date = first_of_year
+        let date = rtry!(first_of_year
             .with()
             .day_of_year(doy)
             .build()
-            .context(E::InvalidDate)?;
+            .context(E::InvalidDate));
         Ok(Some(date))
     }
 
@@ -1813,11 +1820,12 @@ impl BrokenDownTime {
         };
         let week = i16::from(week);
         let wday = i16::from(weekday.to_monday_zero_offset());
-        let first_of_year = Date::new(year, 1, 1).context(E::InvalidDate)?;
-        let first_monday = first_of_year
+        let first_of_year =
+            rtry!(Date::new(year, 1, 1).context(E::InvalidDate));
+        let first_monday = rtry!(first_of_year
             .nth_weekday_of_month(1, Weekday::Monday)
             .map(|d| d.day_of_year())
-            .context(E::InvalidDate)?;
+            .context(E::InvalidDate));
         let doy = if week == 0 {
             let days_before_first_monday = 7 - wday;
             let doy = first_monday
@@ -1834,11 +1842,11 @@ impl BrokenDownTime {
             let doy = first_monday + days_since_first_monday;
             doy
         };
-        let date = first_of_year
+        let date = rtry!(first_of_year
             .with()
             .day_of_year(doy)
             .build()
-            .context(E::InvalidDate)?;
+            .context(E::InvalidDate));
         Ok(Some(date))
     }
 
@@ -3445,7 +3453,7 @@ impl Extension {
             return Ok((None, fmt));
         }
         let (digits, fmt) = fmt.split_at(digits);
-        let width = util::parse::i64(digits).context(E::FailedWidth)?;
+        let width = rtry!(util::parse::i64(digits).context(E::FailedWidth));
         let width = u8::try_from(width).map_err(|_| E::RangeWidth)?;
         if fmt.is_empty() {
             return Err(Error::from(E::ExpectedDirectiveAfterWidth));

--- a/src/fmt/strtime/parse.rs
+++ b/src/fmt/strtime/parse.rs
@@ -28,7 +28,7 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
 
         while !self.fmt.is_empty() {
             if self.f() != b'%' {
-                self.parse_literal()?;
+                rtry!(self.parse_literal());
                 continue;
             }
             if !self.bump_fmt() {
@@ -42,55 +42,75 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
                 }));
             }
             // Parse extensions like padding/case options and padding width.
-            let ext = self.parse_extension()?;
+            let ext = rtry!(self.parse_extension());
             match self.f() {
-                b'%' => self.parse_percent().context(fail(b'%'))?,
-                b'A' => self.parse_weekday_full().context(fail(b'A'))?,
-                b'a' => self.parse_weekday_abbrev().context(fail(b'a'))?,
-                b'B' => self.parse_month_name_full().context(fail(b'B'))?,
-                b'b' => self.parse_month_name_abbrev().context(fail(b'b'))?,
-                b'C' => self.parse_century(ext).context(fail(b'C'))?,
-                b'D' => self.parse_american_date().context(fail(b'D'))?,
-                b'd' => self.parse_day(ext).context(fail(b'd'))?,
-                b'e' => self.parse_day(ext).context(fail(b'e'))?,
-                b'F' => self.parse_iso_date().context(fail(b'F'))?,
-                b'f' => self.parse_fractional(ext).context(fail(b'f'))?,
-                b'G' => self.parse_iso_week_year(ext).context(fail(b'G'))?,
-                b'g' => self.parse_iso_week_year2(ext).context(fail(b'g'))?,
-                b'H' => self.parse_hour24(ext).context(fail(b'H'))?,
-                b'h' => self.parse_month_name_abbrev().context(fail(b'h'))?,
-                b'I' => self.parse_hour12(ext).context(fail(b'I'))?,
-                b'j' => self.parse_day_of_year(ext).context(fail(b'j'))?,
-                b'k' => self.parse_hour24(ext).context(fail(b'k'))?,
-                b'l' => self.parse_hour12(ext).context(fail(b'l'))?,
-                b'M' => self.parse_minute(ext).context(fail(b'M'))?,
-                b'm' => self.parse_month(ext).context(fail(b'm'))?,
-                b'N' => self.parse_fractional(ext).context(fail(b'N'))?,
-                b'n' => self.parse_whitespace().context(fail(b'n'))?,
-                b'P' => self.parse_ampm().context(fail(b'P'))?,
-                b'p' => self.parse_ampm().context(fail(b'p'))?,
+                b'%' => rtry!(self.parse_percent().context(fail(b'%'))),
+                b'A' => rtry!(self.parse_weekday_full().context(fail(b'A'))),
+                b'a' => rtry!(self.parse_weekday_abbrev().context(fail(b'a'))),
+                b'B' => {
+                    rtry!(self.parse_month_name_full().context(fail(b'B')))
+                }
+                b'b' => {
+                    rtry!(self.parse_month_name_abbrev().context(fail(b'b')))
+                }
+                b'C' => rtry!(self.parse_century(ext).context(fail(b'C'))),
+                b'D' => rtry!(self.parse_american_date().context(fail(b'D'))),
+                b'd' => rtry!(self.parse_day(ext).context(fail(b'd'))),
+                b'e' => rtry!(self.parse_day(ext).context(fail(b'e'))),
+                b'F' => rtry!(self.parse_iso_date().context(fail(b'F'))),
+                b'f' => rtry!(self.parse_fractional(ext).context(fail(b'f'))),
+                b'G' => {
+                    rtry!(self.parse_iso_week_year(ext).context(fail(b'G')))
+                }
+                b'g' => {
+                    rtry!(self.parse_iso_week_year2(ext).context(fail(b'g')))
+                }
+                b'H' => rtry!(self.parse_hour24(ext).context(fail(b'H'))),
+                b'h' => {
+                    rtry!(self.parse_month_name_abbrev().context(fail(b'h')))
+                }
+                b'I' => rtry!(self.parse_hour12(ext).context(fail(b'I'))),
+                b'j' => rtry!(self.parse_day_of_year(ext).context(fail(b'j'))),
+                b'k' => rtry!(self.parse_hour24(ext).context(fail(b'k'))),
+                b'l' => rtry!(self.parse_hour12(ext).context(fail(b'l'))),
+                b'M' => rtry!(self.parse_minute(ext).context(fail(b'M'))),
+                b'm' => rtry!(self.parse_month(ext).context(fail(b'm'))),
+                b'N' => rtry!(self.parse_fractional(ext).context(fail(b'N'))),
+                b'n' => rtry!(self.parse_whitespace().context(fail(b'n'))),
+                b'P' => rtry!(self.parse_ampm().context(fail(b'P'))),
+                b'p' => rtry!(self.parse_ampm().context(fail(b'p'))),
                 b'Q' => match ext.colons {
-                    0 => self.parse_iana_nocolon().context(fail(b'Q'))?,
-                    1 => self.parse_iana_colon().context(failc(b'Q', 1))?,
+                    0 => rtry!(self.parse_iana_nocolon().context(fail(b'Q'))),
+                    1 => {
+                        rtry!(self.parse_iana_colon().context(failc(b'Q', 1)))
+                    }
                     _ => return Err(E::ColonCount { directive: b'Q' }.into()),
                 },
-                b'R' => self.parse_clock_nosecs().context(fail(b'R'))?,
-                b'S' => self.parse_second(ext).context(fail(b'S'))?,
-                b's' => self.parse_timestamp(ext).context(fail(b's'))?,
-                b'T' => self.parse_clock_secs().context(fail(b'T'))?,
-                b't' => self.parse_whitespace().context(fail(b't'))?,
-                b'U' => self.parse_week_sun(ext).context(fail(b'U'))?,
-                b'u' => self.parse_weekday_mon(ext).context(fail(b'u'))?,
-                b'V' => self.parse_week_iso(ext).context(fail(b'V'))?,
-                b'W' => self.parse_week_mon(ext).context(fail(b'W'))?,
-                b'w' => self.parse_weekday_sun(ext).context(fail(b'w'))?,
-                b'Y' => self.parse_year(ext).context(fail(b'Y'))?,
-                b'y' => self.parse_year2(ext).context(fail(b'y'))?,
+                b'R' => rtry!(self.parse_clock_nosecs().context(fail(b'R'))),
+                b'S' => rtry!(self.parse_second(ext).context(fail(b'S'))),
+                b's' => rtry!(self.parse_timestamp(ext).context(fail(b's'))),
+                b'T' => rtry!(self.parse_clock_secs().context(fail(b'T'))),
+                b't' => rtry!(self.parse_whitespace().context(fail(b't'))),
+                b'U' => rtry!(self.parse_week_sun(ext).context(fail(b'U'))),
+                b'u' => rtry!(self.parse_weekday_mon(ext).context(fail(b'u'))),
+                b'V' => rtry!(self.parse_week_iso(ext).context(fail(b'V'))),
+                b'W' => rtry!(self.parse_week_mon(ext).context(fail(b'W'))),
+                b'w' => rtry!(self.parse_weekday_sun(ext).context(fail(b'w'))),
+                b'Y' => rtry!(self.parse_year(ext).context(fail(b'Y'))),
+                b'y' => rtry!(self.parse_year2(ext).context(fail(b'y'))),
                 b'z' => match ext.colons {
-                    0 => self.parse_offset_nocolon().context(fail(b'z'))?,
-                    1 => self.parse_offset_colon().context(failc(b'z', 1))?,
-                    2 => self.parse_offset_colon2().context(failc(b'z', 2))?,
-                    3 => self.parse_offset_colon3().context(failc(b'z', 3))?,
+                    0 => {
+                        rtry!(self.parse_offset_nocolon().context(fail(b'z')))
+                    }
+                    1 => rtry!(self
+                        .parse_offset_colon()
+                        .context(failc(b'z', 1))),
+                    2 => rtry!(self
+                        .parse_offset_colon2()
+                        .context(failc(b'z', 2))),
+                    3 => rtry!(self
+                        .parse_offset_colon3()
+                        .context(failc(b'z', 3))),
                     _ => return Err(E::ColonCount { directive: b'z' }.into()),
                 },
                 b'c' => {
@@ -116,13 +136,13 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
                     }
                     // Skip over any precision settings that might be here.
                     // This is a specific special format supported by `%.f`.
-                    let (width, fmt) = Extension::parse_width(self.fmt)?;
+                    let (width, fmt) = rtry!(Extension::parse_width(self.fmt));
                     let ext = Extension { width, ..ext };
                     self.fmt = fmt;
                     match self.f() {
-                        b'f' => self.parse_dot_fractional(ext).context(
+                        b'f' => rtry!(self.parse_dot_fractional(ext).context(
                             E::DirectiveFailureDot { directive: b'f' },
-                        )?,
+                        )),
                         unk => {
                             return Err(Error::from(
                                 E::UnknownDirectiveAfterDot { directive: unk },
@@ -180,9 +200,9 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
     /// after the `%`. If any extensions are parsed, the parser is bumped
     /// to the next byte. (If no next byte exists, then an error is returned.)
     fn parse_extension(&mut self) -> Result<Extension, Error> {
-        let (flag, fmt) = Extension::parse_flag(self.fmt)?;
-        let (width, fmt) = Extension::parse_width(fmt)?;
-        let (colons, fmt) = Extension::parse_colons(fmt)?;
+        let (flag, fmt) = rtry!(Extension::parse_flag(self.fmt));
+        let (width, fmt) = rtry!(Extension::parse_width(fmt));
+        let (colons, fmt) = rtry!(Extension::parse_colons(fmt));
         self.fmt = fmt;
         Ok(Extension { flag, width, colons })
     }
@@ -246,7 +266,7 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
     /// Parses `%D`, which is equivalent to `%m/%d/%y`.
     fn parse_american_date(&mut self) -> Result<(), Error> {
         let mut p = Parser { fmt: b"%m/%d/%y", inp: self.inp, tm: self.tm };
-        p.parse()?;
+        rtry!(p.parse());
         self.inp = p.inp;
         self.bump_fmt();
         Ok(())
@@ -258,7 +278,7 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
     /// the AM/PM moniker will be validated, but it doesn't actually influence
     /// the clock time.
     fn parse_ampm(&mut self) -> Result<(), Error> {
-        let (index, inp) = parse_ampm(self.inp)?;
+        let (index, inp) = rtry!(parse_ampm(self.inp));
         self.inp = inp;
 
         self.tm.set_meridiem(Some(match index {
@@ -274,7 +294,7 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
     /// Parses `%T`, which is equivalent to `%H:%M:%S`.
     fn parse_clock_secs(&mut self) -> Result<(), Error> {
         let mut p = Parser { fmt: b"%H:%M:%S", inp: self.inp, tm: self.tm };
-        p.parse()?;
+        rtry!(p.parse());
         self.inp = p.inp;
         self.bump_fmt();
         Ok(())
@@ -283,7 +303,7 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
     /// Parses `%R`, which is equivalent to `%H:%M`.
     fn parse_clock_nosecs(&mut self) -> Result<(), Error> {
         let mut p = Parser { fmt: b"%H:%M", inp: self.inp, tm: self.tm };
-        p.parse()?;
+        rtry!(p.parse());
         self.inp = p.inp;
         self.bump_fmt();
         Ok(())
@@ -293,12 +313,12 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
     ///
     /// We merely require that it is in the range 1-31 here.
     fn parse_day(&mut self, ext: Extension) -> Result<(), Error> {
-        let (day, inp) = ext
+        let (day, inp) = rtry!(ext
             .parse_number(2, Flag::PadZero, self.inp)
-            .context(PE::ParseDay)?;
+            .context(PE::ParseDay));
         self.inp = inp;
 
-        self.tm.day = Some(b::Day::check(day).context(PE::ParseDay)?);
+        self.tm.day = Some(rtry!(b::Day::check(day).context(PE::ParseDay)));
         self.bump_fmt();
         Ok(())
     }
@@ -307,25 +327,25 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
     ///
     /// We merely require that it is in the range 1-366 here.
     fn parse_day_of_year(&mut self, ext: Extension) -> Result<(), Error> {
-        let (day, inp) = ext
+        let (day, inp) = rtry!(ext
             .parse_number(3, Flag::PadZero, self.inp)
-            .context(PE::ParseDayOfYear)?;
+            .context(PE::ParseDayOfYear));
         self.inp = inp;
 
         self.tm.day_of_year =
-            Some(b::DayOfYear::check(day).context(PE::ParseDayOfYear)?);
+            Some(rtry!(b::DayOfYear::check(day).context(PE::ParseDayOfYear)));
         self.bump_fmt();
         Ok(())
     }
 
     /// Parses `%H`, which is equivalent to the hour.
     fn parse_hour24(&mut self, ext: Extension) -> Result<(), Error> {
-        let (hour, inp) = ext
+        let (hour, inp) = rtry!(ext
             .parse_number(2, Flag::PadZero, self.inp)
-            .context(PE::ParseHour)?;
+            .context(PE::ParseHour));
         self.inp = inp;
 
-        let hour = b::Hour::check(hour).context(PE::ParseHour)?;
+        let hour = rtry!(b::Hour::check(hour).context(PE::ParseHour));
         // OK because our hour is in bounds.
         self.tm.set_hour(Some(hour)).unwrap();
         self.bump_fmt();
@@ -334,12 +354,12 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
 
     /// Parses `%I`, which is equivalent to the hour on a 12-hour clock.
     fn parse_hour12(&mut self, ext: Extension) -> Result<(), Error> {
-        let (hour, inp) = ext
+        let (hour, inp) = rtry!(ext
             .parse_number(2, Flag::PadZero, self.inp)
-            .context(PE::ParseHour)?;
+            .context(PE::ParseHour));
         self.inp = inp;
 
-        let hour = b::Hour12::check(hour).context(PE::ParseHour)?;
+        let hour = rtry!(b::Hour12::check(hour).context(PE::ParseHour));
         // OK because our hour is in bounds.
         self.tm.set_hour(Some(hour)).unwrap();
         self.bump_fmt();
@@ -349,7 +369,7 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
     /// Parses `%F`, which is equivalent to `%Y-%m-%d`.
     fn parse_iso_date(&mut self) -> Result<(), Error> {
         let mut p = Parser { fmt: b"%Y-%m-%d", inp: self.inp, tm: self.tm };
-        p.parse()?;
+        rtry!(p.parse());
         self.inp = p.inp;
         self.bump_fmt();
         Ok(())
@@ -357,13 +377,13 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
 
     /// Parses `%M`, which is equivalent to the minute.
     fn parse_minute(&mut self, ext: Extension) -> Result<(), Error> {
-        let (minute, inp) = ext
+        let (minute, inp) = rtry!(ext
             .parse_number(2, Flag::PadZero, self.inp)
-            .context(PE::ParseMinute)?;
+            .context(PE::ParseMinute));
         self.inp = inp;
 
         self.tm.minute =
-            Some(b::Minute::check(minute).context(PE::ParseMinute)?);
+            Some(rtry!(b::Minute::check(minute).context(PE::ParseMinute)));
         self.bump_fmt();
         Ok(())
     }
@@ -385,7 +405,7 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
             if !self.inp.is_empty() && matches!(self.inp[0], b'+' | b'-') {
                 return self.parse_offset_nocolon();
             }
-            let (iana, inp) = parse_iana(self.inp)?;
+            let (iana, inp) = rtry!(parse_iana(self.inp));
             self.inp = inp;
             self.tm.iana = Some(iana.to_string());
             self.bump_fmt();
@@ -410,7 +430,7 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
             if !self.inp.is_empty() && matches!(self.inp[0], b'+' | b'-') {
                 return self.parse_offset_colon();
             }
-            let (iana, inp) = parse_iana(self.inp)?;
+            let (iana, inp) = rtry!(parse_iana(self.inp));
             self.inp = inp;
             self.tm.iana = Some(iana.to_string());
             self.bump_fmt();
@@ -428,8 +448,8 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
             .subsecond(false)
             .colon(offset::Colon::Absent);
 
-        let Parsed { value, input } = PARSER.parse(self.inp)?;
-        self.tm.offset = Some(value.to_offset()?);
+        let Parsed { value, input } = rtry!(PARSER.parse(self.inp));
+        self.tm.offset = Some(rtry!(value.to_offset()));
         self.inp = input;
         self.bump_fmt();
 
@@ -446,8 +466,8 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
             .subsecond(false)
             .colon(offset::Colon::Required);
 
-        let Parsed { value, input } = PARSER.parse(self.inp)?;
-        self.tm.offset = Some(value.to_offset()?);
+        let Parsed { value, input } = rtry!(PARSER.parse(self.inp));
+        self.tm.offset = Some(rtry!(value.to_offset()));
         self.inp = input;
         self.bump_fmt();
 
@@ -465,8 +485,8 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
             .subsecond(false)
             .colon(offset::Colon::Required);
 
-        let Parsed { value, input } = PARSER.parse(self.inp)?;
-        self.tm.offset = Some(value.to_offset()?);
+        let Parsed { value, input } = rtry!(PARSER.parse(self.inp));
+        self.tm.offset = Some(rtry!(value.to_offset()));
         self.inp = input;
         self.bump_fmt();
 
@@ -485,8 +505,8 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
             .subsecond(false)
             .colon(offset::Colon::Required);
 
-        let Parsed { value, input } = PARSER.parse(self.inp)?;
-        self.tm.offset = Some(value.to_offset()?);
+        let Parsed { value, input } = rtry!(PARSER.parse(self.inp));
+        self.tm.offset = Some(rtry!(value.to_offset()));
         self.inp = input;
         self.bump_fmt();
 
@@ -495,9 +515,9 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
 
     /// Parses `%S`, which is equivalent to the second.
     fn parse_second(&mut self, ext: Extension) -> Result<(), Error> {
-        let (mut second, inp) = ext
+        let (mut second, inp) = rtry!(ext
             .parse_number(2, Flag::PadZero, self.inp)
-            .context(PE::ParseSecond)?;
+            .context(PE::ParseSecond));
         self.inp = inp;
 
         // As with other parses in Jiff, and like Temporal,
@@ -507,7 +527,7 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
             second = 59;
         }
         self.tm.second =
-            Some(b::Second::check(second).context(PE::ParseSecond)?);
+            Some(rtry!(b::Second::check(second).context(PE::ParseSecond)));
         self.bump_fmt();
         Ok(())
     }
@@ -515,17 +535,18 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
     /// Parses `%s`, which is equivalent to a Unix timestamp.
     fn parse_timestamp(&mut self, ext: Extension) -> Result<(), Error> {
         let (sign, inp) = parse_optional_sign(self.inp);
-        let (timestamp, inp) = ext
+        let (timestamp, inp) = rtry!(ext
             // 19 comes from `i64::MAX.to_string().len()`.
             .parse_number(19, Flag::PadSpace, inp)
-            .context(PE::ParseTimestamp)?;
+            .context(PE::ParseTimestamp));
         // I believe this error case is actually impossible. Since `timestamp`
         // is guaranteed to be positive, and negating any positive `i64` will
         // always result in a valid `i64`.
         let timestamp =
             timestamp.checked_mul(sign).ok_or(PE::ParseTimestamp)?;
-        let timestamp =
-            Timestamp::from_second(timestamp).context(PE::ParseTimestamp)?;
+        let timestamp = rtry!(
+            Timestamp::from_second(timestamp).context(PE::ParseTimestamp)
+        );
         self.inp = inp;
         self.tm.timestamp = Some(timestamp);
 
@@ -555,15 +576,13 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
         // than 9 ASCII digits. Any sequence of 9 ASCII digits can be parsed
         // into an `i64`.
         let nanoseconds =
-            parse::fraction(digits).context(PE::ParseFractionalSeconds)?;
+            rtry!(parse::fraction(digits).context(PE::ParseFractionalSeconds));
         // I believe this is also impossible to fail, since the maximal
         // fractional nanosecond is 999_999_999, and which also corresponds
         // to the maximal expressible number with 9 ASCII digits. So every
         // possible expressible value here is in range.
-        self.tm.subsec = Some(
-            b::SubsecNanosecond::check(nanoseconds)
-                .context(PE::ParseFractionalSeconds)?,
-        );
+        self.tm.subsec = Some(rtry!(b::SubsecNanosecond::check(nanoseconds)
+            .context(PE::ParseFractionalSeconds)));
         self.bump_fmt();
         Ok(())
     }
@@ -582,19 +601,20 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
 
     /// Parses `%m`, which is equivalent to the month.
     fn parse_month(&mut self, ext: Extension) -> Result<(), Error> {
-        let (month, inp) = ext
+        let (month, inp) = rtry!(ext
             .parse_number(2, Flag::PadZero, self.inp)
-            .context(PE::ParseMonth)?;
+            .context(PE::ParseMonth));
         self.inp = inp;
 
-        self.tm.month = Some(b::Month::check(month).context(PE::ParseMonth)?);
+        self.tm.month =
+            Some(rtry!(b::Month::check(month).context(PE::ParseMonth)));
         self.bump_fmt();
         Ok(())
     }
 
     /// Parse `%b` or `%h`, which is an abbreviated month name.
     fn parse_month_name_abbrev(&mut self) -> Result<(), Error> {
-        let (index, inp) = parse_month_name_abbrev(self.inp)?;
+        let (index, inp) = rtry!(parse_month_name_abbrev(self.inp));
         self.inp = inp;
 
         // Both are OK because 0 <= index <= 11.
@@ -620,8 +640,9 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
             b"December",
         ];
 
-        let (index, inp) =
-            parse_choice(self.inp, CHOICES).context(PE::UnknownMonthName)?;
+        let (index, inp) = rtry!(
+            parse_choice(self.inp, CHOICES).context(PE::UnknownMonthName)
+        );
         self.inp = inp;
 
         // Both are OK because 0 <= index <= 11.
@@ -632,7 +653,7 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
 
     /// Parse `%a`, which is an abbreviated weekday.
     fn parse_weekday_abbrev(&mut self) -> Result<(), Error> {
-        let (index, inp) = parse_weekday_abbrev(self.inp)?;
+        let (index, inp) = rtry!(parse_weekday_abbrev(self.inp));
         self.inp = inp;
 
         // Both are OK because 0 <= index <= 6.
@@ -655,8 +676,8 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
             b"Saturday",
         ];
 
-        let (index, inp) = parse_choice(self.inp, CHOICES)
-            .context(PE::UnknownWeekdayAbbreviation)?;
+        let (index, inp) = rtry!(parse_choice(self.inp, CHOICES)
+            .context(PE::UnknownWeekdayAbbreviation));
         self.inp = inp;
 
         // Both are OK because 0 <= index <= 6.
@@ -670,15 +691,15 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
     /// Parse `%u`, which is a weekday number with Monday being `1` and
     /// Sunday being `7`.
     fn parse_weekday_mon(&mut self, ext: Extension) -> Result<(), Error> {
-        let (weekday, inp) = ext
+        let (weekday, inp) = rtry!(ext
             .parse_number(1, Flag::NoPad, self.inp)
-            .context(PE::ParseWeekdayNumber)?;
+            .context(PE::ParseWeekdayNumber));
         self.inp = inp;
 
         let weekday =
             i8::try_from(weekday).map_err(|_| PE::ParseWeekdayNumber)?;
-        let weekday = Weekday::from_monday_one_offset(weekday)
-            .context(PE::ParseWeekdayNumber)?;
+        let weekday = rtry!(Weekday::from_monday_one_offset(weekday)
+            .context(PE::ParseWeekdayNumber));
         self.tm.weekday = Some(weekday);
         self.bump_fmt();
         Ok(())
@@ -686,15 +707,15 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
 
     /// Parse `%w`, which is a weekday number with Sunday being `0`.
     fn parse_weekday_sun(&mut self, ext: Extension) -> Result<(), Error> {
-        let (weekday, inp) = ext
+        let (weekday, inp) = rtry!(ext
             .parse_number(1, Flag::NoPad, self.inp)
-            .context(PE::ParseWeekdayNumber)?;
+            .context(PE::ParseWeekdayNumber));
         self.inp = inp;
 
         let weekday =
             i8::try_from(weekday).map_err(|_| PE::ParseWeekdayNumber)?;
-        let weekday = Weekday::from_sunday_zero_offset(weekday)
-            .context(PE::ParseWeekdayNumber)?;
+        let weekday = rtry!(Weekday::from_sunday_zero_offset(weekday)
+            .context(PE::ParseWeekdayNumber));
         self.tm.weekday = Some(weekday);
         self.bump_fmt();
         Ok(())
@@ -703,26 +724,28 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
     /// Parse `%U`, which is a week number with Sunday being the first day
     /// in the first week numbered `01`.
     fn parse_week_sun(&mut self, ext: Extension) -> Result<(), Error> {
-        let (week, inp) = ext
+        let (week, inp) = rtry!(ext
             .parse_number(2, Flag::PadZero, self.inp)
-            .context(PE::ParseSundayWeekNumber)?;
+            .context(PE::ParseSundayWeekNumber));
         self.inp = inp;
 
-        self.tm.week_sun =
-            Some(b::WeekNum::check(week).context(PE::ParseSundayWeekNumber)?);
+        self.tm.week_sun = Some(rtry!(
+            b::WeekNum::check(week).context(PE::ParseSundayWeekNumber)
+        ));
         self.bump_fmt();
         Ok(())
     }
 
     /// Parse `%V`, which is an ISO 8601 week number.
     fn parse_week_iso(&mut self, ext: Extension) -> Result<(), Error> {
-        let (week, inp) = ext
+        let (week, inp) = rtry!(ext
             .parse_number(2, Flag::PadZero, self.inp)
-            .context(PE::ParseIsoWeekNumber)?;
+            .context(PE::ParseIsoWeekNumber));
         self.inp = inp;
 
-        self.tm.iso_week =
-            Some(b::ISOWeek::check(week).context(PE::ParseIsoWeekNumber)?);
+        self.tm.iso_week = Some(rtry!(
+            b::ISOWeek::check(week).context(PE::ParseIsoWeekNumber)
+        ));
         self.bump_fmt();
         Ok(())
     }
@@ -730,13 +753,14 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
     /// Parse `%W`, which is a week number with Monday being the first day
     /// in the first week numbered `01`.
     fn parse_week_mon(&mut self, ext: Extension) -> Result<(), Error> {
-        let (week, inp) = ext
+        let (week, inp) = rtry!(ext
             .parse_number(2, Flag::PadZero, self.inp)
-            .context(PE::ParseMondayWeekNumber)?;
+            .context(PE::ParseMondayWeekNumber));
         self.inp = inp;
 
-        self.tm.week_mon =
-            Some(b::WeekNum::check(week).context(PE::ParseMondayWeekNumber)?);
+        self.tm.week_mon = Some(rtry!(
+            b::WeekNum::check(week).context(PE::ParseMondayWeekNumber)
+        ));
         self.bump_fmt();
         Ok(())
     }
@@ -744,14 +768,16 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
     /// Parses `%Y`, which we permit to be any year, including a negative year.
     fn parse_year(&mut self, ext: Extension) -> Result<(), Error> {
         let (sign, inp) = parse_optional_sign(self.inp);
-        let (year, inp) =
-            ext.parse_number(4, Flag::PadZero, inp).context(PE::ParseYear)?;
+        let (year, inp) = rtry!(ext
+            .parse_number(4, Flag::PadZero, inp)
+            .context(PE::ParseYear));
         self.inp = inp;
 
         // OK because sign=={1,-1} and year can't be bigger than 4 digits
         // so overflow isn't possible.
         let year = sign.checked_mul(year).unwrap();
-        self.tm.year = Some(b::Year::check(year).context(PE::ParseYear)?);
+        self.tm.year =
+            Some(rtry!(b::Year::check(year).context(PE::ParseYear)));
         self.bump_fmt();
         Ok(())
     }
@@ -760,13 +786,13 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
     ///
     /// The numbers 69-99 refer to 1969-1999, while 00-68 refer to 2000-2068.
     fn parse_year2(&mut self, ext: Extension) -> Result<(), Error> {
-        let (year, inp) = ext
+        let (year, inp) = rtry!(ext
             .parse_number(2, Flag::PadZero, self.inp)
-            .context(PE::ParseYearTwoDigit)?;
+            .context(PE::ParseYearTwoDigit));
         self.inp = inp;
 
         let mut year =
-            b::YearTwoDigit::check(year).context(PE::ParseYearTwoDigit)?;
+            rtry!(b::YearTwoDigit::check(year).context(PE::ParseYearTwoDigit));
         if year <= 68 {
             year += 2000;
         } else {
@@ -781,12 +807,14 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
     /// century.
     fn parse_century(&mut self, ext: Extension) -> Result<(), Error> {
         let (sign, inp) = parse_optional_sign(self.inp);
-        let (century, inp) =
-            ext.parse_number(2, Flag::NoPad, inp).context(PE::ParseCentury)?;
+        let (century, inp) = rtry!(ext
+            .parse_number(2, Flag::NoPad, inp)
+            .context(PE::ParseCentury));
         self.inp = inp;
 
-        let century =
-            i64::from(b::Century::check(century).context(PE::ParseCentury)?);
+        let century = i64::from(rtry!(
+            b::Century::check(century).context(PE::ParseCentury)
+        ));
         // OK because sign=={1,-1} and century can't be bigger than 2 digits
         // so overflow isn't possible.
         let century = sign.checked_mul(century).unwrap();
@@ -794,7 +822,8 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
         // 100 will never overflow.
         let year = century.checked_mul(100).unwrap();
         // I believe the error condition here is impossible.
-        self.tm.year = Some(b::Year::check(year).context(PE::ParseCentury)?);
+        self.tm.year =
+            Some(rtry!(b::Year::check(year).context(PE::ParseCentury)));
         self.bump_fmt();
         Ok(())
     }
@@ -802,16 +831,16 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
     /// Parses `%G`, which we permit to be any year, including a negative year.
     fn parse_iso_week_year(&mut self, ext: Extension) -> Result<(), Error> {
         let (sign, inp) = parse_optional_sign(self.inp);
-        let (year, inp) = ext
+        let (year, inp) = rtry!(ext
             .parse_number(4, Flag::PadZero, inp)
-            .context(PE::ParseIsoWeekYear)?;
+            .context(PE::ParseIsoWeekYear));
         self.inp = inp;
 
         // OK because sign=={1,-1} and year can't be bigger than 4 digits
         // so overflow isn't possible.
         let year = sign.checked_mul(year).unwrap();
         self.tm.iso_week_year =
-            Some(b::ISOYear::check(year).context(PE::ParseIsoWeekYear)?);
+            Some(rtry!(b::ISOYear::check(year).context(PE::ParseIsoWeekYear)));
         self.bump_fmt();
         Ok(())
     }
@@ -820,13 +849,14 @@ impl<'f, 'i, 't> Parser<'f, 'i, 't> {
     ///
     /// The numbers 69-99 refer to 1969-1999, while 00-68 refer to 2000-2068.
     fn parse_iso_week_year2(&mut self, ext: Extension) -> Result<(), Error> {
-        let (year, inp) = ext
+        let (year, inp) = rtry!(ext
             .parse_number(2, Flag::PadZero, self.inp)
-            .context(PE::ParseIsoWeekYearTwoDigit)?;
+            .context(PE::ParseIsoWeekYearTwoDigit));
         self.inp = inp;
 
-        let mut year = b::YearTwoDigit::check(year)
-            .context(PE::ParseIsoWeekYearTwoDigit)?;
+        let mut year =
+            rtry!(b::YearTwoDigit::check(year)
+                .context(PE::ParseIsoWeekYearTwoDigit));
         if year <= 68 {
             year += 2000;
         } else {
@@ -1033,10 +1063,10 @@ fn parse_month_name_abbrev<'i>(
 #[cfg_attr(feature = "perf-inline", inline(always))]
 fn parse_iana<'i>(input: &'i [u8]) -> Result<(&'i str, &'i [u8]), Error> {
     let mkiana = parse::slicer(input);
-    let (_, mut input) = parse_iana_component(input)?;
+    let (_, mut input) = rtry!(parse_iana_component(input));
     while let Some(tail) = input.strip_prefix(b"/") {
         input = tail;
-        let (_, unconsumed) = parse_iana_component(input)?;
+        let (_, unconsumed) = rtry!(parse_iana_component(input));
         input = unconsumed;
     }
     // This is OK because all bytes in a IANA TZ annotation are guaranteed

--- a/src/fmt/strtime/printer.rs
+++ b/src/fmt/strtime/printer.rs
@@ -95,17 +95,17 @@ impl<'config, 'fmt, 'tm, 'writer, 'buffer, 'data, 'write, L: Custom>
         while !self.fmt.is_empty() {
             if self.f() != b'%' {
                 if self.f().is_ascii() {
-                    self.wtr.write_ascii_char(self.f())?;
+                    rtry!(self.wtr.write_ascii_char(self.f()));
                     self.bump_fmt();
                 } else {
                     let ch = self.utf8_decode_and_bump()?;
-                    self.wtr.write_char(ch)?;
+                    rtry!(self.wtr.write_char(ch));
                 }
                 continue;
             }
             if !self.bump_fmt() {
                 if self.config.lenient {
-                    self.wtr.write_ascii_char(b'%')?;
+                    rtry!(self.wtr.write_ascii_char(b'%'));
                     break;
                 }
                 return Err(E::UnexpectedEndAfterPercent.into());
@@ -120,7 +120,7 @@ impl<'config, 'fmt, 'tm, 'writer, 'buffer, 'data, 'write, L: Custom>
                 // `orig` is whatever failed to parse immediately after a `%`.
                 // Since it failed, we write out the `%` and then proceed to
                 // handle what failed to parse literally.
-                self.wtr.write_ascii_char(b'%')?;
+                rtry!(self.wtr.write_ascii_char(b'%'));
                 // Reset back to right after parsing the `%`.
                 self.fmt = orig;
             }
@@ -139,7 +139,7 @@ impl<'config, 'fmt, 'tm, 'writer, 'buffer, 'data, 'write, L: Custom>
 
         // Parse extensions like padding/case options and padding width.
         let mut directive = self.f();
-        let item = match directive {
+        let item = rtry!(match directive {
             b'%' => self.fmt_literal("%").map(s).context(fail(b'%')),
             b'A' => self.fmt_weekday_full().map(s).context(fail(b'A')),
             b'a' => self.fmt_weekday_abbrev().map(s).context(fail(b'a')),
@@ -201,8 +201,10 @@ impl<'config, 'fmt, 'tm, 'writer, 'buffer, 'data, 'write, L: Custom>
                 }
                 // Parse precision settings after the `.`, effectively
                 // overriding any digits that came before it.
-                let ext =
-                    &Extension { width: self.parse_width()?, ..ext.clone() };
+                let ext = &Extension {
+                    width: rtry!(self.parse_width()),
+                    ..ext.clone()
+                };
                 directive = self.f();
                 match directive {
                     b'f' => self
@@ -216,8 +218,8 @@ impl<'config, 'fmt, 'tm, 'writer, 'buffer, 'data, 'write, L: Custom>
                 }
             }
             _ => return Err(Error::from(E::UnknownDirective { directive })),
-        }?;
-        self.write_item(ext, &item).context(fail(directive))?;
+        });
+        rtry!(self.write_item(ext, &item).context(fail(directive)));
         self.bump_fmt();
         Ok(())
     }
@@ -285,9 +287,9 @@ impl<'config, 'fmt, 'tm, 'writer, 'buffer, 'data, 'write, L: Custom>
         if self.f().is_ascii_alphabetic() {
             return Ok(Extension { flag: None, width: None, colons: 0 });
         }
-        let flag = self.parse_flag()?;
-        let width = self.parse_width()?;
-        let colons = self.parse_colons()?;
+        let flag = rtry!(self.parse_flag());
+        let width = rtry!(self.parse_width());
+        let colons = rtry!(self.parse_colons());
         Ok(Extension { flag, width, colons })
     }
 
@@ -295,7 +297,7 @@ impl<'config, 'fmt, 'tm, 'writer, 'buffer, 'data, 'write, L: Custom>
     /// to the next byte. (If no next byte exists, then an error is returned.)
     #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_flag(&mut self) -> Result<Option<Flag>, Error> {
-        let (flag, fmt) = Extension::parse_flag(self.fmt)?;
+        let (flag, fmt) = rtry!(Extension::parse_flag(self.fmt));
         self.fmt = fmt;
         Ok(flag)
     }
@@ -311,7 +313,7 @@ impl<'config, 'fmt, 'tm, 'writer, 'buffer, 'data, 'write, L: Custom>
     /// technically valid, but the `5` is ignored.
     #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_width(&mut self) -> Result<Option<u8>, Error> {
-        let (width, fmt) = Extension::parse_width(self.fmt)?;
+        let (width, fmt) = rtry!(Extension::parse_width(self.fmt));
         self.fmt = fmt;
         Ok(width)
     }
@@ -320,7 +322,7 @@ impl<'config, 'fmt, 'tm, 'writer, 'buffer, 'data, 'write, L: Custom>
     /// conversion specifier.
     #[cfg_attr(feature = "perf-inline", inline(always))]
     fn parse_colons(&mut self) -> Result<u8, Error> {
-        let (colons, fmt) = Extension::parse_colons(self.fmt)?;
+        let (colons, fmt) = rtry!(Extension::parse_colons(self.fmt));
         self.fmt = fmt;
         Ok(colons)
     }
@@ -341,7 +343,7 @@ impl<'config, 'fmt, 'tm, 'writer, 'buffer, 'data, 'write, L: Custom>
             ),
             Item::Fraction(ItemFraction { width, dot, subsec }) => {
                 if dot {
-                    self.wtr.write_ascii_char(b'.')?;
+                    rtry!(self.wtr.write_ascii_char(b'.'));
                 }
                 self.wtr.write_fraction(width, subsec)
             }
@@ -413,56 +415,56 @@ impl<'config, 'fmt, 'tm, 'writer, 'buffer, 'data, 'write, L: Custom>
 
     /// %D
     fn fmt_american_date(&mut self) -> Result<Item, Error> {
-        let ItemInteger { number, .. } = self.fmt_month()?;
-        self.wtr.write_int_pad2(number.unsigned_abs())?;
-        self.wtr.write_ascii_char(b'/')?;
-        let ItemInteger { number, .. } = self.fmt_day_zero()?;
-        self.wtr.write_int_pad2(number.unsigned_abs())?;
-        self.wtr.write_ascii_char(b'/')?;
-        let ItemInteger { number, .. } = self.fmt_year2()?;
+        let ItemInteger { number, .. } = rtry!(self.fmt_month());
+        rtry!(self.wtr.write_int_pad2(number.unsigned_abs()));
+        rtry!(self.wtr.write_ascii_char(b'/'));
+        let ItemInteger { number, .. } = rtry!(self.fmt_day_zero());
+        rtry!(self.wtr.write_int_pad2(number.unsigned_abs()));
+        rtry!(self.wtr.write_ascii_char(b'/'));
+        let ItemInteger { number, .. } = rtry!(self.fmt_year2());
         if number < 0 {
-            self.wtr.write_ascii_char(b'-')?;
+            rtry!(self.wtr.write_ascii_char(b'-'));
         }
-        self.wtr.write_int_pad2(number.unsigned_abs())?;
+        rtry!(self.wtr.write_int_pad2(number.unsigned_abs()));
         Ok(Item::AlreadyFormatted)
     }
 
     /// %R
     fn fmt_clock_nosecs(&mut self) -> Result<Item, Error> {
-        let ItemInteger { number, .. } = self.fmt_hour24_zero()?;
-        self.wtr.write_int_pad2(number.unsigned_abs())?;
-        self.wtr.write_ascii_char(b':')?;
-        let ItemInteger { number, .. } = self.fmt_minute()?;
-        self.wtr.write_int_pad2(number.unsigned_abs())?;
+        let ItemInteger { number, .. } = rtry!(self.fmt_hour24_zero());
+        rtry!(self.wtr.write_int_pad2(number.unsigned_abs()));
+        rtry!(self.wtr.write_ascii_char(b':'));
+        let ItemInteger { number, .. } = rtry!(self.fmt_minute());
+        rtry!(self.wtr.write_int_pad2(number.unsigned_abs()));
         Ok(Item::AlreadyFormatted)
     }
 
     /// %T
     fn fmt_clock_secs(&mut self) -> Result<Item, Error> {
-        let ItemInteger { number, .. } = self.fmt_hour24_zero()?;
-        self.wtr.write_int_pad2(number.unsigned_abs())?;
-        self.wtr.write_ascii_char(b':')?;
-        let ItemInteger { number, .. } = self.fmt_minute()?;
-        self.wtr.write_int_pad2(number.unsigned_abs())?;
-        self.wtr.write_ascii_char(b':')?;
-        let ItemInteger { number, .. } = self.fmt_second()?;
-        self.wtr.write_int_pad2(number.unsigned_abs())?;
+        let ItemInteger { number, .. } = rtry!(self.fmt_hour24_zero());
+        rtry!(self.wtr.write_int_pad2(number.unsigned_abs()));
+        rtry!(self.wtr.write_ascii_char(b':'));
+        let ItemInteger { number, .. } = rtry!(self.fmt_minute());
+        rtry!(self.wtr.write_int_pad2(number.unsigned_abs()));
+        rtry!(self.wtr.write_ascii_char(b':'));
+        let ItemInteger { number, .. } = rtry!(self.fmt_second());
+        rtry!(self.wtr.write_int_pad2(number.unsigned_abs()));
         Ok(Item::AlreadyFormatted)
     }
 
     /// %F
     fn fmt_iso_date(&mut self) -> Result<Item, Error> {
-        let ItemInteger { number, .. } = self.fmt_year()?;
+        let ItemInteger { number, .. } = rtry!(self.fmt_year());
         if number < 0 {
-            self.wtr.write_ascii_char(b'-')?;
+            rtry!(self.wtr.write_ascii_char(b'-'));
         }
-        self.wtr.write_int_pad4(number.unsigned_abs())?;
-        self.wtr.write_ascii_char(b'-')?;
-        let ItemInteger { number, .. } = self.fmt_month()?;
-        self.wtr.write_int_pad2(number.unsigned_abs())?;
-        self.wtr.write_ascii_char(b'-')?;
-        let ItemInteger { number, .. } = self.fmt_day_zero()?;
-        self.wtr.write_int_pad2(number.unsigned_abs())?;
+        rtry!(self.wtr.write_int_pad4(number.unsigned_abs()));
+        rtry!(self.wtr.write_ascii_char(b'-'));
+        let ItemInteger { number, .. } = rtry!(self.fmt_month());
+        rtry!(self.wtr.write_int_pad2(number.unsigned_abs()));
+        rtry!(self.wtr.write_ascii_char(b'-'));
+        let ItemInteger { number, .. } = rtry!(self.fmt_day_zero());
+        rtry!(self.wtr.write_int_pad2(number.unsigned_abs()));
         Ok(Item::AlreadyFormatted)
     }
 
@@ -564,7 +566,7 @@ impl<'config, 'fmt, 'tm, 'writer, 'buffer, 'data, 'write, L: Custom>
                 offset, false, true, false,
             )));
         };
-        self.wtr.write_str(iana)?;
+        rtry!(self.wtr.write_str(iana));
         Ok(Item::AlreadyFormatted)
     }
 
@@ -576,7 +578,7 @@ impl<'config, 'fmt, 'tm, 'writer, 'buffer, 'data, 'write, L: Custom>
                 offset, true, true, false,
             )));
         };
-        self.wtr.write_str(iana)?;
+        rtry!(self.wtr.write_str(iana));
         Ok(Item::AlreadyFormatted)
     }
 
@@ -684,7 +686,7 @@ impl<'config, 'fmt, 'tm, 'writer, 'buffer, 'data, 'write, L: Custom>
         let tz = self.tm.tz.as_ref().ok_or(FE::RequiresTimeZone)?;
         let ts = self.tm.to_timestamp().map_err(|_| FE::RequiresInstant)?;
         let oinfo = tz.to_offset_info(ts);
-        ext.write_str(Case::Upper, oinfo.abbreviation(), self.wtr)?;
+        rtry!(ext.write_str(Case::Upper, oinfo.abbreviation(), self.wtr));
         Ok(Item::AlreadyFormatted)
     }
 
@@ -883,35 +885,45 @@ impl<'config, 'fmt, 'tm, 'writer, 'buffer, 'data, 'write, L: Custom>
 
     /// %c
     fn fmt_datetime(&mut self, ext: &Extension) -> Result<Item, Error> {
-        self.config.custom.format_datetime(
+        rtry!(self.config.custom.format_datetime(
             self.config,
             ext,
             self.tm,
             self.wtr,
-        )?;
+        ));
         Ok(Item::AlreadyFormatted)
     }
 
     /// %x
     fn fmt_date(&mut self, ext: &Extension) -> Result<Item, Error> {
-        self.config.custom.format_date(self.config, ext, self.tm, self.wtr)?;
+        rtry!(self.config.custom.format_date(
+            self.config,
+            ext,
+            self.tm,
+            self.wtr
+        ));
         Ok(Item::AlreadyFormatted)
     }
 
     /// %X
     fn fmt_time(&mut self, ext: &Extension) -> Result<Item, Error> {
-        self.config.custom.format_time(self.config, ext, self.tm, self.wtr)?;
+        rtry!(self.config.custom.format_time(
+            self.config,
+            ext,
+            self.tm,
+            self.wtr
+        ));
         Ok(Item::AlreadyFormatted)
     }
 
     /// %r
     fn fmt_12hour_time(&mut self, ext: &Extension) -> Result<Item, Error> {
-        self.config.custom.format_12hour_time(
+        rtry!(self.config.custom.format_12hour_time(
             self.config,
             ext,
             self.tm,
             self.wtr,
-        )?;
+        ));
         Ok(Item::AlreadyFormatted)
     }
 }
@@ -940,18 +952,22 @@ fn write_offset(
     let minutes = ((total_seconds / 60) % 60) as u8;
     let seconds = (total_seconds % 60) as u8;
 
-    wtr.write_ascii_char(if offset.is_negative() { b'-' } else { b'+' })?;
-    wtr.write_int_pad2(hours)?;
+    rtry!(wtr.write_ascii_char(if offset.is_negative() {
+        b'-'
+    } else {
+        b'+'
+    }));
+    rtry!(wtr.write_int_pad2(hours));
     if minute || minutes != 0 || seconds != 0 {
         if colon {
-            wtr.write_ascii_char(b':')?;
+            rtry!(wtr.write_ascii_char(b':'));
         }
-        wtr.write_int_pad2(minutes)?;
+        rtry!(wtr.write_int_pad2(minutes));
         if second || seconds != 0 {
             if colon {
-                wtr.write_ascii_char(b':')?;
+                rtry!(wtr.write_ascii_char(b':'));
             }
-            wtr.write_int_pad2(seconds)?;
+            rtry!(wtr.write_int_pad2(seconds));
         }
     }
     Ok(())
@@ -988,15 +1004,15 @@ impl Extension {
         };
         match case {
             Case::AsIs => {
-                wtr.write_str(string)?;
+                rtry!(wtr.write_str(string));
             }
             Case::Upper | Case::Lower => {
                 for ch in string.chars() {
-                    wtr.write_char(if matches!(case, Case::Upper) {
+                    rtry!(wtr.write_char(if matches!(case, Case::Upper) {
                         ch.to_ascii_uppercase()
                     } else {
                         ch.to_ascii_lowercase()
-                    })?;
+                    }));
                 }
             }
         }
@@ -1037,7 +1053,7 @@ impl Extension {
                     wtr,
                 );
             }
-            wtr.write_ascii_char(b'-')?;
+            rtry!(wtr.write_ascii_char(b'-'));
         }
         let number = number.unsigned_abs();
         match (pad_byte, pad_width) {
@@ -1069,7 +1085,7 @@ impl Extension {
         if pad_byte == b' ' {
             let d = 1 + number.checked_ilog10().unwrap_or(0) as u8;
             for _ in 0..pad_width.saturating_sub(d) {
-                wtr.write_ascii_char(b' ')?;
+                rtry!(wtr.write_ascii_char(b' '));
             }
             // Don't do any padding to the call below.
             // We could instead add a `BorrowedWriter::write_int`
@@ -1077,7 +1093,7 @@ impl Extension {
             // this case.
             pad_width = 0;
         }
-        wtr.write_ascii_char(b'-')?;
+        rtry!(wtr.write_ascii_char(b'-'));
         wtr.write_int_pad(number, pad_byte, pad_width)
     }
 }

--- a/src/fmt/temporal/mod.rs
+++ b/src/fmt/temporal/mod.rs
@@ -652,10 +652,10 @@ impl DateTimeParser {
         input: I,
     ) -> Result<Zoned, Error> {
         let input = input.as_ref();
-        let parsed = self.p.parse_temporal_datetime(input)?;
-        let dt = parsed.into_full()?;
+        let parsed = rtry!(self.p.parse_temporal_datetime(input));
+        let dt = rtry!(parsed.into_full());
         let zoned =
-            dt.to_zoned(db, self.offset_conflict, self.disambiguation)?;
+            rtry!(dt.to_zoned(db, self.offset_conflict, self.disambiguation));
         Ok(zoned)
     }
 
@@ -706,9 +706,9 @@ impl DateTimeParser {
         input: I,
     ) -> Result<Timestamp, Error> {
         let input = input.as_ref();
-        let parsed = self.p.parse_temporal_datetime(input)?;
-        let dt = parsed.into_full()?;
-        let timestamp = dt.to_timestamp()?;
+        let parsed = rtry!(self.p.parse_temporal_datetime(input));
+        let dt = rtry!(parsed.into_full());
+        let timestamp = rtry!(dt.to_timestamp());
         Ok(timestamp)
     }
 
@@ -765,9 +765,9 @@ impl DateTimeParser {
         input: I,
     ) -> Result<civil::DateTime, Error> {
         let input = input.as_ref();
-        let parsed = self.p.parse_temporal_datetime(input)?;
-        let dt = parsed.into_full()?;
-        let datetime = dt.to_datetime()?;
+        let parsed = rtry!(self.p.parse_temporal_datetime(input));
+        let dt = rtry!(parsed.into_full());
+        let datetime = rtry!(dt.to_datetime());
         Ok(datetime)
     }
 
@@ -824,9 +824,9 @@ impl DateTimeParser {
         input: I,
     ) -> Result<civil::Date, Error> {
         let input = input.as_ref();
-        let parsed = self.p.parse_temporal_datetime(input)?;
-        let dt = parsed.into_full()?;
-        let date = dt.to_date()?;
+        let parsed = rtry!(self.p.parse_temporal_datetime(input));
+        let dt = rtry!(parsed.into_full());
+        let date = rtry!(dt.to_date());
         Ok(date)
     }
 
@@ -883,8 +883,8 @@ impl DateTimeParser {
         input: I,
     ) -> Result<civil::Time, Error> {
         let input = input.as_ref();
-        let parsed = self.p.parse_temporal_time(input)?;
-        let parsed_time = parsed.into_full()?;
+        let parsed = rtry!(self.p.parse_temporal_time(input));
+        let parsed_time = rtry!(parsed.into_full());
         let time = parsed_time.to_time();
         Ok(time)
     }
@@ -982,7 +982,7 @@ impl DateTimeParser {
         input: I,
     ) -> Result<TimeZone, Error> {
         let input = input.as_ref();
-        let parsed = self.p.parse_time_zone(input)?.into_full()?;
+        let parsed = rtry!(rtry!(self.p.parse_time_zone(input)).into_full());
         parsed.into_time_zone(db)
     }
 
@@ -1103,8 +1103,9 @@ impl DateTimeParser {
         input: &'i I,
     ) -> Result<Pieces<'i>, Error> {
         let input = input.as_ref();
-        let parsed = self.p.parse_temporal_datetime(input)?.into_full()?;
-        let pieces = parsed.to_pieces()?;
+        let parsed =
+            rtry!(rtry!(self.p.parse_temporal_datetime(input)).into_full());
+        let pieces = rtry!(parsed.to_pieces());
         Ok(pieces)
     }
 
@@ -1120,7 +1121,7 @@ impl DateTimeParser {
         input: I,
     ) -> Result<ISOWeekDate, Error> {
         let input = input.as_ref();
-        let wd = self.p.parse_iso_week_date(input)?.into_full()?;
+        let wd = rtry!(rtry!(self.p.parse_iso_week_date(input)).into_full());
         Ok(wd)
     }
 }
@@ -1566,7 +1567,7 @@ impl DateTimePrinter {
         let mut buf = alloc::string::String::new();
         // Writing to a `String` itself will never fail, but this could fail
         // as described above in the docs.
-        self.print_time_zone(tz, &mut buf)?;
+        rtry!(self.print_time_zone(tz, &mut buf));
         Ok(buf)
     }
 

--- a/src/fmt/temporal/parser.rs
+++ b/src/fmt/temporal/parser.rs
@@ -44,9 +44,9 @@ impl<'i> ParsedDateTime<'i> {
             pieces = pieces.with_time(time.time);
         }
         if let Some(ref offset) = self.offset {
-            pieces = pieces.with_offset(offset.to_pieces_offset()?);
+            pieces = pieces.with_offset(rtry!(offset.to_pieces_offset()));
         }
-        if let Some(ann) = self.annotations.to_time_zone_annotation()? {
+        if let Some(ann) = rtry!(self.annotations.to_time_zone_annotation()) {
             pieces = pieces.with_time_zone_annotation(ann);
         }
         Ok(pieces)
@@ -59,7 +59,7 @@ impl<'i> ParsedDateTime<'i> {
         offset_conflict: OffsetConflict,
         disambiguation: Disambiguation,
     ) -> Result<Zoned, Error> {
-        self.to_ambiguous_zoned(db, offset_conflict)?
+        rtry!(self.to_ambiguous_zoned(db, offset_conflict))
             .disambiguate(disambiguation)
     }
 
@@ -77,7 +77,7 @@ impl<'i> ParsedDateTime<'i> {
             .annotations
             .to_time_zone_annotation()?
             .ok_or(E::MissingTimeZoneAnnotation)?;
-        let tz = tz_annotation.to_time_zone_with(db)?;
+        let tz = rtry!(tz_annotation.to_time_zone_with(db));
 
         // If there's no offset, then our only choice, regardless of conflict
         // resolution preference, is to use the time zone. That is, there is no
@@ -97,7 +97,7 @@ impl<'i> ParsedDateTime<'i> {
             // the time zone parsed.)
             return OffsetConflict::AlwaysOffset.resolve(dt, Offset::UTC, tz);
         }
-        let offset = parsed_offset.to_offset()?;
+        let offset = rtry!(parsed_offset.to_offset());
         let is_equal = |parsed: Offset, candidate: Offset| {
             // If they're equal down to the second, then no amount of rounding
             // or whatever should change that.
@@ -138,11 +138,11 @@ impl<'i> ParsedDateTime<'i> {
             .ok_or(E::MissingTimeInTimestamp)?;
         let parsed_offset =
             self.offset.as_ref().ok_or(E::MissingOffsetInTimestamp)?;
-        let offset = parsed_offset.to_offset()?;
+        let offset = rtry!(parsed_offset.to_offset());
         let dt = DateTime::from_parts(self.date.date, time);
-        let timestamp = offset
+        let timestamp = rtry!(offset
             .to_timestamp(dt)
-            .context(E::ConvertDateTimeToTimestamp { offset })?;
+            .context(E::ConvertDateTimeToTimestamp { offset }));
         Ok(timestamp)
     }
 
@@ -170,12 +170,12 @@ impl<'i> ParsedDateTime<'i> {
 
 impl<'i> core::fmt::Display for ParsedDateTime<'i> {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        core::fmt::Display::fmt(&self.date, f)?;
+        rtry!(core::fmt::Display::fmt(&self.date, f));
         if let Some(ref time) = self.time {
-            core::fmt::Display::fmt(&time, f)?;
+            rtry!(core::fmt::Display::fmt(&time, f));
         }
         if let Some(ref offset) = self.offset {
-            core::fmt::Display::fmt(&offset, f)?;
+            rtry!(core::fmt::Display::fmt(&offset, f));
         }
         core::fmt::Display::fmt(&self.annotations, f)
     }
@@ -248,7 +248,7 @@ impl<'i> ParsedTimeZone<'i> {
             }
             ParsedTimeZoneKind::Offset(poff) => {
                 let offset =
-                    poff.to_offset().context(E::FailedOffsetNumeric)?;
+                    rtry!(poff.to_offset().context(E::FailedOffsetNumeric));
                 Ok(TimeZone::fixed(offset))
             }
             #[cfg(feature = "alloc")]
@@ -287,7 +287,7 @@ impl DateTimeParser {
         &self,
         input: &'i [u8],
     ) -> Result<Parsed<'i, ParsedDateTime<'i>>, Error> {
-        let Parsed { value: date, input } = self.parse_date_spec(input)?;
+        let Parsed { value: date, input } = rtry!(self.parse_date_spec(input));
         let Some((&first, tail)) = input.split_first() else {
             let value = ParsedDateTime {
                 date,
@@ -304,12 +304,14 @@ impl DateTimeParser {
             // If there's a separator, then we must parse a time and we are
             // *allowed* to parse an offset. But without a separator, we don't
             // support offsets. Just annotations (which are parsed below).
-            let Parsed { value: time, input } = self.parse_time_spec(input)?;
-            let Parsed { value: offset, input } = self.parse_offset(input)?;
+            let Parsed { value: time, input } =
+                rtry!(self.parse_time_spec(input));
+            let Parsed { value: offset, input } =
+                rtry!(self.parse_offset(input));
             (Some(time), offset, input)
         };
         let Parsed { value: annotations, input } =
-            self.parse_annotations(input)?;
+            rtry!(self.parse_annotations(input));
         let value = ParsedDateTime { date, time, offset, annotations };
         Ok(Parsed { value, input })
     }
@@ -341,12 +343,14 @@ impl DateTimeParser {
         if let Some(input) =
             input.strip_prefix(b"T").or_else(|| input.strip_prefix(b"t"))
         {
-            let Parsed { value: time, input } = self.parse_time_spec(input)?;
-            let Parsed { value: offset, input } = self.parse_offset(input)?;
+            let Parsed { value: time, input } =
+                rtry!(self.parse_time_spec(input));
+            let Parsed { value: offset, input } =
+                rtry!(self.parse_offset(input));
             if offset.map_or(false, |o| o.is_zulu()) {
                 return Err(Error::from(E::CivilDateTimeZulu));
             }
-            let Parsed { input, .. } = self.parse_annotations(input)?;
+            let Parsed { input, .. } = rtry!(self.parse_annotations(input));
             return Ok(Parsed { value: time, input });
         }
         // We now look for a full datetime and extract the time from that.
@@ -372,8 +376,8 @@ impl DateTimeParser {
         // At this point, we look for something that is a time that doesn't
         // start with a `T`. We need to check that it isn't ambiguous with a
         // possible date.
-        let Parsed { value: time, input } = self.parse_time_spec(input)?;
-        let Parsed { value: offset, input } = self.parse_offset(input)?;
+        let Parsed { value: time, input } = rtry!(self.parse_time_spec(input));
+        let Parsed { value: offset, input } = rtry!(self.parse_offset(input));
         if offset.map_or(false, |o| o.is_zulu()) {
             return Err(Error::from(E::CivilDateTimeZulu));
         }
@@ -394,7 +398,7 @@ impl DateTimeParser {
             }
         }
         // OK... carry on.
-        let Parsed { input, .. } = self.parse_annotations(input)?;
+        let Parsed { input, .. } = rtry!(self.parse_annotations(input));
         Ok(Parsed { value: time, input })
     }
 
@@ -488,34 +492,36 @@ impl DateTimeParser {
     ) -> Result<Parsed<'i, ISOWeekDate>, Error> {
         // Parse year component.
         let Parsed { value: year, input } =
-            self.parse_year(input).context(E::FailedYearInDate)?;
+            rtry!(self.parse_year(input).context(E::FailedYearInDate));
         let extended = input.starts_with(b"-");
 
         // Parse optional separator.
-        let Parsed { input, .. } = self
+        let Parsed { input, .. } = rtry!(self
             .parse_date_separator(input, extended)
-            .context(E::FailedSeparatorAfterYear)?;
+            .context(E::FailedSeparatorAfterYear));
 
         // Parse 'W' prefix before week num.
-        let Parsed { input, .. } = self
+        let Parsed { input, .. } = rtry!(self
             .parse_week_prefix(input)
-            .context(E::FailedWeekNumberPrefixInDate)?;
+            .context(E::FailedWeekNumberPrefixInDate));
 
         // Parse week num component.
-        let Parsed { value: week, input } =
-            self.parse_week_num(input).context(E::FailedWeekNumberInDate)?;
+        let Parsed { value: week, input } = rtry!(self
+            .parse_week_num(input)
+            .context(E::FailedWeekNumberInDate));
 
         // Parse optional separator.
-        let Parsed { input, .. } = self
+        let Parsed { input, .. } = rtry!(self
             .parse_date_separator(input, extended)
-            .context(E::FailedSeparatorAfterWeekNumber)?;
+            .context(E::FailedSeparatorAfterWeekNumber));
 
         // Parse day component.
         let Parsed { value: weekday, input } =
-            self.parse_weekday(input).context(E::FailedWeekdayInDate)?;
+            rtry!(self.parse_weekday(input).context(E::FailedWeekdayInDate));
 
-        let iso_week_date = ISOWeekDate::new(year, week, weekday)
-            .context(E::InvalidWeekDate)?;
+        let iso_week_date =
+            rtry!(ISOWeekDate::new(year, week, weekday)
+                .context(E::InvalidWeekDate));
 
         Ok(Parsed { value: iso_week_date, input: input })
     }
@@ -530,28 +536,28 @@ impl DateTimeParser {
     ) -> Result<Parsed<'i, ParsedDate>, Error> {
         // Parse year component.
         let Parsed { value: year, input } =
-            self.parse_year(input).context(E::FailedYearInDate)?;
+            rtry!(self.parse_year(input).context(E::FailedYearInDate));
         let extended = input.starts_with(b"-");
 
         // Parse optional separator.
-        let Parsed { input, .. } = self
+        let Parsed { input, .. } = rtry!(self
             .parse_date_separator(input, extended)
-            .context(E::FailedSeparatorAfterYear)?;
+            .context(E::FailedSeparatorAfterYear));
 
         // Parse month component.
         let Parsed { value: month, input } =
-            self.parse_month(input).context(E::FailedMonthInDate)?;
+            rtry!(self.parse_month(input).context(E::FailedMonthInDate));
 
         // Parse optional separator.
-        let Parsed { input, .. } = self
+        let Parsed { input, .. } = rtry!(self
             .parse_date_separator(input, extended)
-            .context(E::FailedSeparatorAfterMonth)?;
+            .context(E::FailedSeparatorAfterMonth));
 
         // Parse day component.
         let Parsed { value: day, input } =
-            self.parse_day(input).context(E::FailedDayInDate)?;
+            rtry!(self.parse_day(input).context(E::FailedDayInDate));
 
-        let date = Date::new(year, month, day).context(E::InvalidDate)?;
+        let date = rtry!(Date::new(year, month, day).context(E::InvalidDate));
         let value = ParsedDate { date };
         Ok(Parsed { value, input })
     }
@@ -569,7 +575,7 @@ impl DateTimeParser {
     ) -> Result<Parsed<'i, ParsedTime>, Error> {
         // Parse hour component.
         let Parsed { value: hour, input } =
-            self.parse_hour(input).context(E::FailedHourInTime)?;
+            rtry!(self.parse_hour(input).context(E::FailedHourInTime));
         let extended = input.starts_with(b":");
 
         // Parse optional minute component.
@@ -583,7 +589,7 @@ impl DateTimeParser {
             return Ok(Parsed { value, input });
         }
         let Parsed { value: minute, input } =
-            self.parse_minute(input).context(E::FailedMinuteInTime)?;
+            rtry!(self.parse_minute(input).context(E::FailedMinuteInTime));
 
         // Parse optional second component.
         let Parsed { value: has_second, input } =
@@ -597,12 +603,12 @@ impl DateTimeParser {
             return Ok(Parsed { value, input });
         }
         let Parsed { value: second, input } =
-            self.parse_second(input).context(E::FailedSecondInTime)?;
+            rtry!(self.parse_second(input).context(E::FailedSecondInTime));
 
         // Parse an optional fractional component.
         let Parsed { value: nanosecond, input } =
-            parse_temporal_fraction(input)
-                .context(E::FailedFractionalSecondInTime)?;
+            rtry!(parse_temporal_fraction(input)
+                .context(E::FailedFractionalSecondInTime));
 
         // OK because we know that all our components are in bounds and all
         // combinations of in-bounds components are valid `Time` values.
@@ -638,7 +644,7 @@ impl DateTimeParser {
     ) -> Result<Parsed<'i, ()>, Error> {
         // Parse month component.
         let Parsed { value: month, mut input } =
-            self.parse_month(input).context(E::FailedMonthInMonthDay)?;
+            rtry!(self.parse_month(input).context(E::FailedMonthInMonthDay));
 
         // Skip over optional separator.
         if let Some(tail) = input.strip_prefix(b"-") {
@@ -647,13 +653,13 @@ impl DateTimeParser {
 
         // Parse day component.
         let Parsed { value: day, input } =
-            self.parse_day(input).context(E::FailedDayInMonthDay)?;
+            rtry!(self.parse_day(input).context(E::FailedDayInMonthDay));
 
         // Check that the month-day is valid. Since Temporal's month-day
         // permits 02-29, we use a leap year. The error message here is
         // probably confusing, but these errors should never be exposed to the
         // user.
-        let _ = Date::new(2024, month, day).context(E::InvalidMonthDay)?;
+        let _ = rtry!(Date::new(2024, month, day).context(E::InvalidMonthDay));
 
         // We have a valid year-month. But we don't return it because we just
         // need to check validity.
@@ -672,7 +678,7 @@ impl DateTimeParser {
     ) -> Result<Parsed<'i, ()>, Error> {
         // Parse year component.
         let Parsed { value: year, mut input } =
-            self.parse_year(input).context(E::FailedYearInYearMonth)?;
+            rtry!(self.parse_year(input).context(E::FailedYearInYearMonth));
 
         // Skip over optional separator.
         if let Some(tail) = input.strip_prefix(b"-") {
@@ -681,11 +687,11 @@ impl DateTimeParser {
 
         // Parse month component.
         let Parsed { value: month, input } =
-            self.parse_month(input).context(E::FailedMonthInYearMonth)?;
+            rtry!(self.parse_month(input).context(E::FailedMonthInYearMonth));
 
         // Check that the year-month is valid. We just use a day of 1, since
         // every month in every year must have a day 1.
-        let _ = Date::new(year, month, 1).context(E::InvalidYearMonth)?;
+        let _ = rtry!(Date::new(year, month, 1).context(E::InvalidYearMonth));
 
         // We have a valid year-month. But we don't return it because we just
         // need to check validity.
@@ -714,7 +720,7 @@ impl DateTimeParser {
 
         let (year, input) =
             parse::split(input, 4).ok_or(E::ExpectedFourDigitYear)?;
-        let year = b::Year::parse(year).context(E::ParseYearFourDigit)?;
+        let year = rtry!(b::Year::parse(year).context(E::ParseYearFourDigit));
         Ok(Parsed { value: year, input })
     }
 
@@ -727,7 +733,7 @@ impl DateTimeParser {
     ) -> Result<Parsed<'i, i16>, Error> {
         let (year, input) =
             parse::split(input, 6).ok_or(E::ExpectedSixDigitYear)?;
-        let year = b::Year::parse(year).context(E::ParseYearSixDigit)?;
+        let year = rtry!(b::Year::parse(year).context(E::ParseYearSixDigit));
         if year == 0 && sign.is_negative() {
             return Err(Error::from(E::InvalidYearZero));
         }
@@ -746,7 +752,8 @@ impl DateTimeParser {
     ) -> Result<Parsed<'i, i8>, Error> {
         let (month, input) =
             parse::split(input, 2).ok_or(E::ExpectedTwoDigitMonth)?;
-        let month = b::Month::parse(month).context(E::ParseMonthTwoDigit)?;
+        let month =
+            rtry!(b::Month::parse(month).context(E::ParseMonthTwoDigit));
         Ok(Parsed { value: month, input })
     }
 
@@ -760,7 +767,7 @@ impl DateTimeParser {
     fn parse_day<'i>(&self, input: &'i [u8]) -> Result<Parsed<'i, i8>, Error> {
         let (day, input) =
             parse::split(input, 2).ok_or(E::ExpectedTwoDigitDay)?;
-        let day = b::Day::parse(day).context(E::ParseDayTwoDigit)?;
+        let day = rtry!(b::Day::parse(day).context(E::ParseDayTwoDigit));
         Ok(Parsed { value: day, input })
     }
 
@@ -781,7 +788,7 @@ impl DateTimeParser {
     ) -> Result<Parsed<'i, i8>, Error> {
         let (hour, input) =
             parse::split(input, 2).ok_or(E::ExpectedTwoDigitHour)?;
-        let hour = b::Hour::parse(hour).context(E::ParseHourTwoDigit)?;
+        let hour = rtry!(b::Hour::parse(hour).context(E::ParseHourTwoDigit));
         Ok(Parsed { value: hour, input })
     }
 
@@ -803,7 +810,7 @@ impl DateTimeParser {
         let (minute, input) =
             parse::split(input, 2).ok_or(E::ExpectedTwoDigitMinute)?;
         let minute =
-            b::Minute::parse(minute).context(E::ParseMinuteTwoDigit)?;
+            rtry!(b::Minute::parse(minute).context(E::ParseMinuteTwoDigit));
         Ok(Parsed { value: minute, input })
     }
 
@@ -825,8 +832,9 @@ impl DateTimeParser {
     ) -> Result<Parsed<'i, i8>, Error> {
         let (second, input) =
             parse::split(input, 2).ok_or(E::ExpectedTwoDigitSecond)?;
-        let mut second =
-            b::LeapSecond::parse(second).context(E::ParseSecondTwoDigit)?;
+        let mut second = rtry!(
+            b::LeapSecond::parse(second).context(E::ParseSecondTwoDigit)
+        );
         // NOTE: I believe Temporal allows one to make this configurable. That
         // is, to reject it. But for now, we just always clamp a leap second.
         if second == 60 {
@@ -974,7 +982,8 @@ impl DateTimeParser {
         let (week_num, input) =
             parse::split(input, 2).ok_or(E::ExpectedTwoDigitWeekNumber)?;
         let week_num =
-            b::ISOWeek::parse(week_num).context(E::ParseWeekNumberTwoDigit)?;
+            rtry!(b::ISOWeek::parse(week_num)
+                .context(E::ParseWeekNumberTwoDigit));
         Ok(Parsed { value: week_num, input })
     }
 
@@ -987,8 +996,8 @@ impl DateTimeParser {
     ) -> Result<Parsed<'i, Weekday>, Error> {
         let (weekday, input) =
             parse::split(input, 1).ok_or(E::ExpectedOneDigitWeekday)?;
-        let weekday = b::WeekdayMondayOne::parse(weekday)
-            .context(E::ParseWeekdayOneDigit)?;
+        let weekday = rtry!(b::WeekdayMondayOne::parse(weekday)
+            .context(E::ParseWeekdayOneDigit));
         // OK because we know `weekday` is in bounds from above.
         let weekday = Weekday::from_monday_one_offset(weekday).unwrap();
         Ok(Parsed { value: weekday, input })
@@ -1018,8 +1027,8 @@ impl SpanParser {
         #[inline(never)]
         fn imp(p: &SpanParser, input: &[u8]) -> Result<Span, Error> {
             let mut builder = DurationUnits::default();
-            let parsed = p.parse_calendar_and_time(input, &mut builder)?;
-            let parsed = parsed.and_then(|_| builder.to_span())?;
+            let parsed = rtry!(p.parse_calendar_and_time(input, &mut builder));
+            let parsed = rtry!(parsed.and_then(|_| builder.to_span()));
             parsed.into_full()
         }
         imp(self, input.as_ref())
@@ -1033,8 +1042,9 @@ impl SpanParser {
         #[inline(never)]
         fn imp(p: &SpanParser, input: &[u8]) -> Result<SignedDuration, Error> {
             let mut builder = DurationUnits::default();
-            let parsed = p.parse_time_only(input, &mut builder)?;
-            let parsed = parsed.and_then(|_| builder.to_signed_duration())?;
+            let parsed = rtry!(p.parse_time_only(input, &mut builder));
+            let parsed =
+                rtry!(parsed.and_then(|_| builder.to_signed_duration()));
             parsed.into_full()
         }
         imp(self, input.as_ref())
@@ -1051,9 +1061,9 @@ impl SpanParser {
             input: &[u8],
         ) -> Result<core::time::Duration, Error> {
             let mut builder = DurationUnits::default();
-            let parsed = p.parse_time_only(input, &mut builder)?;
+            let parsed = rtry!(p.parse_time_only(input, &mut builder));
             let parsed =
-                parsed.and_then(|_| builder.to_unsigned_duration())?;
+                rtry!(parsed.and_then(|_| builder.to_unsigned_duration()));
             let d = parsed.value;
             parsed.into_full_with(format_args!("{d:?}"))
         }
@@ -1074,12 +1084,14 @@ impl SpanParser {
                 (sign, input)
             };
 
-        let Parsed { input, .. } = self.parse_duration_designator(input)?;
-        let Parsed { input, .. } = self.parse_date_units(input, builder)?;
+        let Parsed { input, .. } =
+            rtry!(self.parse_duration_designator(input));
+        let Parsed { input, .. } =
+            rtry!(self.parse_date_units(input, builder));
         let Parsed { value: has_time, mut input } =
             self.parse_time_designator(input);
         if has_time {
-            let parsed = self.parse_time_units(input, builder)?;
+            let parsed = rtry!(self.parse_time_units(input, builder));
             input = parsed.input;
 
             if builder.get_min().map_or(true, |min| min > Unit::Hour) {
@@ -1104,14 +1116,16 @@ impl SpanParser {
                 (sign, input)
             };
 
-        let Parsed { input, .. } = self.parse_duration_designator(input)?;
+        let Parsed { input, .. } =
+            rtry!(self.parse_duration_designator(input));
         let Parsed { value: has_time, input } =
             self.parse_time_designator(input);
         if !has_time {
             return Err(Error::from(E::ExpectedTimeDesignator));
         }
 
-        let Parsed { input, .. } = self.parse_time_units(input, builder)?;
+        let Parsed { input, .. } =
+            rtry!(self.parse_time_units(input, builder));
         if builder.get_min().map_or(true, |min| min > Unit::Hour) {
             return Err(Error::from(E::ExpectedTimeUnits));
         }
@@ -1128,15 +1142,15 @@ impl SpanParser {
         builder: &mut DurationUnits,
     ) -> Result<Parsed<'i, ()>, Error> {
         loop {
-            let parsed = self.parse_unit_value(input)?;
+            let parsed = rtry!(self.parse_unit_value(input));
             input = parsed.input;
             let Some(value) = parsed.value else { break };
 
-            let parsed = self.parse_unit_date_designator(input)?;
+            let parsed = rtry!(self.parse_unit_date_designator(input));
             input = parsed.input;
             let unit = parsed.value;
 
-            builder.set_unit_value(unit, value)?;
+            rtry!(builder.set_unit_value(unit, value));
         }
         Ok(Parsed { value: (), input })
     }
@@ -1150,21 +1164,21 @@ impl SpanParser {
         builder: &mut DurationUnits,
     ) -> Result<Parsed<'i, ()>, Error> {
         loop {
-            let parsed = self.parse_unit_value(input)?;
+            let parsed = rtry!(self.parse_unit_value(input));
             input = parsed.input;
             let Some(value) = parsed.value else { break };
 
-            let parsed = parse_temporal_fraction(input)?;
+            let parsed = rtry!(parse_temporal_fraction(input));
             input = parsed.input;
             let fraction = parsed.value;
 
-            let parsed = self.parse_unit_time_designator(input)?;
+            let parsed = rtry!(self.parse_unit_time_designator(input));
             input = parsed.input;
             let unit = parsed.value;
 
-            builder.set_unit_value(unit, value)?;
+            rtry!(builder.set_unit_value(unit, value));
             if let Some(fraction) = fraction {
-                builder.set_fraction(fraction)?;
+                rtry!(builder.set_fraction(fraction));
                 // Once we see a fraction, we are done. We don't permit parsing
                 // any more units. That is, a fraction can only occur on the
                 // lowest unit of time.

--- a/src/fmt/temporal/pieces.rs
+++ b/src/fmt/temporal/pieces.rs
@@ -1594,7 +1594,7 @@ impl<'n> TimeZoneAnnotation<'n> {
         // between offsets and time zones.
         let tz = match *self.kind() {
             TimeZoneAnnotationKind::Named(ref name) => {
-                db.get(name.as_str())?
+                rtry!(db.get(name.as_str()))
             }
             TimeZoneAnnotationKind::Offset(offset) => TimeZone::fixed(offset),
         };

--- a/src/fmt/temporal/printer.rs
+++ b/src/fmt/temporal/printer.rs
@@ -206,7 +206,7 @@ impl DateTimePrinter {
         let mut buf = ArrayBuffer::<REASONABLE_ZONED_LEN>::default();
         let mut bbuf = buf.as_borrowed();
         let mut wtr = BorrowedWriter::new(&mut bbuf, wtr);
-        self.print_zoned_wtr(zdt, &mut wtr)?;
+        rtry!(self.print_zoned_wtr(zdt, &mut wtr));
         wtr.finish()
     }
 
@@ -226,13 +226,17 @@ impl DateTimePrinter {
         zdt: &Zoned,
         wtr: &mut BorrowedWriter<'_, '_, '_>,
     ) -> Result<(), Error> {
-        self.print_datetime_wtr(&zdt.datetime(), wtr)?;
+        rtry!(self.print_datetime_wtr(&zdt.datetime(), wtr));
         let tz = zdt.time_zone();
         if tz.is_unknown() {
-            wtr.write_str("Z[Etc/Unknown]")?;
+            rtry!(wtr.write_str("Z[Etc/Unknown]"));
         } else {
-            self.print_offset_rounded_wtr(&zdt.offset(), wtr)?;
-            self.print_time_zone_annotation_wtr(&tz, &zdt.offset(), wtr)?;
+            rtry!(self.print_offset_rounded_wtr(&zdt.offset(), wtr));
+            rtry!(self.print_time_zone_annotation_wtr(
+                &tz,
+                &zdt.offset(),
+                wtr
+            ));
         }
         Ok(())
     }
@@ -332,13 +336,13 @@ impl DateTimePrinter {
         dt: &DateTime,
         wtr: &mut BorrowedWriter<'_, '_, '_>,
     ) -> Result<(), Error> {
-        self.print_date_wtr(&dt.date(), wtr)?;
-        wtr.write_ascii_char(if self.lowercase {
+        rtry!(self.print_date_wtr(&dt.date(), wtr));
+        rtry!(wtr.write_ascii_char(if self.lowercase {
             self.separator.to_ascii_lowercase()
         } else {
             self.separator
-        })?;
-        self.print_time_wtr(&dt.time(), wtr)?;
+        }));
+        rtry!(self.print_time_wtr(&dt.time(), wtr));
         Ok(())
     }
 
@@ -373,13 +377,13 @@ impl DateTimePrinter {
     ) -> Result<(), Error> {
         let year = date.year();
         if year < 0 {
-            wtr.write_str("-00")?;
+            rtry!(wtr.write_str("-00"));
         }
-        wtr.write_int_pad4(year.unsigned_abs())?;
-        wtr.write_ascii_char(b'-')?;
-        wtr.write_int_pad2(date.month().unsigned_abs())?;
-        wtr.write_ascii_char(b'-')?;
-        wtr.write_int_pad2(date.day().unsigned_abs())?;
+        rtry!(wtr.write_int_pad4(year.unsigned_abs()));
+        rtry!(wtr.write_ascii_char(b'-'));
+        rtry!(wtr.write_int_pad2(date.month().unsigned_abs()));
+        rtry!(wtr.write_ascii_char(b'-'));
+        rtry!(wtr.write_int_pad2(date.day().unsigned_abs()));
         Ok(())
     }
 
@@ -421,18 +425,18 @@ impl DateTimePrinter {
         time: &Time,
         wtr: &mut BorrowedWriter<'_, '_, '_>,
     ) -> Result<(), Error> {
-        wtr.write_int_pad2(time.hour().unsigned_abs())?;
-        wtr.write_ascii_char(b':')?;
-        wtr.write_int_pad2(time.minute().unsigned_abs())?;
-        wtr.write_ascii_char(b':')?;
-        wtr.write_int_pad2(time.second().unsigned_abs())?;
+        rtry!(wtr.write_int_pad2(time.hour().unsigned_abs()));
+        rtry!(wtr.write_ascii_char(b':'));
+        rtry!(wtr.write_int_pad2(time.minute().unsigned_abs()));
+        rtry!(wtr.write_ascii_char(b':'));
+        rtry!(wtr.write_int_pad2(time.second().unsigned_abs()));
         let fractional_nanosecond = time.subsec_nanosecond();
         if self.precision.map_or(fractional_nanosecond != 0, |p| p > 0) {
-            wtr.write_ascii_char(b'.')?;
-            wtr.write_fraction(
+            rtry!(wtr.write_ascii_char(b'.'));
+            rtry!(wtr.write_fraction(
                 self.precision,
                 fractional_nanosecond.unsigned_abs(),
-            )?;
+            ));
         }
         Ok(())
     }
@@ -512,7 +516,7 @@ impl DateTimePrinter {
         let mut buf = ArrayBuffer::<REASONABLE_PIECES_LEN>::default();
         let mut bbuf = buf.as_borrowed();
         let mut wtr = BorrowedWriter::new(&mut bbuf, &mut wtr);
-        self.print_pieces_wtr(pieces, &mut wtr)?;
+        rtry!(self.print_pieces_wtr(pieces, &mut wtr));
         wtr.finish()
     }
 
@@ -523,41 +527,41 @@ impl DateTimePrinter {
     ) -> Result<(), Error> {
         if let Some(time) = pieces.time() {
             let dt = DateTime::from_parts(pieces.date(), time);
-            self.print_datetime_wtr(&dt, wtr)?;
+            rtry!(self.print_datetime_wtr(&dt, wtr));
             if let Some(poffset) = pieces.offset() {
-                self.print_pieces_offset(&poffset, wtr)?;
+                rtry!(self.print_pieces_offset(&poffset, wtr));
             }
         } else if let Some(poffset) = pieces.offset() {
             // In this case, we have an offset but no time component. Since
             // `2025-01-02-05:00` isn't valid, we forcefully write out the
             // default time (which is what would be assumed anyway).
             let dt = DateTime::from_parts(pieces.date(), Time::midnight());
-            self.print_datetime_wtr(&dt, wtr)?;
-            self.print_pieces_offset(&poffset, wtr)?;
+            rtry!(self.print_datetime_wtr(&dt, wtr));
+            rtry!(self.print_pieces_offset(&poffset, wtr));
         } else {
             // We have no time and no offset, so we can just write the date.
             // It's okay to write this followed by an annotation, e.g.,
             // `2025-01-02[America/New_York]` or even `2025-01-02[-05:00]`.
-            self.print_date_wtr(&pieces.date(), wtr)?;
+            rtry!(self.print_date_wtr(&pieces.date(), wtr));
         }
         // For the time zone annotation, a `Pieces` gives us the annotation
         // name or offset directly, where as with `Zoned`, we have a
         // `TimeZone`. So we hand-roll our own formatter directly from the
         // annotation.
         if let Some(ann) = pieces.time_zone_annotation() {
-            wtr.write_ascii_char(b'[')?;
+            rtry!(wtr.write_ascii_char(b'['));
             if ann.is_critical() {
-                wtr.write_ascii_char(b'!')?;
+                rtry!(wtr.write_ascii_char(b'!'));
             }
             match *ann.kind() {
                 TimeZoneAnnotationKind::Named(ref name) => {
-                    wtr.write_str(name.as_str())?;
+                    rtry!(wtr.write_str(name.as_str()));
                 }
                 TimeZoneAnnotationKind::Offset(offset) => {
-                    self.print_offset_rounded_wtr(&offset, wtr)?;
+                    rtry!(self.print_offset_rounded_wtr(&offset, wtr));
                 }
             }
-            wtr.write_ascii_char(b']')?;
+            rtry!(wtr.write_ascii_char(b']'));
         }
         Ok(())
     }
@@ -635,11 +639,15 @@ impl DateTimePrinter {
         offset: &Offset,
         wtr: &mut BorrowedWriter<'_, '_, '_>,
     ) -> Result<(), Error> {
-        wtr.write_ascii_char(if offset.is_negative() { b'-' } else { b'+' })?;
+        rtry!(wtr.write_ascii_char(if offset.is_negative() {
+            b'-'
+        } else {
+            b'+'
+        }));
         let (offset_hours, offset_minutes) = offset.round_to_nearest_minute();
-        wtr.write_int_pad2(offset_hours)?;
-        wtr.write_ascii_char(b':')?;
-        wtr.write_int_pad2(offset_minutes)?;
+        rtry!(wtr.write_int_pad2(offset_hours));
+        rtry!(wtr.write_ascii_char(b':'));
+        rtry!(wtr.write_int_pad2(offset_minutes));
         Ok(())
     }
 
@@ -720,13 +728,13 @@ impl DateTimePrinter {
         offset: &Offset,
         wtr: &mut BorrowedWriter<'_, '_, '_>,
     ) -> Result<(), Error> {
-        wtr.write_ascii_char(b'[')?;
+        rtry!(wtr.write_ascii_char(b'['));
         if let Some(iana_name) = time_zone.iana_name() {
-            wtr.write_str(iana_name)?;
+            rtry!(wtr.write_str(iana_name));
         } else {
-            self.print_offset_rounded_wtr(offset, wtr)?;
+            rtry!(self.print_offset_rounded_wtr(offset, wtr));
         }
-        wtr.write_ascii_char(b']')?;
+        rtry!(wtr.write_ascii_char(b']'));
         Ok(())
     }
 }

--- a/src/fmt/util.rs
+++ b/src/fmt/util.rs
@@ -120,11 +120,11 @@ impl DurationUnits {
                 return Err(Error::from(E::OutOfOrderHMS { found: min }));
             }
         }
-        self.set_unit_value(Unit::Hour, hours)?;
-        self.set_unit_value(Unit::Minute, minutes)?;
-        self.set_unit_value(Unit::Second, seconds)?;
+        rtry!(self.set_unit_value(Unit::Hour, hours));
+        rtry!(self.set_unit_value(Unit::Minute, minutes));
+        rtry!(self.set_unit_value(Unit::Second, seconds));
         if let Some(fraction) = fraction {
-            self.set_fraction(fraction)?;
+            rtry!(self.set_fraction(fraction));
         }
         Ok(())
     }
@@ -283,73 +283,76 @@ impl DurationUnits {
                 .context(E::FailedValueSet { unit })
         }
 
-        let (min, _) = self.get_min_max_units()?;
+        let (min, _) = rtry!(self.get_min_max_units());
         let mut span = Span::new();
 
         if self.values[Unit::Year.as_usize()] != 0 {
-            let value = self.get_unit_value(Unit::Year)?;
-            span = span
+            let value = rtry!(self.get_unit_value(Unit::Year));
+            span = rtry!(span
                 .try_years(value)
-                .context(E::FailedValueSet { unit: Unit::Year })?;
+                .context(E::FailedValueSet { unit: Unit::Year }));
         }
         if self.values[Unit::Month.as_usize()] != 0 {
-            let value = self.get_unit_value(Unit::Month)?;
-            span = span
+            let value = rtry!(self.get_unit_value(Unit::Month));
+            span = rtry!(span
                 .try_months(value)
-                .context(E::FailedValueSet { unit: Unit::Month })?;
+                .context(E::FailedValueSet { unit: Unit::Month }));
         }
         if self.values[Unit::Week.as_usize()] != 0 {
-            let value = self.get_unit_value(Unit::Week)?;
-            span = span
+            let value = rtry!(self.get_unit_value(Unit::Week));
+            span = rtry!(span
                 .try_weeks(value)
-                .context(E::FailedValueSet { unit: Unit::Week })?;
+                .context(E::FailedValueSet { unit: Unit::Week }));
         }
         if self.values[Unit::Day.as_usize()] != 0 {
-            let value = self.get_unit_value(Unit::Day)?;
-            span = span
+            let value = rtry!(self.get_unit_value(Unit::Day));
+            span = rtry!(span
                 .try_days(value)
-                .context(E::FailedValueSet { unit: Unit::Day })?;
+                .context(E::FailedValueSet { unit: Unit::Day }));
         }
         if self.values[Unit::Hour.as_usize()] != 0 {
-            let value = self.get_unit_value(Unit::Hour)?;
-            span = set_time_unit(Unit::Hour, value, span, |span| {
+            let value = rtry!(self.get_unit_value(Unit::Hour));
+            span = rtry!(set_time_unit(Unit::Hour, value, span, |span| {
                 span.try_hours(value)
-            })?;
+            }));
         }
         if self.values[Unit::Minute.as_usize()] != 0 {
-            let value = self.get_unit_value(Unit::Minute)?;
-            span = set_time_unit(Unit::Minute, value, span, |span| {
+            let value = rtry!(self.get_unit_value(Unit::Minute));
+            span = rtry!(set_time_unit(Unit::Minute, value, span, |span| {
                 span.try_minutes(value)
-            })?;
+            }));
         }
         if self.values[Unit::Second.as_usize()] != 0 {
-            let value = self.get_unit_value(Unit::Second)?;
-            span = set_time_unit(Unit::Second, value, span, |span| {
+            let value = rtry!(self.get_unit_value(Unit::Second));
+            span = rtry!(set_time_unit(Unit::Second, value, span, |span| {
                 span.try_seconds(value)
-            })?;
+            }));
         }
         if self.values[Unit::Millisecond.as_usize()] != 0 {
-            let value = self.get_unit_value(Unit::Millisecond)?;
-            span = set_time_unit(Unit::Millisecond, value, span, |span| {
-                span.try_milliseconds(value)
-            })?;
+            let value = rtry!(self.get_unit_value(Unit::Millisecond));
+            span =
+                rtry!(set_time_unit(Unit::Millisecond, value, span, |span| {
+                    span.try_milliseconds(value)
+                }));
         }
         if self.values[Unit::Microsecond.as_usize()] != 0 {
-            let value = self.get_unit_value(Unit::Microsecond)?;
-            span = set_time_unit(Unit::Microsecond, value, span, |span| {
-                span.try_microseconds(value)
-            })?;
+            let value = rtry!(self.get_unit_value(Unit::Microsecond));
+            span =
+                rtry!(set_time_unit(Unit::Microsecond, value, span, |span| {
+                    span.try_microseconds(value)
+                }));
         }
         if self.values[Unit::Nanosecond.as_usize()] != 0 {
-            let value = self.get_unit_value(Unit::Nanosecond)?;
-            span = set_time_unit(Unit::Nanosecond, value, span, |span| {
-                span.try_nanoseconds(value)
-            })?;
+            let value = rtry!(self.get_unit_value(Unit::Nanosecond));
+            span =
+                rtry!(set_time_unit(Unit::Nanosecond, value, span, |span| {
+                    span.try_nanoseconds(value)
+                }));
         }
 
-        if let Some(fraction) = self.get_fraction()? {
-            let value = self.get_unit_value(min)?;
-            span = fractional_time_to_span(min, value, fraction, span)?;
+        if let Some(fraction) = rtry!(self.get_fraction()) {
+            let value = rtry!(self.get_unit_value(min));
+            span = rtry!(fractional_time_to_span(min, value, fraction, span));
         }
 
         Ok(span)
@@ -418,50 +421,50 @@ impl DurationUnits {
     #[cold]
     #[inline(never)]
     fn to_signed_duration_general(&self) -> Result<SignedDuration, Error> {
-        let (min, max) = self.get_min_max_units()?;
+        let (min, max) = rtry!(self.get_min_max_units());
         if max > Unit::Hour {
             return Err(Error::from(E::NotAllowedCalendarUnit { unit: max }));
         }
 
         let mut sdur = SignedDuration::ZERO;
         if self.values[Unit::Hour.as_usize()] != 0 {
-            let value = self.get_unit_value(Unit::Hour)?;
+            let value = rtry!(self.get_unit_value(Unit::Hour));
             sdur = SignedDuration::try_from_hours(value)
                 .and_then(|nanos| sdur.checked_add(nanos))
                 .ok_or(E::OverflowForUnit { unit: Unit::Hour })?;
         }
         if self.values[Unit::Minute.as_usize()] != 0 {
-            let value = self.get_unit_value(Unit::Minute)?;
+            let value = rtry!(self.get_unit_value(Unit::Minute));
             sdur = SignedDuration::try_from_mins(value)
                 .and_then(|nanos| sdur.checked_add(nanos))
                 .ok_or(E::OverflowForUnit { unit: Unit::Minute })?;
         }
         if self.values[Unit::Second.as_usize()] != 0 {
-            let value = self.get_unit_value(Unit::Second)?;
+            let value = rtry!(self.get_unit_value(Unit::Second));
             sdur = SignedDuration::from_secs(value)
                 .checked_add(sdur)
                 .ok_or(E::OverflowForUnit { unit: Unit::Second })?;
         }
         if self.values[Unit::Millisecond.as_usize()] != 0 {
-            let value = self.get_unit_value(Unit::Millisecond)?;
+            let value = rtry!(self.get_unit_value(Unit::Millisecond));
             sdur = SignedDuration::from_millis(value)
                 .checked_add(sdur)
                 .ok_or(E::OverflowForUnit { unit: Unit::Millisecond })?;
         }
         if self.values[Unit::Microsecond.as_usize()] != 0 {
-            let value = self.get_unit_value(Unit::Microsecond)?;
+            let value = rtry!(self.get_unit_value(Unit::Microsecond));
             sdur = SignedDuration::from_micros(value)
                 .checked_add(sdur)
                 .ok_or(E::OverflowForUnit { unit: Unit::Microsecond })?;
         }
         if self.values[Unit::Nanosecond.as_usize()] != 0 {
-            let value = self.get_unit_value(Unit::Nanosecond)?;
+            let value = rtry!(self.get_unit_value(Unit::Nanosecond));
             sdur = SignedDuration::from_nanos(value)
                 .checked_add(sdur)
                 .ok_or(E::OverflowForUnit { unit: Unit::Nanosecond })?;
         }
 
-        if let Some(fraction) = self.get_fraction()? {
+        if let Some(fraction) = rtry!(self.get_fraction()) {
             sdur = sdur
                 .checked_add(fractional_duration(min, fraction)?)
                 .ok_or(E::OverflowForUnitFractional { unit: min })?;
@@ -558,7 +561,7 @@ impl DurationUnits {
             return Err(Error::from(E::NotAllowedNegative));
         }
 
-        let (min, max) = self.get_min_max_units()?;
+        let (min, max) = rtry!(self.get_min_max_units());
         if max > Unit::Hour {
             return Err(Error::from(E::NotAllowedCalendarUnit { unit: max }));
         }
@@ -601,7 +604,7 @@ impl DurationUnits {
                 .ok_or(E::OverflowForUnit { unit: Unit::Nanosecond })?;
         }
 
-        if let Some(fraction) = self.get_fraction()? {
+        if let Some(fraction) = rtry!(self.get_fraction()) {
             sdur = sdur
                 .checked_add(
                     fractional_duration(min, fraction)?.unsigned_abs(),
@@ -758,7 +761,7 @@ pub(crate) fn parse_temporal_fraction<'i>(
         // than 9 ASCII digits. Any sequence of 9 ASCII digits can be parsed
         // into an `i64`.
         let nanoseconds =
-            parse::fraction(digits).context(E::InvalidFraction)?;
+            rtry!(parse::fraction(digits).context(E::InvalidFraction));
         // OK because parsing is forcefully limited to 9 digits,
         // which can never be greater than `999_999_99`,
         // which is less than `u32::MAX`.
@@ -824,7 +827,7 @@ fn fractional_time_to_span(
     // out anything over the limit and carry it over to the lesser units. If
     // our value is truly too big, then the final call to set nanoseconds will
     // fail.
-    let mut sdur = fractional_time_to_duration(unit, value, fraction)?;
+    let mut sdur = rtry!(fractional_time_to_duration(unit, value, fraction));
 
     if unit >= Unit::Hour && !sdur.is_zero() {
         let (mut hours, rem) = sdur.as_hours_with_remainder();
@@ -895,8 +898,9 @@ fn fractional_time_to_span(
         let nanos = sdur.as_nanos();
         let nanos64 =
             i64::try_from(nanos).map_err(|_| E::InvalidFractionNanos)?;
-        span =
-            span.try_nanoseconds(nanos64).context(E::InvalidFractionNanos)?;
+        span = rtry!(span
+            .try_nanoseconds(nanos64)
+            .context(E::InvalidFractionNanos));
     }
 
     Ok(span)
@@ -924,8 +928,8 @@ fn fractional_time_to_duration(
     value: i64,
     fraction: i32,
 ) -> Result<SignedDuration, Error> {
-    let sdur = duration_unit_value(unit, value)?;
-    let fraction_dur = fractional_duration(unit, fraction)?;
+    let sdur = rtry!(duration_unit_value(unit, value));
+    let fraction_dur = rtry!(fractional_duration(unit, fraction));
     Ok(sdur
         .checked_add(fraction_dur)
         .ok_or(E::OverflowForUnitFractional { unit })?)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -742,6 +742,9 @@ For more, see the [`fmt::serde`] sub-module. (This requires enabling Jiff's
 #[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
 compile_error!("jiff currently not supported on non-{32,64}");
 
+#[macro_use]
+mod logging;
+
 #[cfg(any(test, feature = "std"))]
 extern crate std;
 
@@ -765,9 +768,6 @@ pub use crate::{
         ZonedWith,
     },
 };
-
-#[macro_use]
-mod logging;
 
 pub mod civil;
 mod duration;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -2,6 +2,17 @@
 // Which is fine. Just squash the warnings.
 #![allow(dead_code, unused_macros)]
 
+// Simplified try operator that by passes Try and From traits, used to reduce
+// compile times. (3-4% on debug builds).
+macro_rules! rtry {
+    ($($tt:tt)*) => {
+        match $($tt)* {
+            Ok(ok) => ok,
+            Err(err) => return Err(err),
+        }
+    };
+}
+
 macro_rules! log {
     ($($tt:tt)*) => {
         #[cfg(feature = "logging")]
@@ -90,7 +101,7 @@ impl Logger {
     pub(crate) fn init() -> Result<(), log::SetLoggerError> {
         #[cfg(all(feature = "std", feature = "logging"))]
         {
-            log::set_logger(LOGGER)?;
+            rtry!(log::set_logger(LOGGER));
             log::set_max_level(log::LevelFilter::Trace);
             Ok(())
         }

--- a/src/shared/posix.rs
+++ b/src/shared/posix.rs
@@ -343,13 +343,13 @@ impl<ABBREV: AsRef<str> + Debug> PosixTimeZone<ABBREV> {
 
 impl<ABBREV: AsRef<str>> core::fmt::Display for PosixTimeZone<ABBREV> {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        core::fmt::Display::fmt(
+        rtry!(core::fmt::Display::fmt(
             &AbbreviationDisplay(self.std_abbrev.as_ref()),
             f,
-        )?;
-        core::fmt::Display::fmt(&self.std_offset, f)?;
+        ));
+        rtry!(core::fmt::Display::fmt(&self.std_offset, f));
         if let Some(ref dst) = self.dst {
-            dst.display(&self.std_offset, f)?;
+            rtry!(dst.display(&self.std_offset, f));
         }
         Ok(())
     }
@@ -361,28 +361,28 @@ impl<ABBREV: AsRef<str>> PosixDst<ABBREV> {
         std_offset: &PosixOffset,
         f: &mut core::fmt::Formatter,
     ) -> core::fmt::Result {
-        core::fmt::Display::fmt(
+        rtry!(core::fmt::Display::fmt(
             &AbbreviationDisplay(self.abbrev.as_ref()),
             f,
-        )?;
+        ));
         // The overwhelming common case is that DST is exactly one hour ahead
         // of standard time. So common that this is the default. So don't write
         // the offset if we don't need to.
         let default = PosixOffset { second: std_offset.second + 3600 };
         if self.offset != default {
-            core::fmt::Display::fmt(&self.offset, f)?;
+            rtry!(core::fmt::Display::fmt(&self.offset, f));
         }
-        f.write_str(",")?;
-        core::fmt::Display::fmt(&self.rule, f)?;
+        rtry!(f.write_str(","));
+        rtry!(core::fmt::Display::fmt(&self.rule, f));
         Ok(())
     }
 }
 
 impl core::fmt::Display for PosixRule {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        core::fmt::Display::fmt(&self.start, f)?;
-        f.write_str(",")?;
-        core::fmt::Display::fmt(&self.end, f)?;
+        rtry!(core::fmt::Display::fmt(&self.start, f));
+        rtry!(f.write_str(","));
+        rtry!(core::fmt::Display::fmt(&self.end, f));
         Ok(())
     }
 }
@@ -434,12 +434,12 @@ impl PosixDayTime {
 
 impl core::fmt::Display for PosixDayTime {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        core::fmt::Display::fmt(&self.date, f)?;
+        rtry!(core::fmt::Display::fmt(&self.date, f));
         // This is the default time, so don't write it if we
         // don't need to.
         if self.time != PosixTime::DEFAULT {
-            f.write_str("/")?;
-            core::fmt::Display::fmt(&self.time, f)?;
+            rtry!(f.write_str("/"));
+            rtry!(core::fmt::Display::fmt(&self.time, f));
         }
         Ok(())
     }
@@ -508,17 +508,17 @@ impl core::fmt::Display for PosixDay {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match *self {
             PosixDay::JulianOne(n) => {
-                f.write_str("J")?;
+                rtry!(f.write_str("J"));
                 core::fmt::Display::fmt(&n, f)
             }
             PosixDay::JulianZero(n) => core::fmt::Display::fmt(&n, f),
             PosixDay::WeekdayOfMonth { month, week, weekday } => {
-                f.write_str("M")?;
-                core::fmt::Display::fmt(&month, f)?;
-                f.write_str(".")?;
-                core::fmt::Display::fmt(&week, f)?;
-                f.write_str(".")?;
-                core::fmt::Display::fmt(&weekday, f)?;
+                rtry!(f.write_str("M"));
+                rtry!(core::fmt::Display::fmt(&month, f));
+                rtry!(f.write_str("."));
+                rtry!(core::fmt::Display::fmt(&week, f));
+                rtry!(f.write_str("."));
+                rtry!(core::fmt::Display::fmt(&weekday, f));
                 Ok(())
             }
         }
@@ -532,7 +532,7 @@ impl PosixTime {
 impl core::fmt::Display for PosixTime {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         if self.second.is_negative() {
-            f.write_str("-")?;
+            rtry!(f.write_str("-"));
             // The default is positive, so when
             // positive, we write nothing.
         }
@@ -540,11 +540,11 @@ impl core::fmt::Display for PosixTime {
         let h = second / 3600;
         let m = (second / 60) % 60;
         let s = second % 60;
-        core::fmt::Display::fmt(&h, f)?;
+        rtry!(core::fmt::Display::fmt(&h, f));
         if m != 0 || s != 0 {
-            write!(f, ":{m:02}")?;
+            rtry!(write!(f, ":{m:02}"));
             if s != 0 {
-                write!(f, ":{s:02}")?;
+                rtry!(write!(f, ":{s:02}"));
             }
         }
         Ok(())
@@ -563,17 +563,17 @@ impl core::fmt::Display for PosixOffset {
         // N.B. `+` is the default, so we don't
         // need to write that out.
         if self.second > 0 {
-            f.write_str("-")?;
+            rtry!(f.write_str("-"));
         }
         let second = self.second.unsigned_abs();
         let h = second / 3600;
         let m = (second / 60) % 60;
         let s = second % 60;
-        core::fmt::Display::fmt(&h, f)?;
+        rtry!(core::fmt::Display::fmt(&h, f));
         if m != 0 || s != 0 {
-            write!(f, ":{m:02}")?;
+            rtry!(write!(f, ":{m:02}"));
             if s != 0 {
-                write!(f, ":{s:02}")?;
+                rtry!(write!(f, ":{s:02}"));
             }
         }
         Ok(())
@@ -591,8 +591,8 @@ impl<S: AsRef<str>> core::fmt::Display for AbbreviationDisplay<S> {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         let s = self.0.as_ref();
         if s.chars().any(|ch| ch == '+' || ch == '-') {
-            f.write_str("<")?;
-            core::fmt::Display::fmt(&s, f)?;
+            rtry!(f.write_str("<"));
+            rtry!(core::fmt::Display::fmt(&s, f));
             f.write_str(">")
         } else {
             core::fmt::Display::fmt(&s, f)
@@ -692,7 +692,7 @@ impl<'s> Parser<'s> {
     fn parse(
         &self,
     ) -> Result<PosixTimeZone<Abbreviation>, PosixTimeZoneError> {
-        let (time_zone, remaining) = self.parse_prefix()?;
+        let (time_zone, remaining) = rtry!(self.parse_prefix());
         if !remaining.is_empty() {
             return Err(ErrorKind::FoundRemaining.into());
         }
@@ -705,7 +705,7 @@ impl<'s> Parser<'s> {
         &self,
     ) -> Result<(PosixTimeZone<Abbreviation>, &'s [u8]), PosixTimeZoneError>
     {
-        let time_zone = self.parse_posix_time_zone()?;
+        let time_zone = rtry!(self.parse_posix_time_zone());
         Ok((time_zone, self.remaining()))
     }
 
@@ -727,7 +727,7 @@ impl<'s> Parser<'s> {
         if !self.is_done()
             && (self.byte().is_ascii_alphabetic() || self.byte() == b'<')
         {
-            dst = Some(self.parse_posix_dst(&std_offset)?);
+            dst = Some(rtry!(self.parse_posix_dst(&std_offset)));
         }
         Ok(PosixTimeZone { std_abbrev, std_offset, dst })
     }
@@ -823,8 +823,8 @@ impl<'s> Parser<'s> {
             }
         }
         let end = self.pos();
-        let abbrev =
-            core::str::from_utf8(&self.tz[start..end]).map_err(|_| {
+        let abbrev = rtry!(core::str::from_utf8(&self.tz[start..end])
+            .map_err(|_| {
                 // NOTE: I believe this error is technically impossible
                 // since the loop above restricts letters in an
                 // abbreviation to ASCII. So everything from `start` to
@@ -832,7 +832,7 @@ impl<'s> Parser<'s> {
                 // cost us anything to report an error here in case the
                 // code above evolves somehow.
                 UnquotedAbbreviationError::InvalidUtf8
-            })?;
+            }));
         if abbrev.len() < 3 {
             return Err(UnquotedAbbreviationError::TooShort);
         }
@@ -871,8 +871,8 @@ impl<'s> Parser<'s> {
             }
         }
         let end = self.pos();
-        let abbrev =
-            core::str::from_utf8(&self.tz[start..end]).map_err(|_| {
+        let abbrev = rtry!(core::str::from_utf8(&self.tz[start..end])
+            .map_err(|_| {
                 // NOTE: I believe this error is technically impossible
                 // since the loop above restricts letters in an
                 // abbreviation to ASCII. So everything from `start` to
@@ -880,7 +880,7 @@ impl<'s> Parser<'s> {
                 // cost us anything to report an error here in case the
                 // code above evolves somehow.
                 QuotedAbbreviationError::InvalidUtf8
-            })?;
+            }));
         if self.is_done() {
             return Err(QuotedAbbreviationError::UnexpectedEnd);
         }
@@ -947,15 +947,15 @@ impl<'s> Parser<'s> {
     /// DST transition rule. In typical cases, this corresponds to the end
     /// of the TZ string.
     fn parse_rule(&self) -> Result<PosixRule, PosixRuleError> {
-        let start = self
+        let start = rtry!(self
             .parse_posix_datetime()
-            .map_err(PosixRuleError::DateTimeStart)?;
+            .map_err(PosixRuleError::DateTimeStart));
         if self.maybe_byte() != Some(b',') || !self.bump() {
             return Err(PosixRuleError::ExpectedEnd);
         }
-        let end = self
+        let end = rtry!(self
             .parse_posix_datetime()
-            .map_err(PosixRuleError::DateTimeEnd)?;
+            .map_err(PosixRuleError::DateTimeEnd));
         Ok(PosixRule { start, end })
     }
 
@@ -1028,11 +1028,12 @@ impl<'s> Parser<'s> {
     fn parse_posix_julian_day_no_leap(
         &self,
     ) -> Result<i16, PosixJulianNoLeapError> {
-        let number = self
+        let number = rtry!(self
             .parse_number_with_upto_n_digits(3)
-            .map_err(PosixJulianNoLeapError::Parse)?;
-        let number = i16::try_from(number)
-            .map_err(|_| PosixJulianNoLeapError::Range)?;
+            .map_err(PosixJulianNoLeapError::Parse));
+        let number =
+            rtry!(i16::try_from(number)
+                .map_err(|_| PosixJulianNoLeapError::Range));
         if !(1 <= number && number <= 365) {
             return Err(PosixJulianNoLeapError::Range);
         }
@@ -1048,11 +1049,12 @@ impl<'s> Parser<'s> {
     fn parse_posix_julian_day_with_leap(
         &self,
     ) -> Result<i16, PosixJulianLeapError> {
-        let number = self
+        let number = rtry!(self
             .parse_number_with_upto_n_digits(3)
-            .map_err(PosixJulianLeapError::Parse)?;
-        let number =
-            i16::try_from(number).map_err(|_| PosixJulianLeapError::Range)?;
+            .map_err(PosixJulianLeapError::Parse));
+        let number = rtry!(
+            i16::try_from(number).map_err(|_| PosixJulianLeapError::Range)
+        );
         if !(0 <= number && number <= 365) {
             return Err(PosixJulianLeapError::Range);
         }
@@ -1137,10 +1139,11 @@ impl<'s> Parser<'s> {
     /// the parser will be positioned after the month (which may contain
     /// two digits).
     fn parse_month(&self) -> Result<i8, MonthError> {
-        let number = self
+        let number = rtry!(self
             .parse_number_with_upto_n_digits(2)
-            .map_err(MonthError::Parse)?;
-        let number = i8::try_from(number).map_err(|_| MonthError::Range)?;
+            .map_err(MonthError::Parse));
+        let number =
+            rtry!(i8::try_from(number).map_err(|_| MonthError::Range));
         if !(1 <= number && number <= 12) {
             return Err(MonthError::Range);
         }
@@ -1152,11 +1155,11 @@ impl<'s> Parser<'s> {
     /// This is expected to be positioned at the first digit. Upon success,
     /// the parser will be positioned after the week digit.
     fn parse_week(&self) -> Result<i8, WeekOfMonthError> {
-        let number = self
+        let number = rtry!(self
             .parse_number_with_exactly_n_digits(1)
-            .map_err(WeekOfMonthError::Parse)?;
+            .map_err(WeekOfMonthError::Parse));
         let number =
-            i8::try_from(number).map_err(|_| WeekOfMonthError::Range)?;
+            rtry!(i8::try_from(number).map_err(|_| WeekOfMonthError::Range));
         if !(1 <= number && number <= 5) {
             return Err(WeekOfMonthError::Range);
         }
@@ -1171,10 +1174,11 @@ impl<'s> Parser<'s> {
     /// The weekday returned is guaranteed to be in the range `0..=6`, with
     /// `0` corresponding to Sunday.
     fn parse_weekday(&self) -> Result<i8, WeekdayError> {
-        let number = self
+        let number = rtry!(self
             .parse_number_with_exactly_n_digits(1)
-            .map_err(WeekdayError::Parse)?;
-        let number = i8::try_from(number).map_err(|_| WeekdayError::Range)?;
+            .map_err(WeekdayError::Parse));
+        let number =
+            rtry!(i8::try_from(number).map_err(|_| WeekdayError::Range));
         if !(0 <= number && number <= 6) {
             return Err(WeekdayError::Range);
         }
@@ -1196,11 +1200,11 @@ impl<'s> Parser<'s> {
         // Callers should only be using this method when IANA v3+ parsing
         // is enabled.
         assert!(self.ianav3plus);
-        let number = self
+        let number = rtry!(self
             .parse_number_with_upto_n_digits(3)
-            .map_err(HourIanaError::Parse)?;
+            .map_err(HourIanaError::Parse));
         let number =
-            i16::try_from(number).map_err(|_| HourIanaError::Range)?;
+            rtry!(i16::try_from(number).map_err(|_| HourIanaError::Range));
         if !(0 <= number && number <= 167) {
             // The error message says -167 but the check above uses 0.
             // This is because the caller is responsible for parsing
@@ -1220,11 +1224,11 @@ impl<'s> Parser<'s> {
     /// first hour digit should occur. Upon success, the parser will be
     /// positioned immediately after the last hour digit.
     fn parse_hour_posix(&self) -> Result<i8, HourPosixError> {
-        let number = self
+        let number = rtry!(self
             .parse_number_with_upto_n_digits(2)
-            .map_err(HourPosixError::Parse)?;
+            .map_err(HourPosixError::Parse));
         let number =
-            i8::try_from(number).map_err(|_| HourPosixError::Range)?;
+            rtry!(i8::try_from(number).map_err(|_| HourPosixError::Range));
         if !(0 <= number && number <= 24) {
             return Err(HourPosixError::Range);
         }
@@ -1239,10 +1243,11 @@ impl<'s> Parser<'s> {
     /// first minute digit should occur. Upon success, the parser will be
     /// positioned immediately after the second minute digit.
     fn parse_minute(&self) -> Result<i8, MinuteError> {
-        let number = self
+        let number = rtry!(self
             .parse_number_with_exactly_n_digits(2)
-            .map_err(MinuteError::Parse)?;
-        let number = i8::try_from(number).map_err(|_| MinuteError::Range)?;
+            .map_err(MinuteError::Parse));
+        let number =
+            rtry!(i8::try_from(number).map_err(|_| MinuteError::Range));
         if !(0 <= number && number <= 59) {
             return Err(MinuteError::Range);
         }
@@ -1257,10 +1262,11 @@ impl<'s> Parser<'s> {
     /// first second digit should occur. Upon success, the parser will be
     /// positioned immediately after the second second digit.
     fn parse_second(&self) -> Result<i8, SecondError> {
-        let number = self
+        let number = rtry!(self
             .parse_number_with_exactly_n_digits(2)
-            .map_err(SecondError::Parse)?;
-        let number = i8::try_from(number).map_err(|_| SecondError::Range)?;
+            .map_err(SecondError::Parse));
+        let number =
+            rtry!(i8::try_from(number).map_err(|_| SecondError::Range));
         if !(0 <= number && number <= 59) {
             return Err(SecondError::Range);
         }
@@ -1298,10 +1304,10 @@ impl<'s> Parser<'s> {
                     i32::from(digit)
                 }
             };
-            number = number
+            number = rtry!(number
                 .checked_mul(10)
                 .and_then(|n| n.checked_add(digit))
-                .ok_or(NumberError::TooBig)?;
+                .ok_or(NumberError::TooBig));
             self.bump();
         }
         Ok(number)
@@ -1327,10 +1333,10 @@ impl<'s> Parser<'s> {
                 break;
             }
             let digit = i32::from(self.byte() - b'0');
-            number = number
+            number = rtry!(number
                 .checked_mul(10)
                 .and_then(|n| n.checked_add(digit))
-                .ok_or(NumberError::TooBig)?;
+                .ok_or(NumberError::TooBig));
             self.bump();
         }
         Ok(number)
@@ -1439,13 +1445,13 @@ impl core::fmt::Display for PosixTimeZoneError {
         use self::ErrorKind::*;
         match self.kind {
             AbbreviationDst(ref err) => {
-                f.write_str("failed to parse DST time zone abbreviation: ")?;
+                rtry!(f.write_str("failed to parse DST time zone abbreviation: "));
                 core::fmt::Display::fmt(err, f)
             }
             AbbreviationStd(ref err) => {
-                f.write_str(
+                rtry!(f.write_str(
                     "failed to parse standard time zone abbreviation: ",
-                )?;
+                ));
                 core::fmt::Display::fmt(err, f)
             }
             Empty => f.write_str(
@@ -1478,11 +1484,11 @@ impl core::fmt::Display for PosixTimeZoneError {
                  parsing a valid time zone transition rule",
             ),
             OffsetDst(ref err) => {
-                f.write_str("failed to parse DST offset: ")?;
+                rtry!(f.write_str("failed to parse DST offset: "));
                 core::fmt::Display::fmt(err, f)
             }
             OffsetStd(ref err) => {
-                f.write_str("failed to parse standard offset: ")?;
+                rtry!(f.write_str("failed to parse standard offset: "));
                 core::fmt::Display::fmt(err, f)
             }
             Rule(ref err) => core::fmt::Display::fmt(err, f),
@@ -1522,10 +1528,10 @@ impl core::fmt::Display for PosixOffsetError {
             Minute(ref err) => core::fmt::Display::fmt(err, f),
             Second(ref err) => core::fmt::Display::fmt(err, f),
             OptionalSign(ref err) => {
-                f.write_str(
+                rtry!(f.write_str(
                     "failed to parse sign for time offset \
                      POSIX time zone string",
-                )?;
+                ));
                 core::fmt::Display::fmt(err, f)
             }
         }
@@ -1568,11 +1574,15 @@ impl core::fmt::Display for PosixRuleError {
         use self::PosixRuleError::*;
         match *self {
             DateTimeEnd(ref err) => {
-                f.write_str("failed to parse end of DST transition rule: ")?;
+                rtry!(f.write_str(
+                    "failed to parse end of DST transition rule: "
+                ));
                 core::fmt::Display::fmt(err, f)
             }
             DateTimeStart(ref err) => {
-                f.write_str("failed to parse start of DST transition rule: ")?;
+                rtry!(f.write_str(
+                    "failed to parse start of DST transition rule: "
+                ));
                 core::fmt::Display::fmt(err, f)
             }
             ExpectedEnd => f.write_str(
@@ -1680,7 +1690,7 @@ impl core::fmt::Display for PosixJulianNoLeapError {
         use self::PosixJulianNoLeapError::*;
         match *self {
             Parse(ref err) => {
-                f.write_str("invalid one-based Julian day digits: ")?;
+                rtry!(f.write_str("invalid one-based Julian day digits: "));
                 core::fmt::Display::fmt(err, f)
             }
             Range => f.write_str(
@@ -1702,7 +1712,7 @@ impl core::fmt::Display for PosixJulianLeapError {
         use self::PosixJulianLeapError::*;
         match *self {
             Parse(ref err) => {
-                f.write_str("invalid zero-based Julian day digits: ")?;
+                rtry!(f.write_str("invalid zero-based Julian day digits: "));
                 core::fmt::Display::fmt(err, f)
             }
             Range => f.write_str(
@@ -1883,9 +1893,9 @@ impl core::fmt::Display for PosixTimeError {
             Minute(ref err) => core::fmt::Display::fmt(err, f),
             Second(ref err) => core::fmt::Display::fmt(err, f),
             OptionalSign(ref err) => {
-                f.write_str(
+                rtry!(f.write_str(
                     "failed to parse sign for time zone transition time",
-                )?;
+                ));
                 core::fmt::Display::fmt(err, f)
             }
         }
@@ -1933,7 +1943,7 @@ impl core::fmt::Display for MonthError {
         use self::MonthError::*;
         match *self {
             Parse(ref err) => {
-                f.write_str("invalid month digits: ")?;
+                rtry!(f.write_str("invalid month digits: "));
                 core::fmt::Display::fmt(err, f)
             }
             Range => f.write_str(
@@ -1955,7 +1965,7 @@ impl core::fmt::Display for WeekOfMonthError {
         use self::WeekOfMonthError::*;
         match *self {
             Parse(ref err) => {
-                f.write_str("invalid week-of-month digits: ")?;
+                rtry!(f.write_str("invalid week-of-month digits: "));
                 core::fmt::Display::fmt(err, f)
             }
             Range => f.write_str(
@@ -1977,7 +1987,7 @@ impl core::fmt::Display for WeekdayError {
         use self::WeekdayError::*;
         match *self {
             Parse(ref err) => {
-                f.write_str("invalid weekday digits: ")?;
+                rtry!(f.write_str("invalid weekday digits: "));
                 core::fmt::Display::fmt(err, f)
             }
             Range => f.write_str(
@@ -1999,7 +2009,7 @@ impl core::fmt::Display for HourIanaError {
         use self::HourIanaError::*;
         match *self {
             Parse(ref err) => {
-                f.write_str("invalid hour digits: ")?;
+                rtry!(f.write_str("invalid hour digits: "));
                 core::fmt::Display::fmt(err, f)
             }
             Range => f.write_str(
@@ -2021,7 +2031,7 @@ impl core::fmt::Display for HourPosixError {
         use self::HourPosixError::*;
         match *self {
             Parse(ref err) => {
-                f.write_str("invalid hour digits: ")?;
+                rtry!(f.write_str("invalid hour digits: "));
                 core::fmt::Display::fmt(err, f)
             }
             Range => f.write_str(
@@ -2043,7 +2053,7 @@ impl core::fmt::Display for MinuteError {
         use self::MinuteError::*;
         match *self {
             Parse(ref err) => {
-                f.write_str("invalid minute digits: ")?;
+                rtry!(f.write_str("invalid minute digits: "));
                 core::fmt::Display::fmt(err, f)
             }
             Range => f.write_str(
@@ -2065,7 +2075,7 @@ impl core::fmt::Display for SecondError {
         use self::SecondError::*;
         match *self {
             Parse(ref err) => {
-                f.write_str("invalid second digits: ")?;
+                rtry!(f.write_str("invalid second digits: "));
                 core::fmt::Display::fmt(err, f)
             }
             Range => f.write_str(

--- a/src/shared/tzif.rs
+++ b/src/shared/tzif.rs
@@ -82,9 +82,9 @@ impl TzifOwned {
         let (header32, rest) =
             Header::parse(4, bytes).map_err(TzifErrorKind::Header32)?;
         let (mut tzif, rest) = if header32.version == 0 {
-            TzifOwned::parse32(name, header32, rest)?
+            rtry!(TzifOwned::parse32(name, header32, rest))
         } else {
-            TzifOwned::parse64(name, header32, rest)?
+            rtry!(TzifOwned::parse64(name, header32, rest))
         };
         tzif.fatten();
         // This should come after fattening, because fattening may add new
@@ -131,11 +131,11 @@ impl TzifOwned {
                 infos: vec![],
             },
         };
-        let rest = tzif.parse_transitions(&header32, bytes)?;
+        let rest = rtry!(tzif.parse_transitions(&header32, bytes));
         let rest = tzif.parse_transition_types(&header32, rest)?;
-        let rest = tzif.parse_local_time_types(&header32, rest)?;
+        let rest = rtry!(tzif.parse_local_time_types(&header32, rest));
         let rest = tzif.parse_time_zone_designations(&header32, rest)?;
-        let rest = tzif.parse_leap_seconds(&header32, rest)?;
+        let rest = rtry!(tzif.parse_leap_seconds(&header32, rest));
         let rest = tzif.parse_indicators(&header32, rest)?;
         Ok((tzif, rest))
     }
@@ -166,11 +166,11 @@ impl TzifOwned {
                 infos: vec![],
             },
         };
-        let rest = tzif.parse_transitions(&header64, rest)?;
+        let rest = rtry!(tzif.parse_transitions(&header64, rest));
         let rest = tzif.parse_transition_types(&header64, rest)?;
-        let rest = tzif.parse_local_time_types(&header64, rest)?;
+        let rest = rtry!(tzif.parse_local_time_types(&header64, rest));
         let rest = tzif.parse_time_zone_designations(&header64, rest)?;
-        let rest = tzif.parse_leap_seconds(&header64, rest)?;
+        let rest = rtry!(tzif.parse_leap_seconds(&header64, rest));
         let rest = tzif.parse_indicators(&header64, rest)?;
         let rest = tzif.parse_footer(&header64, rest)?;
         // Note that we don't check that the TZif data is fully valid. It is
@@ -299,24 +299,24 @@ impl TzifOwned {
             bytes,
             header.time_zone_designations_len(),
         )?;
-        self.fixed.designations = String::from_utf8(bytes.to_vec())
-            .map_err(|_| TimeZoneDesignatorError::InvalidUtf8)?;
+        self.fixed.designations = rtry!(String::from_utf8(bytes.to_vec())
+            .map_err(|_| TimeZoneDesignatorError::InvalidUtf8));
         // Holy hell, this is brutal. The boundary conditions are crazy.
         for typ in self.types.iter_mut() {
             let start = usize::from(typ.designation.0);
-            let suffix = self
+            let suffix = rtry!(self
                 .fixed
                 .designations
                 .get(start..)
-                .ok_or(TimeZoneDesignatorError::InvalidStart)?;
-            let len = suffix
+                .ok_or(TimeZoneDesignatorError::InvalidStart));
+            let len = rtry!(suffix
                 .find('\x00')
-                .ok_or(TimeZoneDesignatorError::MissingNul)?;
-            let end = start
+                .ok_or(TimeZoneDesignatorError::MissingNul));
+            let end = rtry!(start
                 .checked_add(len)
-                .ok_or(TimeZoneDesignatorError::InvalidLength)?;
-            typ.designation.1 = u8::try_from(end)
-                .map_err(|_| TimeZoneDesignatorError::InvalidEnd)?;
+                .ok_or(TimeZoneDesignatorError::InvalidLength));
+            typ.designation.1 = rtry!(u8::try_from(end)
+                .map_err(|_| TimeZoneDesignatorError::InvalidEnd));
         }
         Ok(rest)
     }
@@ -437,10 +437,10 @@ impl TzifOwned {
         // Only scan up to 1KB for a NUL terminator in case we somehow got
         // passed a huge block of bytes.
         let toscan = &bytes[..bytes.len().min(1024)];
-        let nlat = toscan
+        let nlat = rtry!(toscan
             .iter()
             .position(|&b| b == b'\n')
-            .ok_or(FooterError::TerminatorNotFound)?;
+            .ok_or(FooterError::TerminatorNotFound));
         let (bytes, rest) = bytes.split_at(nlat);
         if !bytes.is_empty() {
             // We could in theory limit TZ strings to their strict POSIX
@@ -449,8 +449,8 @@ impl TzifOwned {
             // that GNU tooling allows it via the `TZ` environment variable
             // even though POSIX doesn't specify it. This all seems okay to me
             // because the V3+ extension is a strict superset of functionality.
-            let posix_tz = PosixTimeZone::parse(bytes)
-                .map_err(FooterError::InvalidPosixTz)?;
+            let posix_tz = rtry!(PosixTimeZone::parse(bytes)
+                .map_err(FooterError::InvalidPosixTz));
             self.fixed.posix_tz = Some(posix_tz);
         }
         Ok(&rest[1..])
@@ -813,30 +813,34 @@ impl Header {
         let (tzh_typecnt_bytes, rest) = rest.split_at(4);
         let (tzh_charcnt_bytes, rest) = rest.split_at(4);
 
-        let tzh_ttisutcnt =
-            from_be_bytes_u32_to_usize(tzh_ttisutcnt_bytes).map_err(|e| {
-                HeaderError::ParseCount { kind: CountKind::Ut, convert: e }
-            })?;
-        let tzh_ttisstdcnt =
-            from_be_bytes_u32_to_usize(tzh_ttisstdcnt_bytes).map_err(|e| {
-                HeaderError::ParseCount { kind: CountKind::Std, convert: e }
-            })?;
-        let tzh_leapcnt =
-            from_be_bytes_u32_to_usize(tzh_leapcnt_bytes).map_err(|e| {
+        let tzh_ttisutcnt = rtry!(from_be_bytes_u32_to_usize(
+            tzh_ttisutcnt_bytes
+        )
+        .map_err(|e| {
+            HeaderError::ParseCount { kind: CountKind::Ut, convert: e }
+        }));
+        let tzh_ttisstdcnt = rtry!(from_be_bytes_u32_to_usize(
+            tzh_ttisstdcnt_bytes
+        )
+        .map_err(|e| {
+            HeaderError::ParseCount { kind: CountKind::Std, convert: e }
+        }));
+        let tzh_leapcnt = rtry!(from_be_bytes_u32_to_usize(tzh_leapcnt_bytes)
+            .map_err(|e| {
                 HeaderError::ParseCount { kind: CountKind::Leap, convert: e }
-            })?;
-        let tzh_timecnt =
-            from_be_bytes_u32_to_usize(tzh_timecnt_bytes).map_err(|e| {
+            }));
+        let tzh_timecnt = rtry!(from_be_bytes_u32_to_usize(tzh_timecnt_bytes)
+            .map_err(|e| {
                 HeaderError::ParseCount { kind: CountKind::Time, convert: e }
-            })?;
-        let tzh_typecnt =
-            from_be_bytes_u32_to_usize(tzh_typecnt_bytes).map_err(|e| {
+            }));
+        let tzh_typecnt = rtry!(from_be_bytes_u32_to_usize(tzh_typecnt_bytes)
+            .map_err(|e| {
                 HeaderError::ParseCount { kind: CountKind::Type, convert: e }
-            })?;
-        let tzh_charcnt =
-            from_be_bytes_u32_to_usize(tzh_charcnt_bytes).map_err(|e| {
+            }));
+        let tzh_charcnt = rtry!(from_be_bytes_u32_to_usize(tzh_charcnt_bytes)
+            .map_err(|e| {
                 HeaderError::ParseCount { kind: CountKind::Char, convert: e }
-            })?;
+            }));
 
         if tzh_ttisutcnt != 0 && tzh_ttisutcnt != tzh_typecnt {
             return Err(HeaderError::MismatchUtType);
@@ -880,11 +884,11 @@ impl Header {
     /// This is useful for, e.g., skipping over the 32-bit V1 data block in
     /// V2+ TZif formatted files.
     fn data_block_len(&self) -> Result<usize, HeaderError> {
-        let a = self.transition_times_len()?;
+        let a = rtry!(self.transition_times_len());
         let b = self.transition_types_len();
-        let c = self.local_time_types_len()?;
+        let c = rtry!(self.local_time_types_len());
         let d = self.time_zone_designations_len();
-        let e = self.leap_second_len()?;
+        let e = rtry!(self.leap_second_len());
         let f = self.standard_wall_len();
         let g = self.ut_local_len();
         a.checked_add(b)
@@ -960,44 +964,46 @@ impl core::fmt::Display for TzifError {
         use self::TzifErrorKind::*;
         match self.kind {
             Footer(ref err) => {
-                f.write_str("invalid TZif footer: ")?;
+                rtry!(f.write_str("invalid TZif footer: "));
                 err.fmt(f)
             }
             Header(ref err) => {
-                f.write_str("invalid TZif header: ")?;
+                rtry!(f.write_str("invalid TZif header: "));
                 err.fmt(f)
             }
             Header32(ref err) => {
-                f.write_str("invalid 32-bit TZif header: ")?;
+                rtry!(f.write_str("invalid 32-bit TZif header: "));
                 err.fmt(f)
             }
             Header64(ref err) => {
-                f.write_str("invalid 64-bit TZif header: ")?;
+                rtry!(f.write_str("invalid 64-bit TZif header: "));
                 err.fmt(f)
             }
             InconsistentPosixTimeZone(ref err) => {
-                f.write_str(
+                rtry!(f.write_str(
                     "found inconsistency with \
                      POSIX time zone transition rule \
                      in TZif file footer: ",
-                )?;
+                ));
                 err.fmt(f)
             }
             Indicator(ref err) => {
-                f.write_str("failed to parse indicators: ")?;
+                rtry!(f.write_str("failed to parse indicators: "));
                 err.fmt(f)
             }
             LocalTimeType(ref err) => {
-                f.write_str("failed to parse local time types: ")?;
+                rtry!(f.write_str("failed to parse local time types: "));
                 err.fmt(f)
             }
             SplitAt(ref err) => err.fmt(f),
             TimeZoneDesignator(ref err) => {
-                f.write_str("failed to parse time zone designators: ")?;
+                rtry!(f.write_str("failed to parse time zone designators: "));
                 err.fmt(f)
             }
             TransitionType(ref err) => {
-                f.write_str("failed to parse time zone transition types: ")?;
+                rtry!(f.write_str(
+                    "failed to parse time zone transition types: "
+                ));
                 err.fmt(f)
             }
         }
@@ -1231,7 +1237,7 @@ impl core::fmt::Display for FooterError {
 
         match *self {
             InvalidPosixTz(ref err) => {
-                f.write_str("invalid POSIX time zone transition rule")?;
+                rtry!(f.write_str("invalid POSIX time zone transition rule"));
                 core::fmt::Display::fmt(err, f)
             }
             MismatchEnd => f.write_str(
@@ -1361,8 +1367,8 @@ impl core::fmt::Display for SplitAtError {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         use self::SplitAtError::*;
 
-        f.write_str("expected bytes for '")?;
-        f.write_str(match *self {
+        rtry!(f.write_str("expected bytes for '"));
+        rtry!(f.write_str(match *self {
             V1 => "v1 TZif",
             LeapSeconds => "leap seconds",
             LocalTimeTypes => "local time types",
@@ -1371,8 +1377,8 @@ impl core::fmt::Display for SplitAtError {
             TransitionTimes => "transition times",
             TransitionTypes => "transition types",
             UTLocalIndicators => "UT/local indicators",
-        })?;
-        f.write_str("data block', but did not find enough bytes")?;
+        }));
+        rtry!(f.write_str("data block', but did not find enough bytes"));
         Ok(())
     }
 }

--- a/src/shared/util/itime.rs
+++ b/src/shared/util/itime.rs
@@ -152,15 +152,15 @@ impl IDateTime {
         &self,
         seconds: i32,
     ) -> Result<IDateTime, RangeError> {
-        let day_second = self
+        let day_second = rtry!(self
             .time
             .to_second()
             .second
             .checked_add(seconds)
-            .ok_or_else(|| RangeError::DateTimeSeconds)?;
+            .ok_or_else(|| RangeError::DateTimeSeconds));
         let days = day_second.div_euclid(86400);
         let second = day_second.rem_euclid(86400);
-        let date = self.date.checked_add_days(days)?;
+        let date = rtry!(self.date.checked_add_days(days));
         let time = ITimeSecond { second }.to_time();
         Ok(IDateTime { date, time })
     }
@@ -234,9 +234,9 @@ impl IEpochDay {
         amount: i32,
     ) -> Result<IEpochDay, RangeError> {
         let epoch_day = self.epoch_day;
-        let sum = epoch_day
+        let sum = rtry!(epoch_day
             .checked_add(amount)
-            .ok_or_else(|| RangeError::EpochDayI32)?;
+            .ok_or_else(|| RangeError::EpochDayI32));
         let ret = IEpochDay { epoch_day: sum };
         if !(IEpochDay::MIN <= ret && ret <= IEpochDay::MAX) {
             return Err(RangeError::EpochDayDays);
@@ -292,11 +292,11 @@ impl IDate {
             return Err(RangeError::DateInvalidDayOfYear { year });
         }
         let start = IDate { year, month: 1, day: 1 }.to_epoch_day();
-        let end = start
+        let end = rtry!(start
             .checked_add(i32::from(day) - 1)
             // This can only happen when `year=9999` and `day=366`.
-            .map_err(|_| RangeError::DayOfYear)?
-            .to_date();
+            .map_err(|_| RangeError::DayOfYear))
+        .to_date();
         // If we overflowed into the next year, then `day` is too big.
         if year != end.year {
             // Can only happen given day=366 and this is a leap year.

--- a/src/signed_duration.rs
+++ b/src/signed_duration.rs
@@ -2139,8 +2139,8 @@ impl SignedDuration {
             }
             Err(err) => {
                 let dur = err.duration();
-                let dur = SignedDuration::try_from(dur)
-                    .context(E::ConvertSystemTime)?;
+                let dur = rtry!(SignedDuration::try_from(dur)
+                    .context(E::ConvertSystemTime));
                 dur.checked_neg()
                     .ok_or_else(b::SignedDurationSeconds::error)
                     .context(E::ConvertSystemTime)
@@ -2473,18 +2473,18 @@ impl core::fmt::Debug for SignedDuration {
 
         if f.alternate() {
             if self.subsec_nanos() == 0 {
-                core::fmt::Display::fmt(&self.as_secs(), f)?;
+                rtry!(core::fmt::Display::fmt(&self.as_secs(), f));
                 f.write_str("s")
             } else if self.as_secs() == 0 {
-                core::fmt::Display::fmt(&self.subsec_nanos(), f)?;
+                rtry!(core::fmt::Display::fmt(&self.subsec_nanos(), f));
                 f.write_str("ns")
             } else {
-                core::fmt::Display::fmt(&self.as_secs(), f)?;
-                f.write_str("s ")?;
-                core::fmt::Display::fmt(
+                rtry!(core::fmt::Display::fmt(&self.as_secs(), f));
+                rtry!(f.write_str("s "));
+                rtry!(core::fmt::Display::fmt(
                     &self.subsec_nanos().unsigned_abs(),
                     f,
-                )?;
+                ));
                 f.write_str("ns")
             }
         } else {
@@ -2889,8 +2889,10 @@ impl SignedDurationRound {
 
     /// Does the actual duration rounding.
     fn round(&self, dur: SignedDuration) -> Result<SignedDuration, Error> {
-        let increment =
-            Increment::for_signed_duration(self.smallest, self.increment)?;
+        let increment = rtry!(Increment::for_signed_duration(
+            self.smallest,
+            self.increment
+        ));
         increment
             .round(self.mode, dur)
             .with_context(|| E::RoundOverflowed { unit: self.smallest })

--- a/src/span.rs
+++ b/src/span.rs
@@ -1769,17 +1769,17 @@ impl Span {
         let (span1, span2) = (*self, *span);
         let unit = span1.largest_unit().max(span2.largest_unit());
         let start = match relative {
-            Some(r) => match r.to_relative(unit)? {
+            Some(r) => match rtry!(r.to_relative(unit)) {
                 None => return span1.checked_add_invariant(unit, &span2),
                 Some(r) => r,
             },
             None => {
-                requires_relative_date_err(unit)?;
+                rtry!(requires_relative_date_err(unit));
                 return span1.checked_add_invariant(unit, &span2);
             }
         };
-        let mid = start.checked_add(span1)?;
-        let end = mid.checked_add(span2)?;
+        let mid = rtry!(start.checked_add(span1));
+        let end = rtry!(mid.checked_add(span2));
         start.until(unit, &end)
     }
 
@@ -1792,19 +1792,19 @@ impl Span {
         let (span1, dur2) = (*self, duration);
         let unit = span1.largest_unit();
         let start = match relative {
-            Some(r) => match r.to_relative(unit)? {
+            Some(r) => match rtry!(r.to_relative(unit)) {
                 None => {
                     return span1.checked_add_invariant_duration(unit, dur2)
                 }
                 Some(r) => r,
             },
             None => {
-                requires_relative_date_err(unit)?;
+                rtry!(requires_relative_date_err(unit));
                 return span1.checked_add_invariant_duration(unit, dur2);
             }
         };
-        let mid = start.checked_add(span1)?;
-        let end = mid.checked_add_duration(dur2)?;
+        let mid = rtry!(start.checked_add(span1));
+        let end = rtry!(mid.checked_add_duration(dur2));
         start.until(unit, &end)
     }
 
@@ -1871,7 +1871,7 @@ impl Span {
         options: A,
     ) -> Result<Span, Error> {
         let mut options: SpanArithmetic<'_> = options.into();
-        options.duration = options.duration.checked_neg()?;
+        options.duration = rtry!(options.duration.checked_neg());
         options.checked_add(*self)
     }
 
@@ -2389,7 +2389,7 @@ impl Span {
         let Some(result) = relative.to_relative(max_unit).transpose() else {
             return Ok(self.to_invariant_duration());
         };
-        let relspan = result
+        let relspan = rtry!(result
             .and_then(|r| r.into_relative_span(Unit::Second, *self))
             .with_context(|| match relative.kind {
                 SpanRelativeToKind::Civil(_) => E::ToDurationCivil,
@@ -2397,7 +2397,7 @@ impl Span {
                 SpanRelativeToKind::DaysAre24Hours => {
                     E::ToDurationDaysAre24Hours
                 }
-            })?;
+            }));
         debug_assert!(relspan.span.largest_unit() <= Unit::Second);
         Ok(relspan.span.to_invariant_duration())
     }
@@ -2680,47 +2680,47 @@ impl Span {
 
         if matches!(largest, Unit::Week) {
             let (weeks, rem) = dur.as_civil_weeks_with_remainder();
-            span = span.try_weeks(weeks)?;
+            span = rtry!(span.try_weeks(weeks));
             dur = rem;
         }
         if largest >= Unit::Day {
             let (days, rem) = dur.as_civil_days_with_remainder();
-            span = span.try_days(days)?;
+            span = rtry!(span.try_days(days));
             dur = rem;
         }
         if largest >= Unit::Hour {
             let (hours, rem) = dur.as_hours_with_remainder();
-            span = span.try_hours(hours)?;
+            span = rtry!(span.try_hours(hours));
             dur = rem;
         }
         if largest >= Unit::Minute {
             let (mins, rem) = dur.as_mins_with_remainder();
-            span = span.try_minutes(mins)?;
+            span = rtry!(span.try_minutes(mins));
             dur = rem;
         }
         if largest >= Unit::Second {
             let (secs, rem) = dur.as_secs_with_remainder();
-            span = span.try_seconds(secs)?;
+            span = rtry!(span.try_seconds(secs));
             dur = rem;
         }
         if largest >= Unit::Millisecond {
             let (millis, rem) = dur.as_millis_with_remainder();
             let millis = i64::try_from(millis)
                 .map_err(|_| b::SpanMilliseconds::error())?;
-            span = span.try_milliseconds(millis)?;
+            span = rtry!(span.try_milliseconds(millis));
             dur = rem;
         }
         if largest >= Unit::Microsecond {
             let (micros, rem) = dur.as_micros_with_remainder();
             let micros = i64::try_from(micros)
                 .map_err(|_| b::SpanMicroseconds::error())?;
-            span = span.try_microseconds(micros)?;
+            span = rtry!(span.try_microseconds(micros));
             dur = rem;
         }
         if largest >= Unit::Nanosecond {
             let nanos = i64::try_from(dur.as_nanos())
                 .map_err(|_| b::SpanNanoseconds::error())?;
-            span = span.try_nanoseconds(nanos)?;
+            span = rtry!(span.try_nanoseconds(nanos));
         }
 
         Ok(span)
@@ -3239,8 +3239,8 @@ impl TryFrom<Span> for SignedDuration {
 
     #[inline]
     fn try_from(sp: Span) -> Result<SignedDuration, Error> {
-        requires_relative_date_err(sp.largest_unit())
-            .context(E::ConvertSpanToSignedDuration)?;
+        rtry!(requires_relative_date_err(sp.largest_unit())
+            .context(E::ConvertSpanToSignedDuration));
         Ok(sp.to_invariant_duration())
     }
 }
@@ -3309,7 +3309,7 @@ impl TryFrom<SignedDuration> for Span {
             (nanoseconds % b::NANOS_PER_MILLI) / b::NANOS_PER_MICRO;
         let nanoseconds = nanoseconds % b::NANOS_PER_MICRO;
 
-        let span = Span::new().try_seconds(seconds)?;
+        let span = rtry!(Span::new().try_seconds(seconds));
         // These are all OK because `|SignedDuration::subsec_nanos|` is
         // guaranteed to return less than 1_000_000_000 nanoseconds. And
         // splitting that up into millis, micros and nano components is
@@ -4124,7 +4124,7 @@ impl<'a> SpanArithmetic<'a> {
 
     #[inline]
     fn checked_add(self, span1: Span) -> Result<Span, Error> {
-        match self.duration.to_signed()? {
+        match rtry!(self.duration.to_signed()) {
             SDuration::Span(span2) => {
                 span1.checked_add_span(self.relative, &span2)
             }
@@ -4370,7 +4370,7 @@ impl<'a> SpanCompare<'a> {
         let (span1, span2) = (span, self.span);
         let unit = span1.largest_unit().max(span2.largest_unit());
         let start = match self.relative {
-            Some(r) => match r.to_relative(unit)? {
+            Some(r) => match rtry!(r.to_relative(unit)) {
                 Some(r) => r,
                 None => {
                     let dur1 = span1.to_invariant_duration();
@@ -4379,14 +4379,14 @@ impl<'a> SpanCompare<'a> {
                 }
             },
             None => {
-                requires_relative_date_err(unit)?;
+                rtry!(requires_relative_date_err(unit));
                 let dur1 = span1.to_invariant_duration();
                 let dur2 = span2.to_invariant_duration();
                 return Ok(dur1.cmp(&dur2));
             }
         };
-        let end1 = start.checked_add(span1)?.to_duration();
-        let end2 = start.checked_add(span2)?.to_duration();
+        let end1 = rtry!(start.checked_add(span1)).to_duration();
+        let end2 = rtry!(start.checked_add(span2)).to_duration();
         Ok(end1.cmp(&end2))
     }
 }
@@ -4606,18 +4606,18 @@ impl<'a> SpanTotal<'a> {
     fn total(self, span: Span) -> Result<f64, Error> {
         let max_unit = self.unit.max(span.largest_unit());
         let relative = match self.relative {
-            Some(r) => match r.to_relative(max_unit)? {
+            Some(r) => match rtry!(r.to_relative(max_unit)) {
                 Some(r) => r,
                 None => {
                     return Ok(self.total_invariant(span));
                 }
             },
             None => {
-                requires_relative_date_err(max_unit)?;
+                rtry!(requires_relative_date_err(max_unit));
                 return Ok(self.total_invariant(span));
             }
         };
-        let relspan = relative.into_relative_span(self.unit, span)?;
+        let relspan = rtry!(relative.into_relative_span(self.unit, span));
         if !self.unit.is_variable() {
             return Ok(self.total_invariant(relspan.span));
         }
@@ -4636,12 +4636,12 @@ impl<'a> SpanTotal<'a> {
                 (start, end)
             }
         };
-        let (relative0, relative1) = unit_start_and_end(
+        let (relative0, relative1) = rtry!(unit_start_and_end(
             &relative_start,
             relspan.span.without_lower(self.unit),
             self.unit,
             sign.as_i64(),
-        )?;
+        ));
         let denom = (relative1 - relative0).as_nanos() as f64;
         let numer = (relative_end.to_duration() - relative0).as_nanos() as f64;
         let unit_val = relspan.span.get_unit(self.unit) as f64;
@@ -5144,7 +5144,8 @@ impl<'a> SpanRound<'a> {
             .largest
             .unwrap_or_else(|| self.smallest.max(existing_largest));
         let max = existing_largest.max(largest);
-        let increment = Increment::for_span(self.smallest, self.increment)?;
+        let increment =
+            rtry!(Increment::for_span(self.smallest, self.increment));
         if largest < self.smallest {
             return Err(Error::from(
                 UnitConfigError::LargestSmallerThanSmallest {
@@ -5156,7 +5157,7 @@ impl<'a> SpanRound<'a> {
 
         let relative = match self.relative {
             Some(ref r) => {
-                match r.to_relative(max)? {
+                match rtry!(r.to_relative(max)) {
                     Some(r) => r,
                     None => {
                         // If our reference point is civil time, then its units
@@ -5165,9 +5166,9 @@ impl<'a> SpanRound<'a> {
                         // independent of the reference point. In which case,
                         // rounding is a simple matter of converting the span
                         // to a number of nanoseconds and then rounding that.
-                        return Ok(round_span_invariant(
+                        return Ok(rtry!(round_span_invariant(
                             span, largest, &increment, self.mode,
-                        )?);
+                        )));
                     }
                 }
             }
@@ -5177,18 +5178,18 @@ impl<'a> SpanRound<'a> {
                 // when it has weeks/days units, but that requires explicitly
                 // specifying a special relative date marker, which is handled
                 // by the `Some` case above.
-                requires_relative_date_err(self.smallest)
-                    .context(E::OptionSmallest)?;
+                rtry!(requires_relative_date_err(self.smallest)
+                    .context(E::OptionSmallest));
                 if let Some(largest) = self.largest {
-                    requires_relative_date_err(largest)
-                        .context(E::OptionLargest)?;
+                    rtry!(requires_relative_date_err(largest)
+                        .context(E::OptionLargest));
                 }
-                requires_relative_date_err(existing_largest)
-                    .context(E::OptionLargestInSpan)?;
+                rtry!(requires_relative_date_err(existing_largest)
+                    .context(E::OptionLargestInSpan));
                 assert!(max <= Unit::Week);
-                return Ok(round_span_invariant(
+                return Ok(rtry!(round_span_invariant(
                     span, largest, &increment, self.mode,
-                )?);
+                )));
             }
         };
         relative.round(span, largest, &increment, self.mode)
@@ -5474,7 +5475,7 @@ impl<'a> SpanRelativeTo<'a> {
         }
         match self.kind {
             SpanRelativeToKind::Civil(dt) => {
-                Ok(Some(Relative::Civil(RelativeCivil::new(dt)?)))
+                Ok(Some(Relative::Civil(rtry!(RelativeCivil::new(dt)))))
             }
             SpanRelativeToKind::Zoned(zdt) => {
                 Ok(Some(Relative::Zoned(RelativeZoned {
@@ -5620,19 +5621,19 @@ impl UnitSet {
 // part of the public crate API.
 impl core::fmt::Debug for UnitSet {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{{")?;
+        rtry!(write!(f, "{{"));
         let mut units = *self;
         let mut i = 0;
         while let Some(unit) = units.largest_unit() {
             if i > 0 {
-                write!(f, ", ")?;
+                rtry!(write!(f, ", "));
             }
             i += 1;
-            write!(f, "{}", unit.compact())?;
+            rtry!(write!(f, "{}", unit.compact()));
             units = units.set(unit, false);
         }
         if i == 0 {
-            write!(f, "∅")?;
+            rtry!(write!(f, "∅"));
         }
         write!(f, "}}")
     }
@@ -5694,9 +5695,11 @@ impl<'a> Relative<'a> {
     /// would result in overflow.
     fn checked_add(&'a self, span: Span) -> Result<Relative<'a>, Error> {
         match *self {
-            Relative::Civil(dt) => Ok(Relative::Civil(dt.checked_add(span)?)),
+            Relative::Civil(dt) => {
+                Ok(Relative::Civil(rtry!(dt.checked_add(span))))
+            }
             Relative::Zoned(ref zdt) => {
-                Ok(Relative::Zoned(zdt.checked_add(span)?))
+                Ok(Relative::Zoned(rtry!(zdt.checked_add(span))))
             }
         }
     }
@@ -5707,10 +5710,10 @@ impl<'a> Relative<'a> {
     ) -> Result<Relative<'a>, Error> {
         match *self {
             Relative::Civil(dt) => {
-                Ok(Relative::Civil(dt.checked_add_duration(duration)?))
+                Ok(Relative::Civil(rtry!(dt.checked_add_duration(duration))))
             }
             Relative::Zoned(ref zdt) => {
-                Ok(Relative::Zoned(zdt.checked_add_duration(duration)?))
+                Ok(Relative::Zoned(rtry!(zdt.checked_add_duration(duration))))
             }
         }
     }
@@ -5784,15 +5787,15 @@ impl<'a> Relative<'a> {
     ) -> Result<RelativeSpan<'a>, Error> {
         let kind = match self {
             Relative::Civil(start) => {
-                let end = start.checked_add(span)?;
+                let end = rtry!(start.checked_add(span));
                 RelativeSpanKind::Civil { start, end }
             }
             Relative::Zoned(start) => {
-                let end = start.checked_add(span)?;
+                let end = rtry!(start.checked_add(span));
                 RelativeSpanKind::Zoned { start, end }
             }
         };
-        let relspan = kind.into_relative_span(largest)?;
+        let relspan = rtry!(kind.into_relative_span(largest));
         if !span.get_sign().is_zero()
             && !relspan.span.get_sign().is_zero()
             && span.get_sign() != relspan.span.get_sign()
@@ -5817,57 +5820,57 @@ impl<'a> Relative<'a> {
         increment: &Increment,
         mode: RoundMode,
     ) -> Result<Span, Error> {
-        let relspan = self.into_relative_span(largest, span)?;
+        let relspan = rtry!(self.into_relative_span(largest, span));
         if relspan.span.get_sign().is_zero() {
             return Ok(relspan.span);
         }
         let nudge = match relspan.kind {
             RelativeSpanKind::Civil { start, end } => {
                 if increment.unit() > Unit::Day {
-                    Nudge::relative_calendar(
+                    rtry!(Nudge::relative_calendar(
                         relspan.span,
                         &Relative::Civil(start),
                         &Relative::Civil(end),
                         increment,
                         mode,
-                    )?
+                    ))
                 } else {
-                    Nudge::relative_invariant(
+                    rtry!(Nudge::relative_invariant(
                         relspan.span,
                         end.timestamp.as_duration(),
                         largest,
                         increment,
                         mode,
-                    )?
+                    ))
                 }
             }
             RelativeSpanKind::Zoned { ref start, ref end } => {
                 if increment.unit() >= Unit::Day {
-                    Nudge::relative_calendar(
+                    rtry!(Nudge::relative_calendar(
                         relspan.span,
                         &Relative::Zoned(start.borrowed()),
                         &Relative::Zoned(end.borrowed()),
                         increment,
                         mode,
-                    )?
+                    ))
                 } else if largest >= Unit::Day {
                     // This is a special case for zoned datetimes when rounding
                     // could bleed into variable units.
-                    Nudge::relative_zoned_time(
+                    rtry!(Nudge::relative_zoned_time(
                         relspan.span,
                         start,
                         increment,
                         mode,
-                    )?
+                    ))
                 } else {
                     // Otherwise, rounding is the same as civil datetime.
-                    Nudge::relative_invariant(
+                    rtry!(Nudge::relative_invariant(
                         relspan.span,
                         end.zoned.timestamp().as_duration(),
                         largest,
                         increment,
                         mode,
-                    )?
+                    ))
                 }
             }
         };
@@ -5906,14 +5909,14 @@ impl<'a> RelativeSpanKind<'a> {
         largest: Unit,
     ) -> Result<RelativeSpan<'a>, Error> {
         let span = match self {
-            RelativeSpanKind::Civil { ref start, ref end } => start
+            RelativeSpanKind::Civil { ref start, ref end } => rtry!(start
                 .datetime
                 .until((largest, end.datetime))
-                .context(E::FailedSpanBetweenDateTimes { unit: largest })?,
+                .context(E::FailedSpanBetweenDateTimes { unit: largest })),
             RelativeSpanKind::Zoned { ref start, ref end } => {
-                start.zoned.until((largest, &*end.zoned)).context(
+                rtry!(start.zoned.until((largest, &*end.zoned)).context(
                     E::FailedSpanBetweenZonedDateTimes { unit: largest },
-                )?
+                ))
             }
         };
         Ok(RelativeSpan { span, kind: self })
@@ -5953,10 +5956,10 @@ impl RelativeCivil {
     /// timestamp. This only occurs near the minimum and maximum civil datetime
     /// values.
     fn new(datetime: DateTime) -> Result<RelativeCivil, Error> {
-        let timestamp = datetime
+        let timestamp = rtry!(datetime
             .to_zoned(TimeZone::UTC)
-            .context(E::ConvertDateTimeToTimestamp)?
-            .timestamp();
+            .context(E::ConvertDateTimeToTimestamp))
+        .timestamp();
         Ok(RelativeCivil { datetime, timestamp })
     }
 
@@ -5971,11 +5974,11 @@ impl RelativeCivil {
     /// converted to a timestamp in UTC. This only occurs near the minimum and
     /// maximum datetime values.
     fn checked_add(&self, span: Span) -> Result<RelativeCivil, Error> {
-        let datetime = self.datetime.checked_add(span)?;
-        let timestamp = datetime
+        let datetime = rtry!(self.datetime.checked_add(span));
+        let timestamp = rtry!(datetime
             .to_zoned(TimeZone::UTC)
-            .context(E::ConvertDateTimeToTimestamp)?
-            .timestamp();
+            .context(E::ConvertDateTimeToTimestamp))
+        .timestamp();
         Ok(RelativeCivil { datetime, timestamp })
     }
 
@@ -5994,11 +5997,11 @@ impl RelativeCivil {
         &self,
         duration: SignedDuration,
     ) -> Result<RelativeCivil, Error> {
-        let datetime = self.datetime.checked_add(duration)?;
-        let timestamp = datetime
+        let datetime = rtry!(self.datetime.checked_add(duration));
+        let timestamp = rtry!(datetime
             .to_zoned(TimeZone::UTC)
-            .context(E::ConvertDateTimeToTimestamp)?
-            .timestamp();
+            .context(E::ConvertDateTimeToTimestamp))
+        .timestamp();
         Ok(RelativeCivil { datetime, timestamp })
     }
 
@@ -6038,7 +6041,7 @@ impl<'a> RelativeZoned<'a> {
         &self,
         span: Span,
     ) -> Result<RelativeZoned<'static>, Error> {
-        let zoned = self.zoned.checked_add(span)?;
+        let zoned = rtry!(self.zoned.checked_add(span));
         Ok(RelativeZoned { zoned: DumbCow::Owned(zoned) })
     }
 
@@ -6052,7 +6055,7 @@ impl<'a> RelativeZoned<'a> {
         &self,
         duration: SignedDuration,
     ) -> Result<RelativeZoned<'static>, Error> {
-        let zoned = self.zoned.checked_add(duration)?;
+        let zoned = rtry!(self.zoned.checked_add(duration));
         Ok(RelativeZoned { zoned: DumbCow::Owned(zoned) })
     }
 
@@ -6148,9 +6151,10 @@ impl Nudge {
 
         let sign = balanced.get_sign();
         let balanced_nanos = balanced.to_invariant_duration();
-        let rounded_nanos = increment.round(mode, balanced_nanos)?;
-        let span = Span::from_invariant_duration(largest, rounded_nanos)
-            .context(E::ConvertNanoseconds { unit: largest })?
+        let rounded_nanos = rtry!(increment.round(mode, balanced_nanos));
+        let span =
+            rtry!(Span::from_invariant_duration(largest, rounded_nanos)
+                .context(E::ConvertNanoseconds { unit: largest }))
             .years(balanced.get_years())
             .months(balanced.get_months())
             .weeks(balanced.get_weeks());
@@ -6232,8 +6236,9 @@ impl Nudge {
         // Drop all units below smallest. We specifically don't want them and
         // here is where we no longer need them. `relative_end` still captures
         // how "close" we are between increments of `smallest`.
-        let span =
-            balanced.without_lower(smallest).try_unit(smallest, truncated)?;
+        let span = rtry!(balanced
+            .without_lower(smallest)
+            .try_unit(smallest, truncated));
         // This is OK because the increment value is guaranteed to be in the
         // range `1..=1_000_000_000`. Therefore, multiplying by {-1,0,1} is
         // always valid.
@@ -6249,7 +6254,7 @@ impl Nudge {
         // `amount`. Thus, `relative1 - relative0` corresponds to the length
         // in time, in nanoseconds, of `increment` units of `smallest`.
         let (relative0, relative1) =
-            unit_start_and_end(relative_start, span, smallest, amount)?;
+            rtry!(unit_start_and_end(relative_start, span, smallest, amount));
 
         // This corresponds to how far our original span gets us to the next
         // increment. That is, `relative_end = relative_start + original_span`.
@@ -6273,7 +6278,7 @@ impl Nudge {
         // `relative_end` might be much bigger (or smaller, for negative spans)
         // than `relative1`.
         let rounded_nanos =
-            mode.round_by_duration(progress_nanos, increment_nanos)?;
+            rtry!(mode.round_by_duration(progress_nanos, increment_nanos));
         // If we rounded up, then it's possible we might need to to re-balance
         // our span. (This happens in `bubble`.)
         let grew_big_unit =
@@ -6297,12 +6302,12 @@ impl Nudge {
         // rounding. We must multiply by `increment` because `rounded /
         // increment` gets us back the number of *increments* we rounded over.
         // But the actual number of units may be bigger.
-        let span = span.try_unit(
+        let span = rtry!(span.try_unit(
             smallest,
             truncated
                 + (increment_units
                     * (rounded_nanos.as_secs() / increment_nanos.as_secs())),
-        )?;
+        ));
         // If we rounded up, then the time we don't want to exceed is
         // `relative1`. Otherwise, we don't want to exceed `relative0`.
         // (This is used later in `bubble`.)
@@ -6321,13 +6326,13 @@ impl Nudge {
     ) -> Result<Nudge, Error> {
         let sign = balanced.get_sign();
         let time_dur = balanced.only_lower(Unit::Day).to_invariant_duration();
-        let mut rounded_time_nanos = increment.round(mode, time_dur)?;
-        let (relative0, relative1) = unit_start_and_end(
+        let mut rounded_time_nanos = rtry!(increment.round(mode, time_dur));
+        let (relative0, relative1) = rtry!(unit_start_and_end(
             &Relative::Zoned(relative_start.borrowed()),
             balanced.without_lower(Unit::Day),
             Unit::Day,
             sign.as_i64(),
-        )?;
+        ));
         let day_nanos = relative1 - relative0;
         let beyond_day_nanos = rounded_time_nanos - day_nanos;
 
@@ -6336,19 +6341,22 @@ impl Nudge {
             || b::Sign::from(beyond_day_nanos) == sign
         {
             day_delta += 1;
-            rounded_time_nanos = increment.round(mode, beyond_day_nanos)?;
+            rounded_time_nanos =
+                rtry!(increment.round(mode, beyond_day_nanos));
             relative1 + rounded_time_nanos
         } else {
             relative0 + rounded_time_nanos
         };
 
-        let span =
-            Span::from_invariant_duration(Unit::Hour, rounded_time_nanos)
-                .context(E::ConvertNanoseconds { unit: Unit::Hour })?
-                .years(balanced.get_years())
-                .months(balanced.get_months())
-                .weeks(balanced.get_weeks())
-                .days(balanced.get_days() + day_delta);
+        let span = rtry!(Span::from_invariant_duration(
+            Unit::Hour,
+            rounded_time_nanos
+        )
+        .context(E::ConvertNanoseconds { unit: Unit::Hour }))
+        .years(balanced.get_years())
+        .months(balanced.get_months())
+        .weeks(balanced.get_weeks())
+        .days(balanced.get_days() + day_delta);
         let grew_big_unit = day_delta != 0;
         Ok(Nudge { span, rounded_relative_end, grew_big_unit })
     }
@@ -6391,13 +6399,13 @@ impl Nudge {
                 .get_unit(unit)
                 .checked_add(sign.as_i64())
                 .ok_or_else(|| unit.error())?;
-            let span_end = span_start.try_unit(unit, new_units)?;
+            let span_end = rtry!(span_start.try_unit(unit, new_units));
             let threshold = match relative.kind {
                 RelativeSpanKind::Civil { ref start, .. } => {
-                    start.checked_add(span_end)?.timestamp
+                    rtry!(start.checked_add(span_end)).timestamp
                 }
                 RelativeSpanKind::Zoned { ref start, .. } => {
-                    start.checked_add(span_end)?.zoned.timestamp()
+                    rtry!(start.checked_add(span_end)).zoned.timestamp()
                 }
             };
             // If we overshoot our expected endpoint, then bail.
@@ -6432,7 +6440,7 @@ fn round_span_invariant(
     debug_assert!(increment.unit() <= Unit::Week);
     debug_assert!(largest <= Unit::Week);
     let dur = span.to_invariant_duration();
-    let rounded = increment.round(mode, dur)?;
+    let rounded = rtry!(increment.round(mode, dur));
     Span::from_invariant_duration(largest, rounded)
         .context(E::ConvertNanoseconds { unit: largest })
 }
@@ -6460,9 +6468,9 @@ fn unit_start_and_end(
 ) -> Result<(SignedDuration, SignedDuration), Error> {
     let amount =
         span.get_unit(unit).checked_add(amount).ok_or_else(|| unit.error())?;
-    let span_amount = span.try_unit(unit, amount)?;
-    let relative0 = relative.checked_add(span)?.to_duration();
-    let relative1 = relative.checked_add(span_amount)?.to_duration();
+    let span_amount = rtry!(span.try_unit(unit, amount));
+    let relative0 = rtry!(relative.checked_add(span)).to_duration();
+    let relative1 = rtry!(relative.checked_add(span_amount)).to_duration();
     // This assertion gives better failure modes to what would otherwise be
     // subtle errors downstream if the durations returned here were equivalent.
     // It would imply that the physical time duration between them is zero,

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -1306,7 +1306,7 @@ impl Timestamp {
     /// ```
     #[inline]
     pub fn in_tz(self, time_zone_name: &str) -> Result<Zoned, Error> {
-        let tz = crate::tz::db().get(time_zone_name)?;
+        let tz = rtry!(crate::tz::db().get(time_zone_name));
         Ok(self.to_zoned(tz))
     }
 
@@ -1504,8 +1504,9 @@ impl Timestamp {
         if self.subsec_nanosecond() == 0 && !span.has_fractional_seconds() {
             let span_seconds = span.to_hms_seconds();
             let time_seconds = self.as_second();
-            let sum = b::UnixSeconds::checked_add(span_seconds, time_seconds)
-                .context(E::OverflowAddSpan)?;
+            let sum =
+                rtry!(b::UnixSeconds::checked_add(span_seconds, time_seconds)
+                    .context(E::OverflowAddSpan));
             // We know `sum` is in bounds so we don't need to recheck.
             return Ok(Timestamp { dur: SignedDuration::from_secs(sum) });
         }
@@ -1802,7 +1803,7 @@ impl Timestamp {
         other: A,
     ) -> Result<Span, Error> {
         let args: TimestampDifference = other.into();
-        let span = args.until_with_largest_unit(self)?;
+        let span = rtry!(args.until_with_largest_unit(self));
         if args.rounding_may_change_span() {
             span.round(args.round)
         } else {
@@ -1838,7 +1839,7 @@ impl Timestamp {
         other: A,
     ) -> Result<Span, Error> {
         let args: TimestampDifference = other.into();
-        let span = -args.until_with_largest_unit(self)?;
+        let span = -rtry!(args.until_with_largest_unit(self));
         if args.rounding_may_change_span() {
             span.round(args.round)
         } else {
@@ -2627,7 +2628,7 @@ impl TryFrom<std::time::SystemTime> for Timestamp {
         system_time: std::time::SystemTime,
     ) -> Result<Timestamp, Error> {
         let unix_epoch = std::time::SystemTime::UNIX_EPOCH;
-        let dur = SignedDuration::system_until(unix_epoch, system_time)?;
+        let dur = rtry!(SignedDuration::system_until(unix_epoch, system_time));
         Timestamp::from_duration(dur)
     }
 }
@@ -2859,7 +2860,7 @@ pub struct TimestampArithmetic {
 impl TimestampArithmetic {
     #[inline]
     fn checked_add(self, ts: Timestamp) -> Result<Timestamp, Error> {
-        match self.duration.to_signed()? {
+        match rtry!(self.duration.to_signed()) {
             SDuration::Span(span) => ts.checked_add_span(span),
             SDuration::Absolute(sdur) => ts.checked_add_duration(sdur),
         }
@@ -2891,7 +2892,7 @@ impl TimestampArithmetic {
 
     #[inline]
     fn checked_neg(self) -> Result<TimestampArithmetic, Error> {
-        let duration = self.duration.checked_neg()?;
+        let duration = rtry!(self.duration.checked_neg());
         Ok(TimestampArithmetic { duration })
     }
 
@@ -3458,10 +3459,10 @@ impl TimestampRound {
         timestamp: Timestamp,
     ) -> Result<Timestamp, Error> {
         let increment =
-            Increment::for_timestamp(self.smallest, self.increment)?;
-        Timestamp::from_duration(
-            increment.round(self.mode, timestamp.as_duration())?,
-        )
+            rtry!(Increment::for_timestamp(self.smallest, self.increment));
+        Timestamp::from_duration(rtry!(
+            increment.round(self.mode, timestamp.as_duration())
+        ))
     }
 }
 

--- a/src/tz/ambiguous.rs
+++ b/src/tz/ambiguous.rs
@@ -1031,10 +1031,10 @@ impl AmbiguousZoned {
     /// ```
     #[inline]
     pub fn compatible(self) -> Result<Zoned, Error> {
-        let ts = self
+        let ts = rtry!(self
             .ts
             .compatible()
-            .with_context(|| E::InTimeZone { tz: self.time_zone().clone() })?;
+            .with_context(|| E::InTimeZone { tz: self.time_zone().clone() }));
         Ok(ts.to_zoned(self.tz))
     }
 
@@ -1090,10 +1090,10 @@ impl AmbiguousZoned {
     /// ```
     #[inline]
     pub fn earlier(self) -> Result<Zoned, Error> {
-        let ts = self
+        let ts = rtry!(self
             .ts
             .earlier()
-            .with_context(|| E::InTimeZone { tz: self.time_zone().clone() })?;
+            .with_context(|| E::InTimeZone { tz: self.time_zone().clone() }));
         Ok(ts.to_zoned(self.tz))
     }
 
@@ -1149,10 +1149,10 @@ impl AmbiguousZoned {
     /// ```
     #[inline]
     pub fn later(self) -> Result<Zoned, Error> {
-        let ts = self
+        let ts = rtry!(self
             .ts
             .later()
-            .with_context(|| E::InTimeZone { tz: self.time_zone().clone() })?;
+            .with_context(|| E::InTimeZone { tz: self.time_zone().clone() }));
         Ok(ts.to_zoned(self.tz))
     }
 
@@ -1203,10 +1203,10 @@ impl AmbiguousZoned {
     /// ```
     #[inline]
     pub fn unambiguous(self) -> Result<Zoned, Error> {
-        let ts = self
+        let ts = rtry!(self
             .ts
             .unambiguous()
-            .with_context(|| E::InTimeZone { tz: self.time_zone().clone() })?;
+            .with_context(|| E::InTimeZone { tz: self.time_zone().clone() }));
         Ok(ts.to_zoned(self.tz))
     }
 

--- a/src/tz/concatenated.rs
+++ b/src/tz/concatenated.rs
@@ -44,7 +44,7 @@ impl<R: Read> ConcatenatedTzif<R> {
     /// This reads the header and will return an error if the header is
     /// invalid.
     pub(crate) fn open(rdr: R) -> Result<ConcatenatedTzif<R>, Error> {
-        let header = Header::read(&rdr)?;
+        let header = rtry!(Header::read(&rdr));
         Ok(ConcatenatedTzif { rdr, header })
     }
 
@@ -71,10 +71,11 @@ impl<R: Read> ConcatenatedTzif<R> {
         scratch2: &mut Vec<u8>,
     ) -> Result<Option<TimeZone>, Error> {
         scratch1.clear();
-        alloc(scratch1, self.header.index_len())?;
-        self.rdr
+        rtry!(alloc(scratch1, self.header.index_len()));
+        rtry!(self
+            .rdr
             .read_exact_at(scratch1, self.header.index_offset)
-            .context(E::FailedReadIndex)?;
+            .context(E::FailedReadIndex));
 
         let mut index = &**scratch1;
         while !index.is_empty() {
@@ -93,11 +94,12 @@ impl<R: Read> ConcatenatedTzif<R> {
             // `entry.name_bytes()` is itself valid UTF-8.
             let name = entry.name().unwrap();
             scratch2.clear();
-            alloc(scratch2, entry.len())?;
+            rtry!(alloc(scratch2, entry.len()));
             let start = self.header.data_offset.saturating_add(entry.start());
-            self.rdr
+            rtry!(self
+                .rdr
                 .read_exact_at(scratch2, start)
-                .context(E::FailedReadData)?;
+                .context(E::FailedReadData));
             return TimeZone::tzif(name, scratch2).map(Some);
         }
         Ok(None)
@@ -114,10 +116,11 @@ impl<R: Read> ConcatenatedTzif<R> {
         scratch: &mut Vec<u8>,
     ) -> Result<Vec<String>, Error> {
         scratch.clear();
-        alloc(scratch, self.header.index_len())?;
-        self.rdr
+        rtry!(alloc(scratch, self.header.index_len()));
+        rtry!(self
+            .rdr
             .read_exact_at(scratch, self.header.index_offset)
-            .context(E::FailedReadIndex)?;
+            .context(E::FailedReadIndex));
 
         let names_len = self.header.index_len() / IndexEntry::LEN;
         // Why are we careless with this alloc? Well, its size is proportional
@@ -130,7 +133,7 @@ impl<R: Read> ConcatenatedTzif<R> {
         while !index.is_empty() {
             let entry = IndexEntry::new(&index[..IndexEntry::LEN]);
             index = &index[IndexEntry::LEN..];
-            names.push(entry.name()?.to_string());
+            names.push(rtry!(entry.name()).to_string());
         }
         Ok(names)
     }
@@ -157,7 +160,7 @@ impl Header {
     fn read<R: Read + ?Sized>(rdr: &R) -> Result<Header, Error> {
         // 12 bytes plus 3 4-byte big endian integers.
         let mut buf = [0; 12 + 3 * 4];
-        rdr.read_exact_at(&mut buf, 0).context(E::FailedReadHeader)?;
+        rtry!(rdr.read_exact_at(&mut buf, 0).context(E::FailedReadHeader));
         if &buf[..6] != b"tzdata" {
             return Err(Error::from(E::ExpectedFirstSixBytes));
         }
@@ -362,10 +365,10 @@ impl Read for std::fs::File {
                 Ok(0) => break,
                 Ok(n) => {
                     buf = &mut buf[n..];
-                    offset = u64::try_from(n)
+                    offset = rtry!(u64::try_from(n)
                         .ok()
                         .and_then(|n| n.checked_add(offset))
-                        .ok_or(E::InvalidOffsetOverflowFile)?;
+                        .ok_or(E::InvalidOffsetOverflowFile));
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
                 Err(e) => return Err(Error::io(e)),
@@ -387,9 +390,10 @@ impl Read for std::fs::File {
     fn read_exact_at(&self, buf: &mut [u8], offset: u64) -> Result<(), Error> {
         use std::io::{Read as _, Seek as _, SeekFrom};
         let mut file = self;
-        file.seek(SeekFrom::Start(offset))
+        rtry!(file
+            .seek(SeekFrom::Start(offset))
             .map_err(Error::io)
-            .context(E::FailedSeek)?;
+            .context(E::FailedSeek));
         file.read_exact(buf).map_err(Error::io)
     }
 }

--- a/src/tz/concatenated.rs
+++ b/src/tz/concatenated.rs
@@ -365,10 +365,10 @@ impl Read for std::fs::File {
                 Ok(0) => break,
                 Ok(n) => {
                     buf = &mut buf[n..];
-                    offset = rtry!(u64::try_from(n)
+                    offset = u64::try_from(n)
                         .ok()
                         .and_then(|n| n.checked_add(offset))
-                        .ok_or(E::InvalidOffsetOverflowFile));
+                        .ok_or(E::InvalidOffsetOverflowFile)?;
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
                 Err(e) => return Err(Error::io(e)),

--- a/src/tz/db/bundled/enabled.rs
+++ b/src/tz/db/bundled/enabled.rs
@@ -20,7 +20,7 @@ impl Database {
         if let Some(tz) = special_time_zone(name) {
             return Some(tz);
         }
-        let (canonical_name, tzif) = rtry!(lookup(name));
+        let (canonical_name, tzif) = lookup(name)?;
         let tz = match TimeZone::tzif(canonical_name, tzif) {
             Ok(tz) => tz,
             Err(_err) => {

--- a/src/tz/db/bundled/enabled.rs
+++ b/src/tz/db/bundled/enabled.rs
@@ -20,7 +20,7 @@ impl Database {
         if let Some(tz) = special_time_zone(name) {
             return Some(tz);
         }
-        let (canonical_name, tzif) = lookup(name)?;
+        let (canonical_name, tzif) = rtry!(lookup(name));
         let tz = match TimeZone::tzif(canonical_name, tzif) {
             Ok(tz) => tz,
             Err(_err) => {

--- a/src/tz/db/concatenated/enabled.rs
+++ b/src/tz/db/concatenated/enabled.rs
@@ -70,7 +70,7 @@ impl Database {
     }
 
     pub(crate) fn from_path(path: &Path) -> Result<Database, Error> {
-        let names = Some(Names::new(path)?);
+        let names = Some(rtry!(Names::new(path)));
         let zones = RwLock::new(CachedZones::new());
         Ok(Database { path: Some(path.to_path_buf()), names, zones })
     }
@@ -203,11 +203,11 @@ impl Database {
 
 impl core::fmt::Debug for Database {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.write_str("Concatenated(")?;
+        rtry!(f.write_str("Concatenated("));
         if let Some(ref path) = self.path {
-            path.display().fmt(f)?;
+            rtry!(path.display().fmt(f));
         } else {
-            f.write_str("unavailable")?;
+            rtry!(f.write_str("unavailable"));
         }
         f.write_str(")")
     }
@@ -279,9 +279,10 @@ impl CachedTimeZone {
         scratch1: &mut Vec<u8>,
         scratch2: &mut Vec<u8>,
     ) -> Result<Option<CachedTimeZone>, Error> {
-        let file = File::open(path).map_err(|e| Error::io(e).path(path))?;
-        let db = ConcatenatedTzif::open(&file)?;
-        let Some(tz) = db.get(query, scratch1, scratch2)? else {
+        let file =
+            rtry!(File::open(path).map_err(|e| Error::io(e).path(path)));
+        let db = rtry!(ConcatenatedTzif::open(&file));
+        let Some(tz) = rtry!(db.get(query, scratch1, scratch2)) else {
             return Ok(None);
         };
         let last_modified = util::fs::last_modified_from_file(path, &file);
@@ -413,7 +414,8 @@ impl Names {
     fn new(path: &Path) -> Result<Names, Error> {
         let path = path.to_path_buf();
         let mut scratch = vec![];
-        let (names, version) = read_names_and_version(&path, &mut scratch)?;
+        let (names, version) =
+            rtry!(read_names_and_version(&path, &mut scratch));
         trace!(
             "found concatenated tzdata at {path} \
              with version {version} and {len} \
@@ -535,10 +537,10 @@ fn read_names_and_version(
     path: &Path,
     scratch: &mut Vec<u8>,
 ) -> Result<(Vec<Arc<str>>, ArrayStr<5>), Error> {
-    let file = File::open(path).map_err(|e| Error::io(e).path(path))?;
-    let db = ConcatenatedTzif::open(file)?;
+    let file = rtry!(File::open(path).map_err(|e| Error::io(e).path(path)));
+    let db = rtry!(ConcatenatedTzif::open(file));
     let names: Vec<Arc<str>> =
-        db.available(scratch)?.into_iter().map(Arc::from).collect();
+        rtry!(db.available(scratch)).into_iter().map(Arc::from).collect();
     if names.is_empty() {
         return Err(Error::from(E::ConcatenatedMissingIanaIdentifiers));
     }

--- a/src/tz/db/mod.rs
+++ b/src/tz/db/mod.rs
@@ -313,7 +313,7 @@ impl TimeZoneDatabase {
         path: P,
     ) -> Result<TimeZoneDatabase, Error> {
         let path = path.as_ref();
-        let db = zoneinfo::Database::from_dir(path)?;
+        let db = rtry!(zoneinfo::Database::from_dir(path));
         if db.is_definitively_empty() {
             warn!(
                 "could not find zoneinfo data at directory {path}",
@@ -351,7 +351,7 @@ impl TimeZoneDatabase {
         path: P,
     ) -> Result<TimeZoneDatabase, Error> {
         let path = path.as_ref();
-        let db = concatenated::Database::from_path(path)?;
+        let db = rtry!(concatenated::Database::from_path(path));
         if db.is_definitively_empty() {
             warn!(
                 "could not find concatenated tzdata in file {path}",
@@ -565,14 +565,14 @@ impl TimeZoneDatabase {
 
 impl core::fmt::Debug for TimeZoneDatabase {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.write_str("TimeZoneDatabase(")?;
+        rtry!(f.write_str("TimeZoneDatabase("));
         let Some(inner) = self.inner.as_deref() else {
             return f.write_str("unavailable)");
         };
         match *inner {
-            Kind::ZoneInfo(ref db) => core::fmt::Debug::fmt(db, f)?,
-            Kind::Concatenated(ref db) => core::fmt::Debug::fmt(db, f)?,
-            Kind::Bundled(ref db) => core::fmt::Debug::fmt(db, f)?,
+            Kind::ZoneInfo(ref db) => rtry!(core::fmt::Debug::fmt(db, f)),
+            Kind::Concatenated(ref db) => rtry!(core::fmt::Debug::fmt(db, f)),
+            Kind::Bundled(ref db) => rtry!(core::fmt::Debug::fmt(db, f)),
         }
         f.write_str(")")
     }

--- a/src/tz/db/zoneinfo/enabled.rs
+++ b/src/tz/db/zoneinfo/enabled.rs
@@ -81,7 +81,7 @@ impl Database {
     }
 
     pub(crate) fn from_dir(dir: &Path) -> Result<Database, Error> {
-        let names = Some(ZoneInfoNames::new(dir)?);
+        let names = Some(rtry!(ZoneInfoNames::new(dir)));
         let zones = RwLock::new(CachedZones::new());
         Ok(Database { dir: Some(dir.to_path_buf()), names, zones })
     }
@@ -204,11 +204,11 @@ impl Database {
 
 impl core::fmt::Debug for Database {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.write_str("ZoneInfo(")?;
+        rtry!(f.write_str("ZoneInfo("));
         if let Some(ref dir) = self.dir {
-            core::fmt::Display::fmt(&dir.display(), f)?;
+            rtry!(core::fmt::Display::fmt(&dir.display(), f));
         } else {
-            f.write_str("unavailable")?;
+            rtry!(f.write_str("unavailable"));
         }
         f.write_str(")")
     }
@@ -275,12 +275,13 @@ impl CachedTimeZone {
         ) -> Result<CachedTimeZone, Error> {
             let path = info.path();
             let mut file =
-                File::open(path).map_err(|e| Error::io(e).path(path))?;
+                rtry!(File::open(path).map_err(|e| Error::io(e).path(path)));
             let mut data = vec![];
-            file.read_to_end(&mut data)
-                .map_err(|e| Error::io(e).path(path))?;
-            let tz = TimeZone::tzif(&info.inner.original, &data)
-                .map_err(|e| e.path(path))?;
+            rtry!(file
+                .read_to_end(&mut data)
+                .map_err(|e| Error::io(e).path(path)));
+            let tz = rtry!(TimeZone::tzif(&info.inner.original, &data)
+                .map_err(|e| e.path(path)));
             let name = info.clone();
             let last_modified = util::fs::last_modified_from_file(path, &file);
             let expiration = Expiration::after(ttl);
@@ -416,7 +417,7 @@ impl ZoneInfoNames {
     /// If no names of time zones with corresponding TZif data files could be
     /// found in the given directory, then an error is returned.
     fn new(dir: &Path) -> Result<ZoneInfoNames, Error> {
-        let names = walk(dir)?;
+        let names = rtry!(walk(dir));
         let dir = dir.to_path_buf();
         let ttl = ZoneInfoNames::DEFAULT_TTL;
         let expiration = Expiration::after(ttl);
@@ -559,8 +560,8 @@ impl ZoneInfoName {
     /// suffix `time_zone_name` path was returned.
     fn new(base: &Path, time_zone_name: &Path) -> Result<ZoneInfoName, Error> {
         let full = base.join(time_zone_name);
-        let original = parse::os_str_utf8(time_zone_name.as_os_str())
-            .map_err(|err| Error::from(err).path(base))?;
+        let original = rtry!(parse::os_str_utf8(time_zone_name.as_os_str())
+            .map_err(|err| Error::from(err).path(base)));
         let lower = original.to_ascii_lowercase();
         let inner = ZoneInfoNameInner {
             full,

--- a/src/tz/offset.rs
+++ b/src/tz/offset.rs
@@ -639,8 +639,8 @@ impl Offset {
         self,
         duration: SignedDuration,
     ) -> Result<Offset, Error> {
-        let duration = b::OffsetTotalSeconds::check(duration.as_secs())
-            .context(E::OverflowAddSignedDuration)?;
+        let duration = rtry!(b::OffsetTotalSeconds::check(duration.as_secs())
+            .context(E::OverflowAddSignedDuration));
         Offset::from_seconds(duration + self.seconds())
     }
 
@@ -1387,7 +1387,7 @@ pub struct OffsetArithmetic {
 impl OffsetArithmetic {
     #[inline]
     fn checked_add(self, offset: Offset) -> Result<Offset, Error> {
-        match self.duration.to_signed()? {
+        match rtry!(self.duration.to_signed()) {
             SDuration::Span(span) => offset.checked_add_span(span),
             SDuration::Absolute(sdur) => offset.checked_add_duration(sdur),
         }
@@ -1395,7 +1395,7 @@ impl OffsetArithmetic {
 
     #[inline]
     fn checked_neg(self) -> Result<OffsetArithmetic, Error> {
-        let duration = self.duration.checked_neg()?;
+        let duration = rtry!(self.duration.checked_neg());
         Ok(OffsetArithmetic { duration })
     }
 
@@ -1597,11 +1597,12 @@ impl OffsetRound {
 
     /// Does the actual offset rounding.
     fn round(&self, offset: Offset) -> Result<Offset, Error> {
-        let increment = Increment::for_offset(self.smallest, self.increment)?;
+        let increment =
+            rtry!(Increment::for_offset(self.smallest, self.increment));
         // let rounded_sdur = SignedDuration::from(offset).round(self.0)?;
-        let rounded = increment
+        let rounded = rtry!(increment
             .round(self.mode, SignedDuration::from(offset))
-            .context(E::RoundOverflow)?;
+            .context(E::RoundOverflow));
         Offset::try_from(rounded)
             .map_err(|_| b::OffsetTotalSeconds::error())
             .context(E::RoundOverflow)

--- a/src/tz/posix.rs
+++ b/src/tz/posix.rs
@@ -136,7 +136,7 @@ impl core::fmt::Display for PosixTzEnv {
         match *self {
             PosixTzEnv::Rule(ref tz) => core::fmt::Display::fmt(tz, f),
             PosixTzEnv::Implementation(ref imp) => {
-                f.write_str(":")?;
+                rtry!(f.write_str(":"));
                 core::fmt::Display::fmt(imp, f)
             }
         }
@@ -209,9 +209,9 @@ impl PosixTimeZone<Abbreviation> {
         bytes: impl AsRef<[u8]>,
     ) -> Result<PosixTimeZoneOwned, Error> {
         let bytes = bytes.as_ref();
-        let inner = shared::PosixTimeZone::parse(bytes.as_ref())
+        let inner = rtry!(shared::PosixTimeZone::parse(bytes.as_ref())
             .map_err(Error::posix_tz)
-            .context(E::InvalidPosixTz)?;
+            .context(E::InvalidPosixTz));
         Ok(PosixTimeZone { inner })
     }
 
@@ -223,9 +223,9 @@ impl PosixTimeZone<Abbreviation> {
     ) -> Result<(PosixTimeZoneOwned, &'b [u8]), Error> {
         let bytes = bytes.as_ref();
         let (inner, remaining) =
-            shared::PosixTimeZone::parse_prefix(bytes.as_ref())
+            rtry!(shared::PosixTimeZone::parse_prefix(bytes.as_ref())
                 .map_err(Error::posix_tz)
-                .context(E::InvalidPosixTz)?;
+                .context(E::InvalidPosixTz));
         Ok((PosixTimeZone { inner }, remaining))
     }
 

--- a/src/tz/system/android.rs
+++ b/src/tz/system/android.rs
@@ -19,7 +19,7 @@ pub(super) fn get(db: &TimeZoneDatabase) -> Option<TimeZone> {
         // have already done so.
         return None;
     };
-    let tzname = getter.get(cstr(PROPERTY_NAME))?;
+    let tzname = rtry!(getter.get(cstr(PROPERTY_NAME)));
     let Some(tzname) = core::str::from_utf8(&tzname).ok() else {
         warn!(
             "found `{PROPERTY_NAME}` name `{name}` on Android, \
@@ -130,13 +130,14 @@ impl PropertyGetter {
 
         // SAFETY: Our `SystemPropertyFind` type definition matches what is
         // declared in `include/sys/system_properties.h` on Android.
-        let system_property_find: SystemPropertyFind =
-            unsafe { load_symbol(libc, cstr("__system_property_find\0"))? };
+        let system_property_find: SystemPropertyFind = unsafe {
+            rtry!(load_symbol(libc, cstr("__system_property_find\0")))
+        };
 
         // SAFETY: Our `SystemPropertyRead` type definition matches what is
         // declared in `include/sys/system_properties.h` on Android.
         let system_property_read: SystemPropertyRead = unsafe {
-            load_symbol(libc, cstr("__system_property_read_callback\0"))?
+            rtry!(load_symbol(libc, cstr("__system_property_read_callback\0")))
         };
 
         Some(PropertyGetter {

--- a/src/tz/system/android.rs
+++ b/src/tz/system/android.rs
@@ -19,7 +19,7 @@ pub(super) fn get(db: &TimeZoneDatabase) -> Option<TimeZone> {
         // have already done so.
         return None;
     };
-    let tzname = rtry!(getter.get(cstr(PROPERTY_NAME)));
+    let tzname = getter.get(cstr(PROPERTY_NAME))?;
     let Some(tzname) = core::str::from_utf8(&tzname).ok() else {
         warn!(
             "found `{PROPERTY_NAME}` name `{name}` on Android, \
@@ -130,14 +130,13 @@ impl PropertyGetter {
 
         // SAFETY: Our `SystemPropertyFind` type definition matches what is
         // declared in `include/sys/system_properties.h` on Android.
-        let system_property_find: SystemPropertyFind = unsafe {
-            rtry!(load_symbol(libc, cstr("__system_property_find\0")))
-        };
+        let system_property_find: SystemPropertyFind =
+            unsafe { load_symbol(libc, cstr("__system_property_find\0"))? };
 
         // SAFETY: Our `SystemPropertyRead` type definition matches what is
         // declared in `include/sys/system_properties.h` on Android.
         let system_property_read: SystemPropertyRead = unsafe {
-            rtry!(load_symbol(libc, cstr("__system_property_read_callback\0")))
+            load_symbol(libc, cstr("__system_property_read_callback\0"))?
         };
 
         Some(PropertyGetter {

--- a/src/tz/system/mod.rs
+++ b/src/tz/system/mod.rs
@@ -127,7 +127,7 @@ pub(crate) fn get(db: &TimeZoneDatabase) -> Result<TimeZone, Error> {
             }
         }
     }
-    let tz = get_force(db)?;
+    let tz = rtry!(get_force(db));
     {
         // It's okay that we race here. We basically assume that any
         // sufficiently close but approximately simultaneous detection of
@@ -278,10 +278,11 @@ fn get_env_tz(db: &TimeZoneDatabase) -> Result<Option<TimeZone>, Error> {
 /// perhaps have no other way to get a time zone name, we choose to support
 /// that use case. Although I cannot actually name such a platform...
 fn read_unnamed_tzif_file(path: &str) -> Result<TimeZone, Error> {
-    let data = std::fs::read(path)
+    let data = rtry!(std::fs::read(path)
         .map_err(Error::io)
-        .context(E::FailedUnnamedTzifRead)?;
-    let tz =
-        TimeZone::tzif_system(&data).context(E::FailedUnnamedTzifInvalid)?;
+        .context(E::FailedUnnamedTzifRead));
+    let tz = rtry!(
+        TimeZone::tzif_system(&data).context(E::FailedUnnamedTzifInvalid)
+    );
     Ok(tz)
 }

--- a/src/tz/system/windows/mod.rs
+++ b/src/tz/system/windows/mod.rs
@@ -111,12 +111,12 @@ fn get_tz_key_name() -> Result<String, Error> {
 fn nul_terminated_utf16_to_string(
     code_units: &[u16],
 ) -> Result<String, Error> {
-    let nul = rtry!(code_units
+    let nul = code_units
         .iter()
         .position(|&cu| cu == 0)
-        .ok_or(E::WindowsUtf16DecodeNul));
-    let string = rtry!(String::from_utf16(&code_units[..nul])
-        .map_err(|_| E::WindowsUtf16DecodeInvalid));
+        .ok_or(E::WindowsUtf16DecodeNul)?;
+    let string = String::from_utf16(&code_units[..nul])
+        .map_err(|_| E::WindowsUtf16DecodeInvalid)?;
     Ok(string)
 }
 

--- a/src/tz/system/windows/mod.rs
+++ b/src/tz/system/windows/mod.rs
@@ -102,20 +102,21 @@ fn get_tz_key_name() -> Result<String, Error> {
     // to unless it fails, and we check for failure above. So we're only here
     // when `info` is properly initialized.
     let info = unsafe { info.assume_init() };
-    let tz_key_name = nul_terminated_utf16_to_string(&info.TimeZoneKeyName)
-        .context(E::WindowsTimeZoneKeyName)?;
+    let tz_key_name =
+        rtry!(nul_terminated_utf16_to_string(&info.TimeZoneKeyName)
+            .context(E::WindowsTimeZoneKeyName));
     Ok(tz_key_name)
 }
 
 fn nul_terminated_utf16_to_string(
     code_units: &[u16],
 ) -> Result<String, Error> {
-    let nul = code_units
+    let nul = rtry!(code_units
         .iter()
         .position(|&cu| cu == 0)
-        .ok_or(E::WindowsUtf16DecodeNul)?;
-    let string = String::from_utf16(&code_units[..nul])
-        .map_err(|_| E::WindowsUtf16DecodeInvalid)?;
+        .ok_or(E::WindowsUtf16DecodeNul));
+    let string = rtry!(String::from_utf16(&code_units[..nul])
+        .map_err(|_| E::WindowsUtf16DecodeInvalid));
     Ok(string)
 }
 

--- a/src/tz/timezone.rs
+++ b/src/tz/timezone.rs
@@ -504,7 +504,7 @@ impl TimeZone {
     /// ```
     #[cfg(feature = "alloc")]
     pub fn posix(posix_tz_string: &str) -> Result<TimeZone, Error> {
-        let posix_tz = PosixTimeZoneOwned::parse(posix_tz_string)?;
+        let posix_tz = rtry!(PosixTimeZoneOwned::parse(posix_tz_string));
         Ok(TimeZone::from_posix_tz(posix_tz))
     }
 
@@ -538,7 +538,7 @@ impl TimeZone {
         use alloc::string::ToString;
 
         let name = name.to_string();
-        let tzif = crate::tz::tzif::Tzif::parse(Some(name), data)?;
+        let tzif = rtry!(crate::tz::tzif::Tzif::parse(Some(name), data));
         let repr = Repr::arc_tzif(Arc::new(tzif));
         Ok(TimeZone { repr })
     }
@@ -616,7 +616,7 @@ impl TimeZone {
     /// This returns an error if the given TZif data is invalid.
     #[cfg(feature = "tz-system")]
     pub(crate) fn tzif_system(data: &[u8]) -> Result<TimeZone, Error> {
-        let tzif = crate::tz::tzif::Tzif::parse(None, data)?;
+        let tzif = rtry!(crate::tz::tzif::Tzif::parse(None, data));
         let repr = Repr::arc_tzif(Arc::new(tzif));
         Ok(TimeZone { repr })
     }

--- a/src/tz/tzif.rs
+++ b/src/tz/tzif.rs
@@ -157,7 +157,8 @@ impl TzifOwned {
         name: Option<String>,
         bytes: &[u8],
     ) -> Result<Self, Error> {
-        let sh = shared::TzifOwned::parse(name, bytes).map_err(Error::tzif)?;
+        let sh =
+            rtry!(shared::TzifOwned::parse(name, bytes).map_err(Error::tzif));
         Ok(TzifOwned::from_shared_owned(sh))
     }
 
@@ -710,8 +711,9 @@ mod tests {
         let Ok(val) = val.into_string() else {
             anyhow::bail!("{ENV} has invalid UTF-8")
         };
-        let bytes =
-            std::fs::read(&val).with_context(|| alloc::format!("{val:?}"))?;
+        let bytes = rtry!(
+            std::fs::read(&val).with_context(|| alloc::format!("{val:?}"))
+        );
         let tzif = Tzif::parse(Some(val.to_string()), &bytes)?;
         std::eprint!("{}", tzif_to_human_readable(&tzif));
         Ok(())

--- a/src/tz/zic.rs
+++ b/src/tz/zic.rs
@@ -203,12 +203,12 @@ impl Rules {
                 "every name in rule group must be identical"
             );
             let dst = Dst::from(r.save.suffix() == RuleSaveSuffixP::Dst);
-            let offset = r.save.to_offset().with_context(|| {
+            let offset = rtry!(r.save.to_offset().with_context(|| {
                 E::FailedRule { name: inner.name.as_str().into() }
-            })?;
-            let years = r.years().with_context(|| E::FailedRule {
+            }));
+            let years = rtry!(r.years().with_context(|| E::FailedRule {
                 name: inner.name.as_str().into(),
-            })?;
+            }));
             let month = r.inn.month;
             let letters = r.letters.part;
             let day = r.on;
@@ -248,7 +248,7 @@ impl ZicP {
     /// Parse the zic data given into this zic value. If the data given isn't
     /// valid UTF-8, then this returns an error.
     fn parse_bytes(&mut self, src: &[u8]) -> Result<(), Error> {
-        self.parse_with_fields(FieldParser::from_bytes(src)?)
+        self.parse_with_fields(rtry!(FieldParser::from_bytes(src)))
     }
 
     /// Parse the zic data from the given field parser.
@@ -256,9 +256,10 @@ impl ZicP {
         &mut self,
         mut parser: FieldParser<'_>,
     ) -> Result<(), Error> {
-        while parser.read_next_fields()? {
-            self.parse_one(&mut parser)
-                .context(E::Line { number: parser.line_number })?;
+        while rtry!(parser.read_next_fields()) {
+            rtry!(self
+                .parse_one(&mut parser)
+                .context(E::Line { number: parser.line_number }));
         }
         if let Some(ref name) = parser.continuation_zone_for {
             return Err(Error::from(E::ExpectedContinuationZoneLine {
@@ -274,8 +275,8 @@ impl ZicP {
         assert!(!p.fields.is_empty());
 
         if let Some(name) = p.continuation_zone_for.take() {
-            let zone = ZoneContinuationP::parse(&p.fields)
-                .context(E::FailedContinuationZone)?;
+            let zone = rtry!(ZoneContinuationP::parse(&p.fields)
+                .context(E::FailedContinuationZone));
             let more_continuations = zone.until.is_some();
             // OK because `p.continuation_zone_for` is only set when we have
             // seen a first zone with the corresponding name.
@@ -289,11 +290,12 @@ impl ZicP {
 
         let (first, rest) = (&p.fields[0], &p.fields[1..]);
         if first.starts_with("R") && "Rule".starts_with(first) {
-            let rule = RuleP::parse(rest).context(E::FailedRuleLine)?;
+            let rule = rtry!(RuleP::parse(rest).context(E::FailedRuleLine));
             let name = rule.name.name.clone();
             self.rules.entry(name).or_default().push(rule);
         } else if first.starts_with("Z") && "Zone".starts_with(first) {
-            let first = ZoneFirstP::parse(rest).context(E::FailedZoneFirst)?;
+            let first =
+                rtry!(ZoneFirstP::parse(rest).context(E::FailedZoneFirst));
             let name = first.name.name.clone();
             if first.until.is_some() {
                 p.continuation_zone_for = Some(name.clone());
@@ -310,7 +312,7 @@ impl ZicP {
                 }));
             }
         } else if first.starts_with("L") && "Link".starts_with(first) {
-            let link = LinkP::parse(rest).context(E::FailedLinkLine)?;
+            let link = rtry!(LinkP::parse(rest).context(E::FailedLinkLine));
             let name = link.name.name.clone();
             if self.zones.contains_key(&name) {
                 return Err(Error::from(E::DuplicateLinkZone {
@@ -373,23 +375,26 @@ impl RuleP {
         let (save_field, fields) = (fields[0], &fields[1..]);
         let letters_field = fields[0];
 
-        let name = name_field
+        let name = rtry!(name_field
             .parse::<RuleNameP>()
-            .context(E::FailedParseFieldName)?;
-        let from = from_field
+            .context(E::FailedParseFieldName));
+        let from = rtry!(from_field
             .parse::<RuleFromP>()
-            .context(E::FailedParseFieldFrom)?;
-        let to = to_field.parse::<RuleToP>().context(E::FailedParseFieldTo)?;
+            .context(E::FailedParseFieldFrom));
+        let to =
+            rtry!(to_field.parse::<RuleToP>().context(E::FailedParseFieldTo));
         let inn =
-            in_field.parse::<RuleInP>().context(E::FailedParseFieldIn)?;
-        let on = on_field.parse::<RuleOnP>().context(E::FailedParseFieldOn)?;
-        let at = at_field.parse::<RuleAtP>().context(E::FailedParseFieldAt)?;
-        let save = save_field
+            rtry!(in_field.parse::<RuleInP>().context(E::FailedParseFieldIn));
+        let on =
+            rtry!(on_field.parse::<RuleOnP>().context(E::FailedParseFieldOn));
+        let at =
+            rtry!(at_field.parse::<RuleAtP>().context(E::FailedParseFieldAt));
+        let save = rtry!(save_field
             .parse::<RuleSaveP>()
-            .context(E::FailedParseFieldSave)?;
-        let letters = letters_field
+            .context(E::FailedParseFieldSave));
+        let letters = rtry!(letters_field
             .parse::<RuleLettersP>()
-            .context(E::FailedParseFieldLetters)?;
+            .context(E::FailedParseFieldLetters));
 
         Ok(RuleP { name, from, to, inn, on, at, save, letters })
     }
@@ -451,22 +456,24 @@ impl ZoneFirstP {
         let (stdoff_field, fields) = (fields[0], &fields[1..]);
         let (rules_field, fields) = (fields[0], &fields[1..]);
         let (format_field, fields) = (fields[0], &fields[1..]);
-        let name = name_field
+        let name = rtry!(name_field
             .parse::<ZoneNameP>()
-            .context(E::FailedParseFieldName)?;
-        let stdoff = stdoff_field
+            .context(E::FailedParseFieldName));
+        let stdoff = rtry!(stdoff_field
             .parse::<ZoneStdoffP>()
-            .context(E::FailedParseFieldStdOff)?;
-        let rules = rules_field
+            .context(E::FailedParseFieldStdOff));
+        let rules = rtry!(rules_field
             .parse::<ZoneRulesP>()
-            .context(E::FailedParseFieldRules)?;
-        let format = format_field
+            .context(E::FailedParseFieldRules));
+        let format = rtry!(format_field
             .parse::<ZoneFormatP>()
-            .context(E::FailedParseFieldFormat)?;
+            .context(E::FailedParseFieldFormat));
         let until = if fields.is_empty() {
             None
         } else {
-            Some(ZoneUntilP::parse(fields).context(E::FailedParseFieldUntil)?)
+            Some(rtry!(
+                ZoneUntilP::parse(fields).context(E::FailedParseFieldUntil)
+            ))
         };
         Ok(ZoneFirstP { name, stdoff, rules, format, until })
     }
@@ -497,19 +504,21 @@ impl ZoneContinuationP {
         let (stdoff_field, fields) = (fields[0], &fields[1..]);
         let (rules_field, fields) = (fields[0], &fields[1..]);
         let (format_field, fields) = (fields[0], &fields[1..]);
-        let stdoff = stdoff_field
+        let stdoff = rtry!(stdoff_field
             .parse::<ZoneStdoffP>()
-            .context(E::FailedParseFieldStdOff)?;
-        let rules = rules_field
+            .context(E::FailedParseFieldStdOff));
+        let rules = rtry!(rules_field
             .parse::<ZoneRulesP>()
-            .context(E::FailedParseFieldRules)?;
-        let format = format_field
+            .context(E::FailedParseFieldRules));
+        let format = rtry!(format_field
             .parse::<ZoneFormatP>()
-            .context(E::FailedParseFieldFormat)?;
+            .context(E::FailedParseFieldFormat));
         let until = if fields.is_empty() {
             None
         } else {
-            Some(ZoneUntilP::parse(fields).context(E::FailedParseFieldUntil)?)
+            Some(rtry!(
+                ZoneUntilP::parse(fields).context(E::FailedParseFieldUntil)
+            ))
         };
         Ok(ZoneContinuationP { stdoff, rules, format, until })
     }
@@ -530,12 +539,12 @@ impl LinkP {
         if fields.len() != 2 {
             return Err(Error::from(E::ExpectedLinkTwoFields));
         }
-        let target = fields[0]
+        let target = rtry!(fields[0]
             .parse::<ZoneNameP>()
-            .context(E::FailedParseFieldLinkTarget)?;
-        let name = fields[1]
+            .context(E::FailedParseFieldLinkTarget));
+        let name = rtry!(fields[1]
             .parse::<ZoneNameP>()
-            .context(E::FailedParseFieldLinkName)?;
+            .context(E::FailedParseFieldLinkName));
         Ok(LinkP { target, name })
     }
 }
@@ -583,7 +592,7 @@ impl FromStr for RuleFromP {
     type Err = Error;
 
     fn from_str(from: &str) -> Result<RuleFromP, Error> {
-        let year = parse_year(from).context(E::FailedParseFieldFrom)?;
+        let year = rtry!(parse_year(from).context(E::FailedParseFieldFrom));
         Ok(RuleFromP { year })
     }
 }
@@ -610,7 +619,7 @@ impl FromStr for RuleToP {
         } else if to.starts_with("o") && "only".starts_with(to) {
             Ok(RuleToP::Only)
         } else {
-            let year = parse_year(to).context(E::FailedParseFieldTo)?;
+            let year = rtry!(parse_year(to).context(E::FailedParseFieldTo));
             Ok(RuleToP::Year { year })
         }
     }
@@ -675,14 +684,16 @@ impl RuleOnP {
             }
             RuleOnP::OnOrBefore { weekday, day } => {
                 let start =
-                    Date::new(year, month, day)?.checked_add(1.day())?;
+                    rtry!(rtry!(Date::new(year, month, day))
+                        .checked_add(1.day()));
                 // nth_weekday returns "before" instead of "on or before," so
                 // offset the date by a day to get "on or before" semantics.
                 start.nth_weekday(-1, weekday)
             }
             RuleOnP::OnOrAfter { weekday, day } => {
                 let start =
-                    Date::new(year, month, day)?.checked_sub(1.day())?;
+                    rtry!(rtry!(Date::new(year, month, day))
+                        .checked_sub(1.day()));
                 // nth_weekday returns "after" instead of "on or after," so
                 // offset the date by a day to get "on or after" semantics.
                 start.nth_weekday(1, weekday)
@@ -696,18 +707,18 @@ impl FromStr for RuleOnP {
 
     fn from_str(field: &str) -> Result<RuleOnP, Error> {
         if field.starts_with("last") {
-            let weekday = parse_weekday(&field[4..])?;
+            let weekday = rtry!(parse_weekday(&field[4..]));
             Ok(RuleOnP::Last { weekday })
         } else if let Some(i) = field.find("<=") {
-            let weekday = parse_weekday(&field[..i])?;
-            let day = parse_day(&field[i + 2..])?;
+            let weekday = rtry!(parse_weekday(&field[..i]));
+            let day = rtry!(parse_day(&field[i + 2..]));
             Ok(RuleOnP::OnOrBefore { weekday, day })
         } else if let Some(i) = field.find(">=") {
-            let weekday = parse_weekday(&field[..i])?;
-            let day = parse_day(&field[i + 2..])?;
+            let weekday = rtry!(parse_weekday(&field[..i]));
+            let day = rtry!(parse_day(&field[i + 2..]));
             Ok(RuleOnP::OnOrAfter { weekday, day })
         } else if field.chars().all(|ch| ch.is_ascii_digit()) {
-            let day = parse_day(field)?;
+            let day = rtry!(parse_day(field));
             // We don't check that `day` is valid for the month given in the IN
             // field. That gets checked at a higher level.
             Ok(RuleOnP::Day { day })
@@ -751,11 +762,11 @@ impl FromStr for RuleAtP {
         }
         let (span_string, suffix_string) = at.split_at(at.len() - 1);
         if suffix_string.chars().all(|ch| ch.is_ascii_alphabetic()) {
-            let span = parse_duration(span_string)?;
-            let suffix = suffix_string.parse()?;
+            let span = rtry!(parse_duration(span_string));
+            let suffix = rtry!(suffix_string.parse());
             Ok(RuleAtP { dur: span, suffix: Some(suffix) })
         } else {
-            let span = parse_duration(at)?;
+            let span = rtry!(parse_duration(at));
             Ok(RuleAtP { dur: span, suffix: None })
         }
     }
@@ -829,11 +840,11 @@ impl FromStr for RuleSaveP {
         }
         let (span_string, suffix_string) = at.split_at(at.len() - 1);
         if suffix_string.chars().all(|ch| ch.is_ascii_alphabetic()) {
-            let span = parse_duration(span_string)?;
-            let suffix = suffix_string.parse()?;
+            let span = rtry!(parse_duration(span_string));
+            let suffix = rtry!(suffix_string.parse());
             Ok(RuleSaveP { dur: span, suffix: Some(suffix) })
         } else {
-            let span = parse_duration(at)?;
+            let span = rtry!(parse_duration(at));
             Ok(RuleSaveP { dur: span, suffix: None })
         }
     }
@@ -921,7 +932,7 @@ impl FromStr for ZoneStdoffP {
     type Err = Error;
 
     fn from_str(stdoff: &str) -> Result<ZoneStdoffP, Error> {
-        let dur = parse_duration(stdoff)?;
+        let dur = rtry!(parse_duration(stdoff));
         Ok(ZoneStdoffP { dur })
     }
 }
@@ -949,10 +960,10 @@ impl FromStr for ZoneRulesP {
             if rules == "-" {
                 Ok(ZoneRulesP::None)
             } else {
-                Ok(ZoneRulesP::Save(rules.parse()?))
+                Ok(ZoneRulesP::Save(rtry!(rules.parse())))
             }
         } else {
-            Ok(ZoneRulesP::Named(rules.parse()?))
+            Ok(ZoneRulesP::Named(rtry!(rules.parse())))
         }
     }
 }
@@ -1005,16 +1016,16 @@ impl FromStr for ZoneFormatP {
             Ok(ZoneFormatP::Offset)
         } else if let Some((before, after)) = format.split_once("%s") {
             Ok(ZoneFormatP::Variable {
-                before: check_abbrev(before)?,
-                after: check_abbrev(after)?,
+                before: rtry!(check_abbrev(before)),
+                after: rtry!(check_abbrev(after)),
             })
         } else if let Some((std, dst)) = format.split_once("/") {
             Ok(ZoneFormatP::Pair {
-                std: check_abbrev(std)?,
-                dst: check_abbrev(dst)?,
+                std: rtry!(check_abbrev(std)),
+                dst: rtry!(check_abbrev(dst)),
             })
         } else {
-            Ok(ZoneFormatP::Static { format: check_abbrev(format)? })
+            Ok(ZoneFormatP::Static { format: rtry!(check_abbrev(format)) })
         }
     }
 }
@@ -1055,28 +1066,29 @@ impl ZoneUntilP {
         }
 
         let (year_field, fields) = (fields[0], &fields[1..]);
-        let year = parse_year(year_field).context(E::FailedParseYear)?;
+        let year = rtry!(parse_year(year_field).context(E::FailedParseYear));
         if fields.is_empty() {
             return Ok(ZoneUntilP::Year { year });
         }
 
         let (month_field, fields) = (fields[0], &fields[1..]);
         let month =
-            month_field.parse::<RuleInP>().context(E::FailedParseMonth)?;
+            rtry!(month_field.parse::<RuleInP>().context(E::FailedParseMonth));
         if fields.is_empty() {
             return Ok(ZoneUntilP::YearMonth { year, month });
         }
 
         let (day_field, fields) = (fields[0], &fields[1..]);
-        let day = day_field.parse::<RuleOnP>().context(E::FailedParseDay)?;
+        let day =
+            rtry!(day_field.parse::<RuleOnP>().context(E::FailedParseDay));
         if fields.is_empty() {
             return Ok(ZoneUntilP::YearMonthDay { year, month, day });
         }
 
         let (duration_field, fields) = (fields[0], &fields[1..]);
-        let duration = duration_field
+        let duration = rtry!(duration_field
             .parse::<RuleAtP>()
-            .context(E::FailedParseTimeDuration)?;
+            .context(E::FailedParseTimeDuration));
         if !fields.is_empty() {
             return Err(Error::from(E::ExpectedNothingAfterTime));
         }
@@ -1084,9 +1096,10 @@ impl ZoneUntilP {
     }
 
     fn to_datetime(&self) -> Result<DateTime, Error> {
-        let date = self.on().date(self.year(), self.month())?;
-        let dt =
-            date.to_datetime(Time::midnight()).checked_add(self.at().dur)?;
+        let date = rtry!(self.on().date(self.year(), self.month()));
+        let dt = rtry!(date
+            .to_datetime(Time::midnight())
+            .checked_add(self.at().dur));
         Ok(dt)
     }
 
@@ -1142,7 +1155,8 @@ fn parse_year(year: &str) -> Result<i16, Error> {
     } else {
         (b::Sign::Positive, year)
     };
-    let year = b::Year::parse(rest.as_bytes()).context(E::FailedParseYear)?;
+    let year =
+        rtry!(b::Year::parse(rest.as_bytes()).context(E::FailedParseYear));
     Ok(sign * year)
 }
 
@@ -1181,8 +1195,8 @@ fn parse_duration(span: &str) -> Result<SignedDuration, Error> {
     if hour_digits.is_empty() {
         return Err(Error::from(E::ExpectedTimeOneHour));
     }
-    let hours = b::SpanHours::parse(hour_digits.as_bytes())
-        .context(E::FailedParseHour)?;
+    let hours = rtry!(b::SpanHours::parse(hour_digits.as_bytes())
+        .context(E::FailedParseHour));
     dur += SignedDuration::from_hours(sign * i64::from(hours));
     if rest.is_empty() {
         return Ok(dur);
@@ -1198,8 +1212,8 @@ fn parse_duration(span: &str) -> Result<SignedDuration, Error> {
     if minute_digits.is_empty() {
         return Err(Error::from(E::ExpectedMinuteAfterHours));
     }
-    let minutes = b::Minute::parse(minute_digits.as_bytes())
-        .context(E::FailedParseMinute)?;
+    let minutes = rtry!(b::Minute::parse(minute_digits.as_bytes())
+        .context(E::FailedParseMinute));
     dur += SignedDuration::from_mins(sign * i64::from(minutes));
     if rest.is_empty() {
         return Ok(dur);
@@ -1215,8 +1229,8 @@ fn parse_duration(span: &str) -> Result<SignedDuration, Error> {
     if second_digits.is_empty() {
         return Err(Error::from(E::ExpectedSecondAfterMinutes));
     }
-    let seconds = b::Second::parse(second_digits.as_bytes())
-        .context(E::FailedParseSecond)?;
+    let seconds = rtry!(b::Second::parse(second_digits.as_bytes())
+        .context(E::FailedParseSecond));
     dur += SignedDuration::from_secs(sign * i64::from(seconds));
     if rest.is_empty() {
         return Ok(dur);
@@ -1233,8 +1247,8 @@ fn parse_duration(span: &str) -> Result<SignedDuration, Error> {
     if nanosecond_digits.is_empty() {
         return Err(Error::from(E::ExpectedNanosecondDigits));
     }
-    let nanoseconds = parse::fraction(nanosecond_digits.as_bytes())
-        .context(E::FailedParseNanosecond)?;
+    let nanoseconds = rtry!(parse::fraction(nanosecond_digits.as_bytes())
+        .context(E::FailedParseNanosecond));
     // OK because `parse::fraction` can't return anything more than
     // `999_999_999` nanoseconds.
     dur += SignedDuration::from_nanos(sign * i64::from(nanoseconds));
@@ -1305,8 +1319,9 @@ impl<'a> FieldParser<'a> {
     ///
     /// This returns an error if the given bytes are not valid UTF-8.
     fn from_bytes(src: &'a [u8]) -> Result<FieldParser<'a>, Error> {
-        let src = core::str::from_utf8(src)
-            .map_err(|_| Error::from(E::InvalidUtf8))?;
+        let src =
+            rtry!(core::str::from_utf8(src)
+                .map_err(|_| Error::from(E::InvalidUtf8)));
         Ok(FieldParser::new(src))
     }
 
@@ -1324,8 +1339,8 @@ impl<'a> FieldParser<'a> {
             let Some(line) = self.lines.next() else { return Ok(false) };
             self.line_number =
                 self.line_number.checked_add(1).ok_or(E::LineOverflow)?;
-            parse_fields(&line, &mut self.fields)
-                .context(E::Line { number: self.line_number })?;
+            rtry!(parse_fields(&line, &mut self.fields)
+                .context(E::Line { number: self.line_number }));
             if self.fields.is_empty() {
                 continue;
             }

--- a/src/util/b.rs
+++ b/src/util/b.rs
@@ -548,7 +548,7 @@ pub(crate) trait Bounds: Sized {
         n1: Self::Primitive,
         n2: Self::Primitive,
     ) -> Result<Self::Primitive, BoundsError> {
-        Self::check_self(n1.checked_add(n2).ok_or_else(Self::error)?)
+        Self::check_self(rtry!(n1.checked_add(n2).ok_or_else(Self::error)))
     }
 
     /// Performs checked subtraction using this boundary type's primitive
@@ -563,7 +563,7 @@ pub(crate) trait Bounds: Sized {
         n1: Self::Primitive,
         n2: Self::Primitive,
     ) -> Result<Self::Primitive, BoundsError> {
-        Self::check_self(n1.checked_sub(n2).ok_or_else(Self::error)?)
+        Self::check_self(rtry!(n1.checked_sub(n2).ok_or_else(Self::error)))
     }
 
     /// Performs checked multiplication using this boundary type's primitive
@@ -578,7 +578,7 @@ pub(crate) trait Bounds: Sized {
         n1: Self::Primitive,
         n2: Self::Primitive,
     ) -> Result<Self::Primitive, BoundsError> {
-        Self::check_self(n1.checked_mul(n2).ok_or_else(Self::error)?)
+        Self::check_self(rtry!(n1.checked_mul(n2).ok_or_else(Self::error)))
     }
 }
 

--- a/src/util/escape.rs
+++ b/src/util/escape.rs
@@ -38,9 +38,9 @@ impl core::fmt::Display for Byte {
 impl core::fmt::Debug for Byte {
     #[inline(never)]
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.write_str("\"")?;
-        core::fmt::Display::fmt(self, f)?;
-        f.write_str("\"")?;
+        rtry!(f.write_str("\""));
+        rtry!(core::fmt::Display::fmt(self, f));
+        rtry!(f.write_str("\""));
         Ok(())
     }
 }
@@ -63,19 +63,22 @@ impl<'a> core::fmt::Display for Bytes<'a> {
                 Ok(ch) => ch,
                 Err(err) => {
                     // The decode API guarantees `errant_bytes` is non-empty.
-                    write!(f, r"\x{:02x}", err.as_slice()[0])?;
+                    rtry!(write!(f, r"\x{:02x}", err.as_slice()[0]));
                     bytes = &bytes[1..];
                     continue;
                 }
             };
             bytes = &bytes[ch.len_utf8()..];
             match ch {
-                '\0' => f.write_str(r"\0")?,
+                '\0' => rtry!(f.write_str(r"\0")),
                 '\x01'..='\x7f' => {
-                    core::fmt::Display::fmt(&(ch as u8).escape_ascii(), f)?;
+                    rtry!(core::fmt::Display::fmt(
+                        &(ch as u8).escape_ascii(),
+                        f
+                    ));
                 }
                 _ => {
-                    core::fmt::Display::fmt(&ch.escape_debug(), f)?;
+                    rtry!(core::fmt::Display::fmt(&ch.escape_debug(), f));
                 }
             }
         }
@@ -86,9 +89,9 @@ impl<'a> core::fmt::Display for Bytes<'a> {
 impl<'a> core::fmt::Debug for Bytes<'a> {
     #[inline(never)]
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.write_str("\"")?;
-        core::fmt::Display::fmt(self, f)?;
-        f.write_str("\"")?;
+        rtry!(f.write_str("\""));
+        rtry!(core::fmt::Display::fmt(self, f));
+        rtry!(f.write_str("\""));
         Ok(())
     }
 }
@@ -107,7 +110,7 @@ impl core::fmt::Display for RepeatByte {
     #[inline(never)]
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         for _ in 0..self.count {
-            core::fmt::Display::fmt(&Byte(self.byte), f)?;
+            rtry!(core::fmt::Display::fmt(&Byte(self.byte), f));
         }
         Ok(())
     }
@@ -116,9 +119,9 @@ impl core::fmt::Display for RepeatByte {
 impl core::fmt::Debug for RepeatByte {
     #[inline(never)]
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.write_str("\"")?;
-        core::fmt::Display::fmt(self, f)?;
-        f.write_str("\"")?;
+        rtry!(f.write_str("\""));
+        rtry!(core::fmt::Display::fmt(self, f));
+        rtry!(f.write_str("\""));
         Ok(())
     }
 }

--- a/src/util/parse.rs
+++ b/src/util/parse.rs
@@ -20,10 +20,10 @@ pub(crate) fn i64(bytes: &[u8]) -> Result<i64, ParseIntError> {
             return Err(ParseIntError::InvalidDigit(byte));
         }
         let digit = i64::from(byte - b'0');
-        n = n
+        n = rtry!(n
             .checked_mul(10)
             .and_then(|n| n.checked_add(digit))
-            .ok_or(ParseIntError::TooBig)?;
+            .ok_or(ParseIntError::TooBig));
     }
     Ok(n)
 }
@@ -60,10 +60,10 @@ pub(crate) fn u64_prefix(
         digit_count += 1;
         // OK because we confirmed `byte` is an ASCII digit.
         let digit = u64::from(byte - b'0');
-        n = n
+        n = rtry!(n
             .checked_mul(10)
             .and_then(|n| n.checked_add(digit))
-            .ok_or(ParseIntError::TooBig)?;
+            .ok_or(ParseIntError::TooBig));
     }
     if digit_count == 0 {
         return Ok((None, bytes));
@@ -101,13 +101,13 @@ pub(crate) fn fraction(bytes: &[u8]) -> Result<u32, ParseFractionError> {
                 u32::from(digit)
             }
         };
-        n = n
+        n = rtry!(n
             .checked_mul(10)
             .and_then(|n| n.checked_add(digit))
-            .ok_or_else(|| ParseFractionError::TooBig)?;
+            .ok_or_else(|| ParseFractionError::TooBig));
     }
     for _ in bytes.len()..ParseFractionError::MAX_PRECISION {
-        n = n.checked_mul(10).ok_or_else(|| ParseFractionError::TooBig)?;
+        n = rtry!(n.checked_mul(10).ok_or_else(|| ParseFractionError::TooBig));
     }
     Ok(n)
 }
@@ -155,7 +155,7 @@ where
         // that's important, we can add a new API that returns a `&str`. But it
         // probably won't matter because an `OsStr` in this crate is usually
         // just an environment variable.
-        Ok(os_str_utf8(os_str)?.as_bytes())
+        Ok(rtry!(os_str_utf8(os_str)).as_bytes())
     }
 }
 

--- a/src/util/round.rs
+++ b/src/util/round.rs
@@ -62,8 +62,8 @@ impl Increment {
         } else {
             // For calendar units, just verify that the increment is in the
             // correct range.
-            let value = b::Increment32::check(value)
-                .context(RoundingIncrementError::ForSpan)?;
+            let value = rtry!(b::Increment32::check(value)
+                .context(RoundingIncrementError::ForSpan));
             Ok(Increment { unit, value })
         }
     }
@@ -81,8 +81,8 @@ impl Increment {
         }
 
         // For signed durations, we allow any increment that is within range.
-        let value = b::Increment32::check(value)
-            .context(RoundingIncrementError::ForSignedDuration)?;
+        let value = rtry!(b::Increment32::check(value)
+            .context(RoundingIncrementError::ForSignedDuration));
         Ok(Increment { unit, value })
     }
 
@@ -99,8 +99,8 @@ impl Increment {
         }
 
         // For time zone offsets, we allow any increment that is within range.
-        let value = b::Increment32::check(value)
-            .context(RoundingIncrementError::ForOffset)?;
+        let value = rtry!(b::Increment32::check(value)
+            .context(RoundingIncrementError::ForOffset));
         Ok(Increment { unit, value })
     }
 

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -643,7 +643,7 @@ impl Zoned {
     /// ```
     #[inline]
     pub fn in_tz(&self, name: &str) -> Result<Zoned, Error> {
-        let tz = crate::tz::db().get(name)?;
+        let tz = rtry!(crate::tz::db().get(name));
         Ok(self.with_time_zone(tz))
     }
 
@@ -1503,7 +1503,7 @@ impl Zoned {
     /// ```
     #[inline]
     pub fn tomorrow(&self) -> Result<Zoned, Error> {
-        self.datetime().tomorrow()?.to_zoned(self.time_zone().clone())
+        rtry!(self.datetime().tomorrow()).to_zoned(self.time_zone().clone())
     }
 
     /// Returns the zoned datetime with a date immediately preceding this one.
@@ -1561,7 +1561,7 @@ impl Zoned {
     /// ```
     #[inline]
     pub fn yesterday(&self) -> Result<Zoned, Error> {
-        self.datetime().yesterday()?.to_zoned(self.time_zone().clone())
+        rtry!(self.datetime().yesterday()).to_zoned(self.time_zone().clone())
     }
 
     /// Returns the "nth" weekday from the beginning or end of the month in
@@ -1660,8 +1660,7 @@ impl Zoned {
         nth: i8,
         weekday: Weekday,
     ) -> Result<Zoned, Error> {
-        self.datetime()
-            .nth_weekday_of_month(nth, weekday)?
+        rtry!(self.datetime().nth_weekday_of_month(nth, weekday))
             .to_zoned(self.time_zone().clone())
     }
 
@@ -1846,8 +1845,7 @@ impl Zoned {
         nth: i32,
         weekday: Weekday,
     ) -> Result<Zoned, Error> {
-        self.datetime()
-            .nth_weekday(nth, weekday)?
+        rtry!(self.datetime().nth_weekday(nth, weekday))
             .to_zoned(self.time_zone().clone())
     }
 
@@ -2245,17 +2243,17 @@ impl Zoned {
                 .context(E::AddTimestamp);
         }
         let span_time = span.only_time();
-        let dt = self
+        let dt = rtry!(self
             .datetime()
             .checked_add(span_calendar)
-            .context(E::AddDateTime)?;
+            .context(E::AddDateTime));
 
         let tz = self.inner.time_zone;
-        let mut ts = tz
+        let mut ts = rtry!(tz
             .to_ambiguous_timestamp(dt)
             .compatible()
-            .context(E::ConvertDateTimeToTimestamp)?;
-        ts = ts.checked_add(span_time).context(E::AddTimestamp)?;
+            .context(E::ConvertDateTimeToTimestamp));
+        ts = rtry!(ts.checked_add(span_time).context(E::AddTimestamp));
         Ok(ts.to_zoned(tz))
     }
 
@@ -2574,7 +2572,7 @@ impl Zoned {
         other: A,
     ) -> Result<Span, Error> {
         let args: ZonedDifference = other.into();
-        let span = args.until_with_largest_unit(self)?;
+        let span = rtry!(args.until_with_largest_unit(self));
         if args.rounding_may_change_span() {
             span.round(args.round.relative(self))
         } else {
@@ -2613,7 +2611,7 @@ impl Zoned {
         other: A,
     ) -> Result<Span, Error> {
         let args: ZonedDifference = other.into();
-        let span = -args.until_with_largest_unit(self)?;
+        let span = -rtry!(args.until_with_largest_unit(self));
         if args.rounding_may_change_span() {
             span.round(args.round.relative(self))
         } else {
@@ -3519,7 +3517,7 @@ impl TryFrom<std::time::SystemTime> for Zoned {
 
     #[inline]
     fn try_from(system_time: std::time::SystemTime) -> Result<Zoned, Error> {
-        let timestamp = Timestamp::try_from(system_time)?;
+        let timestamp = rtry!(Timestamp::try_from(system_time));
         Ok(Zoned::new(timestamp, TimeZone::system()))
     }
 }
@@ -4034,7 +4032,7 @@ pub struct ZonedArithmetic {
 impl ZonedArithmetic {
     #[inline]
     fn checked_add(self, zdt: Zoned) -> Result<Zoned, Error> {
-        match self.duration.to_signed()? {
+        match rtry!(self.duration.to_signed()) {
             SDuration::Span(span) => zdt.checked_add_span(span),
             SDuration::Absolute(sdur) => zdt.checked_add_duration(sdur),
         }
@@ -4042,7 +4040,7 @@ impl ZonedArithmetic {
 
     #[inline]
     fn checked_neg(self) -> Result<ZonedArithmetic, Error> {
-        let duration = self.duration.checked_neg()?;
+        let duration = rtry!(self.duration.checked_neg());
         Ok(ZonedArithmetic { duration })
     }
 
@@ -4366,28 +4364,28 @@ impl<'a> ZonedDifference<'a> {
             day_correct += 1;
         }
 
-        let mut mid = dt2
+        let mut mid = rtry!(dt2
             .date()
             .checked_add(Span::new().days(day_correct * -sign))
-            .context(E::AddDays)?
-            .to_datetime(dt1.time());
-        let mut zmid: Zoned = mid
+            .context(E::AddDays))
+        .to_datetime(dt1.time());
+        let mut zmid: Zoned = rtry!(mid
             .to_zoned(tz.clone())
-            .context(E::ConvertIntermediateDatetime)?;
+            .context(E::ConvertIntermediateDatetime));
         if b::Sign::from_ordinals(zdt2, &zmid) == -sign {
             if sign.is_negative() {
                 // FIXME
                 panic!("this should be an error");
             }
             day_correct += 1;
-            mid = dt2
+            mid = rtry!(dt2
                 .date()
                 .checked_add(Span::new().days(day_correct * -sign))
-                .context(E::AddDays)?
-                .to_datetime(dt1.time());
-            zmid = mid
+                .context(E::AddDays))
+            .to_datetime(dt1.time());
+            zmid = rtry!(mid
                 .to_zoned(tz.clone())
-                .context(E::ConvertIntermediateDatetime)?;
+                .context(E::ConvertIntermediateDatetime));
             if b::Sign::from_ordinals(zdt2, &zmid) == -sign {
                 // FIXME
                 panic!("this should be an error too");
@@ -4397,7 +4395,7 @@ impl<'a> ZonedDifference<'a> {
             zdt2.timestamp().as_duration() - zmid.timestamp().as_duration();
         dt2 = mid;
 
-        let date_span = dt1.date().until((largest, dt2.date()))?;
+        let date_span = rtry!(dt1.date().until((largest, dt2.date())));
         Ok(Span::from_invariant_duration(Unit::Hour, remainder)
             .expect("difference between time always fits in span")
             .years(date_span.get_years())
@@ -4611,15 +4609,15 @@ impl ZonedRound {
         if self.round.get_smallest() == Unit::Day {
             return self.round_days(zdt);
         }
-        let end = self.round.round(start)?;
+        let end = rtry!(self.round.round(start));
         // Like in the ZonedWith API, in order to avoid small changes to clock
         // time hitting a 1 hour disambiguation shift, we use offset conflict
         // resolution to do our best to "prefer" the offset we already have.
-        let amb = OffsetConflict::PreferOffset.resolve(
+        let amb = rtry!(OffsetConflict::PreferOffset.resolve(
             end,
             zdt.offset(),
             zdt.time_zone().clone(),
-        )?;
+        ));
         amb.compatible()
     }
 
@@ -4633,15 +4631,15 @@ impl ZonedRound {
 
         // Rounding by days requires an increment of 1. We just re-use the
         // civil datetime rounding checks, which has the same constraint.
-        Increment::for_datetime(Unit::Day, self.round.get_increment())?;
+        rtry!(Increment::for_datetime(Unit::Day, self.round.get_increment()));
 
         // FIXME: We should be doing this with a &TimeZone, but will need a
         // refactor so that we do zone-aware arithmetic using just a Timestamp
         // and a &TimeZone. Fixing just this should just be some minor annoying
         // work. The grander refactor is something like an `Unzoned` type, but
         // I'm not sure that's really worth it. ---AG
-        let start = zdt.start_of_day().context(E::FailedStartOfDay)?;
-        let end = start.tomorrow().context(E::FailedLengthOfDay)?;
+        let start = rtry!(zdt.start_of_day().context(E::FailedStartOfDay));
+        let end = rtry!(start.tomorrow().context(E::FailedLengthOfDay));
         // I don't believe this is actually possible, since adding 1 day should
         // always advance the underlying timestamp by some amount. On the
         // other hand, it's somewhat tricky to reason about this because of the
@@ -4658,14 +4656,17 @@ impl ZonedRound {
             end.timestamp().as_duration() - start.timestamp().as_duration();
         let progress =
             zdt.timestamp().as_duration() - start.timestamp().as_duration();
-        let rounded =
-            self.round.get_mode().round_by_duration(progress, day_length)?;
+        let rounded = rtry!(self
+            .round
+            .get_mode()
+            .round_by_duration(progress, day_length));
         let nanos = start
             .timestamp()
             .as_duration()
             .checked_add(rounded)
             .ok_or(E::FailedSpanNanoseconds)?;
-        Ok(Timestamp::from_duration(nanos)?.to_zoned(zdt.time_zone().clone()))
+        Ok(rtry!(Timestamp::from_duration(nanos))
+            .to_zoned(zdt.time_zone().clone()))
     }
 }
 
@@ -4798,10 +4799,11 @@ impl ZonedWith {
     /// ```
     #[inline]
     pub fn build(self) -> Result<Zoned, Error> {
-        let dt = self.datetime_with.build()?;
+        let dt = rtry!(self.datetime_with.build());
         let (_, _, offset, time_zone) = self.original.into_parts();
         let offset = self.offset.unwrap_or(offset);
-        let ambiguous = self.offset_conflict.resolve(dt, offset, time_zone)?;
+        let ambiguous =
+            rtry!(self.offset_conflict.resolve(dt, offset, time_zone));
         ambiguous.disambiguate(self.disambiguation)
     }
 


### PR DESCRIPTION
I'm not sure if for code quality reasons, we actually want to do this for the relatively small gain but
thought I put it up just in case, feel free to close.

I've only done trivial try transforms in this PR, but I think there is more savings that could be had with a similar macro to avoid many of the `map_err(` instances.

This commit introduces the `rtry!` macro and uses it throughout the codebase instead of `?` for forwarding result types whose error types are already same. This is a trick that serde uses: https://github.com/serde-rs/serde/blob/fa7da4a93567ed347ad0735c28e439fca688ef26/serde/src/lib.rs#L236-L248

The de-sugared try operator ('?') invokes the Try and From trait but for most of the error forwarding sites we need neither.

For rustc 1.94.0 (4a4ef493e 2026-03-02):

The total debug build `cargo llvm-lines` of  jiff, reduced from 174096 to 168315 LLVM lines.

Then measured from 5 samples of `perf stat` on a direct rustc invocation to build the jiff rlib (non incremental), shows the following:

Before (using the try operator)
```
    10,889,052,814      cycles:u        ( +-  0.08% )
    15,171,370,701      instructions:u  ( +-  0.01% )
     2,671,428,910      branch:u        ( +-  0.01% )

    1.60105 +- 0.00152 seconds time elapsed  ( +-  0.09% )
```
After (using the macro)
```
    10,454,390,370      cycles:u        ( +-  0.12% )
    14,591,413,777      instructions:u  ( +-  0.01% )
     2,567,871,039      branch:u        ( +-  0.01% )

    1.55956 +- 0.00335 seconds time elapsed  ( +-  0.21% )
```
The above perf results show an improvement of 3-4% percent.

<details>
<summary> System Specs if Needed </summary>

```
rustc:   rustc 1.94.0 (4a4ef493e 2026-03-02) (LLVM 21.1.8)
os:      Arch Linux (kernel 6.18.13-arch1-1)
cpu:     AMD Ryzen 9 5950X 16-Core Processor (32 threads)
memory:  63 GB
caches:  L1d: 512 KiB (16 instances), L1i: 512 KiB (16 instances), L2: 8 MiB (16 instances), L3: 64 MiB (2 instances)
```

</details>

<details>
<summary> Exact perf stat rustc command I used </summary>

```sh
env CARGO_PKG_HOMEPAGE='' CARGO_PKG_LICENSE='Unlicense OR MIT' CARGO_PKG_LICENSE_FILE='' CARGO_PKG_NAME=jiff CARGO_PKG_README=README.md CARGO_PKG_REPOSITORY='https://github.com/BurntSushi/jiff' CARGO_PKG_RUST_VERSION=1.70 CARGO_PKG_VERSION=0.2.23 CARGO_PKG_VERSION_MAJOR=0 CARGO_PKG_VERSION_MINOR=2 CARGO_PKG_VERSION_PATCH=23 CARGO_PKG_VERSION_PRE='' CARGO_PRIMARY_PACKAGE=1 LD_LIBRARY_PATH='/tmp/rust-target/debug/deps:/home/user/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib' perf stat -r 5 -e cycles,instructions,branch /home/user/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name jiff --edition=2021 src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --diagnostic-width=191 --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --allow=unexpected_cfgs --check-cfg 'cfg(docsrs_jiff)' --cfg 'feature="alloc"' --cfg 'feature="default"' --cfg 'feature="perf-inline"' --cfg 'feature="std"' --cfg 'feature="tz-fat"' --cfg 'feature="tz-system"' --cfg 'feature="tzdb-bundle-platform"' --cfg 'feature="tzdb-concatenated"' --cfg 'feature="tzdb-zoneinfo"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("alloc", "default", "js", "logging", "perf-inline", "serde", "static", "static-tz", "std", "tz-fat", "tz-system", "tzdb-bundle-always", "tzdb-bundle-platform", "tzdb-concatenated", "tzdb-zoneinfo"))' -C metadata=6b7754662bf2080e -C extra-filename=-c5cdb0b61b123153 --out-dir /tmp/rust-target/debug/deps -C linker=/usr/bin/clang -L dependency=/tmp/rust-target/debug/deps -Clink-arg=--ld-path=/bin/wild
```

</details>

Replacement Process:
Initially I tried to use debug info to find trivial From invocations of error types, on the same line as a try operators to constrain the replacements but I ended up just doing aggressive replacements using tree-sitter then reverting the cases that failed... 

As you can see from the initial CI failures and patch commits the process has been a bit iterative. I am trusting that CI type checks all code paths, I don't know if I should be. If the premise of this PR is something that could be accepted, I could spend the time to auditing each replacement, just say the word.