### PR TITLE
Fix interoperability wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ adding new dependencies:
 1. When a dependency is _practically_ required in order to interact with a
 platform. For example, `windows-sys` for discovering the system time zone on
 Windows.
-2. When a dependency is necessary for inter-operability. For example, `serde`.
+2. When a dependency is necessary for interoperability. For example, `serde`.
 But even here, I expect to be conservative, where I'm generally only willing
 to depend on things that have fewer breaking change releases than Jiff.
 


### PR DESCRIPTION
## Summary

Fix the README wording by changing "inter-operability" to "interoperability."

## Related issue

N/A, trivial documentation fix.

## Guideline alignment

Single-file docs-only wording update with no behavior change.

## Validation/testing note

Not run; documentation-only change.