### PR TITLE
Replace `windows-sys` with inline bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,7 +329,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: 1.70.0
+        toolchain: 1.71.0
     # We would use `cargo build --all` here, but `jiff-cli` doesn't really
     # track an MSRV and I don't want it to.
     - name: Build jiff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Switch to Rust 2024
       run: sed -i.bak 's/^edition = "2021"$/edition = "2024"/' Cargo.toml
     - name: Bump rust-version to Rust 1.85
-      run: sed -i.bak 's/^rust-version = "1\.70"$/rust-version = "1.85"/' Cargo.toml
+      run: sed -i.bak 's/^rust-version = "1\.71"$/rust-version = "1.85"/' Cargo.toml
     - run: ./scripts/test-default
 
   # Test all features enabled.
@@ -96,7 +96,7 @@ jobs:
     - name: Switch to Rust 2024
       run: sed -i.bak 's/^edition = "2021"$/edition = "2024"/' Cargo.toml
     - name: Bump rust-version to Rust 1.85
-      run: sed -i.bak 's/^rust-version = "1\.70"$/rust-version = "1.85"/' Cargo.toml
+      run: sed -i.bak 's/^rust-version = "1\.71"$/rust-version = "1.85"/' Cargo.toml
     - run: ./scripts/test-all
 
   # Test Jiff when only the bundled tzdb is enabled.
@@ -127,7 +127,7 @@ jobs:
     - name: Switch to Rust 2024
       run: sed -i.bak 's/^edition = "2021"$/edition = "2024"/' Cargo.toml
     - name: Bump rust-version to Rust 1.85
-      run: sed -i.bak 's/^rust-version = "1\.70"$/rust-version = "1.85"/' Cargo.toml
+      run: sed -i.bak 's/^rust-version = "1\.71"$/rust-version = "1.85"/' Cargo.toml
     - run: ./scripts/test-only-bundle
 
   # Test Jiff in core-only (including no-alloc) configurations.
@@ -198,7 +198,7 @@ jobs:
     - name: Switch to Rust 2024
       run: sed -i.bak 's/^edition = "2021"$/edition = "2024"/' Cargo.toml
     - name: Bump rust-version to Rust 1.85
-      run: sed -i.bak 's/^rust-version = "1\.70"$/rust-version = "1.85"/' Cargo.toml
+      run: sed -i.bak 's/^rust-version = "1\.71"$/rust-version = "1.85"/' Cargo.toml
     - name: Run tests under release mode
       run: cargo test --verbose --all --profile testrelease
 
@@ -293,7 +293,7 @@ jobs:
       run: sed -i.bak 's/^edition = "2021"$/edition = "2024"/' Cargo.toml
     - name: Bump rust-version to Rust 1.85
       shell: bash
-      run: sed -i.bak 's/^rust-version = "1\.70"$/rust-version = "1.85"/' Cargo.toml
+      run: sed -i.bak 's/^rust-version = "1\.71"$/rust-version = "1.85"/' Cargo.toml
     - run: cargo build --verbose
     - run: cargo doc --features serde,static --verbose
     - run: cargo test --verbose --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["date", "time", "calendar", "zone", "duration"]
 edition = "2021"
 autotests = false
 autoexamples = false
-rust-version = "1.70"
+rust-version = "1.71"
 # We include `/tests/lib.rs` to squash a `cargo package` warning that the
 # `integration` test target is being ignored. We don't include anything else
 # so tests obviously won't work, but it makes `cargo package` quiet.
@@ -56,9 +56,8 @@ logging = ["dep:log"]
 # When enabled, Jiff will include code that attempts to determine the "system"
 # time zone. For example, on Unix systems, this is usually determined by
 # looking at the symlink information on /etc/localtime. But in general, it's
-# very platform specific and heuristic oriented. On some platforms, this may
-# require extra dependencies. (For example, `windows-sys` on Windows.)
-tz-system = ["std", "dep:windows-sys"]
+# very platform specific and heuristic oriented.
+tz-system = ["std"]
 
 # When enabled, Jiff will "fatten" time zone data so that it contains more
 # transitions. This uses a little extra heap memory (or binary size, when
@@ -204,12 +203,6 @@ jiff-static = { version = "=0.2.24", path = "crates/jiff-static" }
 # actually used on platforms without a system tzdb (i.e., Windows and wasm).
 [target.'cfg(any(windows, target_family = "wasm"))'.dependencies]
 jiff-tzdb-platform = { version = "0.1.3", path = "crates/jiff-tzdb-platform", optional = true }
-
-[target.'cfg(windows)'.dependencies.windows-sys]
-version = ">=0.52.0, <=0.61.*"
-default-features = false
-features = ["Win32_Foundation", "Win32_System_Time"]
-optional = true
 
 [target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dependencies]
 js-sys = { version = "0.3.50", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,8 +56,9 @@ logging = ["dep:log"]
 # When enabled, Jiff will include code that attempts to determine the "system"
 # time zone. For example, on Unix systems, this is usually determined by
 # looking at the symlink information on /etc/localtime. But in general, it's
-# very platform specific and heuristic oriented.
-tz-system = ["std"]
+# very platform specific and heuristic oriented. On some platforms, this may
+# require extra dependencies. (For example, `windows-link` on Windows.)
+tz-system = ["std", "dep:windows-link"]
 
 # When enabled, Jiff will "fatten" time zone data so that it contains more
 # transitions. This uses a little extra heap memory (or binary size, when
@@ -203,6 +204,10 @@ jiff-static = { version = "=0.2.24", path = "crates/jiff-static" }
 # actually used on platforms without a system tzdb (i.e., Windows and wasm).
 [target.'cfg(any(windows, target_family = "wasm"))'.dependencies]
 jiff-tzdb-platform = { version = "0.1.3", path = "crates/jiff-tzdb-platform", optional = true }
+
+# Provides a helper macro for binding Win32 functions
+[target.'cfg(windows)'.dependencies]
+windows-link = { version = "0.2.1", optional = true }
 
 [target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dependencies]
 js-sys = { version = "0.3.50", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["date", "time", "calendar", "zone", "duration"]
 edition = "2021"
 autotests = false
 autoexamples = false
-rust-version = "1.70"
+rust-version = "1.71"
 # We include `/tests/lib.rs` to squash a `cargo package` warning that the
 # `integration` test target is being ignored. We don't include anything else
 # so tests obviously won't work, but it makes `cargo package` quiet.
@@ -56,9 +56,8 @@ logging = ["dep:log"]
 # When enabled, Jiff will include code that attempts to determine the "system"
 # time zone. For example, on Unix systems, this is usually determined by
 # looking at the symlink information on /etc/localtime. But in general, it's
-# very platform specific and heuristic oriented. On some platforms, this may
-# require extra dependencies. (For example, `windows-sys` on Windows.)
-tz-system = ["std", "dep:windows-sys"]
+# very platform specific and heuristic oriented.
+tz-system = ["std"]
 
 # When enabled, Jiff will "fatten" time zone data so that it contains more
 # transitions. This uses a little extra heap memory (or binary size, when
@@ -204,12 +203,6 @@ jiff-static = { version = "=0.2.23", path = "crates/jiff-static" }
 # actually used on platforms without a system tzdb (i.e., Windows and wasm).
 [target.'cfg(any(windows, target_family = "wasm"))'.dependencies]
 jiff-tzdb-platform = { version = "0.1.3", path = "crates/jiff-tzdb-platform", optional = true }
-
-[target.'cfg(windows)'.dependencies.windows-sys]
-version = ">=0.52.0, <=0.61.*"
-default-features = false
-features = ["Win32_Foundation", "Win32_System_Time"]
-optional = true
 
 [target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dependencies]
 js-sys = { version = "0.3.50", optional = true }

--- a/README.md
+++ b/README.md
@@ -169,8 +169,7 @@ Jiff is very conservative. I consider there to be two primary use cases for
 adding new dependencies:
 
 1. When a dependency is _practically_ required in order to interact with a
-platform. For example, `windows-sys` for discovering the system time zone on
-Windows.
+platform.
 2. When a dependency is necessary for interoperability. For example, `serde`.
 But even here, I expect to be conservative, where I'm generally only willing
 to depend on things that have fewer breaking change releases than Jiff.

--- a/README.md
+++ b/README.md
@@ -169,8 +169,7 @@ Jiff is very conservative. I consider there to be two primary use cases for
 adding new dependencies:
 
 1. When a dependency is _practically_ required in order to interact with a
-platform. For example, `windows-sys` for discovering the system time zone on
-Windows.
+platform.
 2. When a dependency is necessary for inter-operability. For example, `serde`.
 But even here, I expect to be conservative, where I'm generally only willing
 to depend on things that have fewer breaking change releases than Jiff.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -636,8 +636,7 @@ For more, see the [`fmt::serde`] sub-module. (This requires enabling Jiff's
   When enabled, Jiff will include code that attempts to determine the "system"
   time zone. For example, on Unix systems, this is usually determined by
   looking at the symlink information on `/etc/localtime`. But in general, it's
-  very platform specific and heuristic oriented. On some platforms, this may
-  require extra dependencies. (For example, `windows-sys` on Windows.)
+  very platform specific and heuristic oriented.
 * **tz-fat** (enabled by default) -
   When enabled, Jiff will "fatten" time zone data with extra transitions to
   make time zone lookups faster. This may result in increased heap memory

--- a/src/tz/system/windows/ffi.rs
+++ b/src/tz/system/windows/ffi.rs
@@ -28,14 +28,9 @@ pub(super) struct DYNAMIC_TIME_ZONE_INFORMATION {
     dynamic_daylight_time_disabled: u8,
 }
 
-#[link(name = "kernel32", kind = "raw-dylib")]
-unsafe extern "system" {
-    /// Retrieves the current time zone and dynamic daylight saving time settings.
-    ///
-    /// These settings control the translations between Coordinated Universal Time (UTC) and local time.
-    ///
-    /// <https://learn.microsoft.com/en-us/windows/win32/api/timezoneapi/nf-timezoneapi-getdynamictimezoneinformation>
-    pub(super) unsafe fn GetDynamicTimeZoneInformation(
-        info: *mut DYNAMIC_TIME_ZONE_INFORMATION,
-    ) -> u32;
-}
+// Retrieves the current time zone and dynamic daylight saving time settings.
+//
+// These settings control the translations between Coordinated Universal Time (UTC) and local time.
+//
+// <https://learn.microsoft.com/en-us/windows/win32/api/timezoneapi/nf-timezoneapi-getdynamictimezoneinformation>
+windows_link::link!("kernel32.dll" "system" fn GetDynamicTimeZoneInformation(info: *mut DYNAMIC_TIME_ZONE_INFORMATION) -> u32);

--- a/src/tz/system/windows/ffi.rs
+++ b/src/tz/system/windows/ffi.rs
@@ -35,7 +35,7 @@ unsafe extern "system" {
     /// These settings control the translations between Coordinated Universal Time (UTC) and local time.
     ///
     /// <https://learn.microsoft.com/en-us/windows/win32/api/timezoneapi/nf-timezoneapi-getdynamictimezoneinformation>
-    pub(super) fn GetDynamicTimeZoneInformation(
+    pub(super) unsafe fn GetDynamicTimeZoneInformation(
         info: *mut DYNAMIC_TIME_ZONE_INFORMATION,
     ) -> u32;
 }

--- a/src/tz/system/windows/ffi.rs
+++ b/src/tz/system/windows/ffi.rs
@@ -1,0 +1,41 @@
+//! FFI bindings to the Windows function and types used to acquire timezone information
+
+pub const TIME_ZONE_ID_INVALID: u32 = 4294967295;
+
+#[repr(C)]
+struct SYSTEMTIME {
+    year: u16,
+    month: u16,
+    day_of_week: u16,
+    day: u16,
+    hour: u16,
+    minute: u16,
+    seconds: u16,
+    milliseconds: u16,
+}
+
+#[repr(C)]
+pub(super) struct DYNAMIC_TIME_ZONE_INFORMATION {
+    bias: i32,
+    standard_name: [u16; 32],
+    standard_date: SYSTEMTIME,
+    standard_bias: i32,
+    daylight_name: [u16; 32],
+    daylight_date: SYSTEMTIME,
+    daylight_bias: i32,
+    /// This is the only field actually read by jiff
+    pub(super) timezone_key_name: [u16; 128],
+    dynamic_daylight_time_disabled: u8,
+}
+
+#[link(name = "kernel32", kind = "raw-dylib")]
+unsafe extern "system" {
+    /// Retrieves the current time zone and dynamic daylight saving time settings.
+    ///
+    /// These settings control the translations between Coordinated Universal Time (UTC) and local time.
+    ///
+    /// <https://learn.microsoft.com/en-us/windows/win32/api/timezoneapi/nf-timezoneapi-getdynamictimezoneinformation>
+    pub(super) fn GetDynamicTimeZoneInformation(
+        info: *mut DYNAMIC_TIME_ZONE_INFORMATION,
+    ) -> u32;
+}

--- a/src/tz/system/windows/ffi.rs
+++ b/src/tz/system/windows/ffi.rs
@@ -1,6 +1,6 @@
 //! FFI bindings to the Windows function and types used to acquire timezone information
 
-pub const TIME_ZONE_ID_INVALID: u32 = 4294967295;
+pub const TIME_ZONE_ID_INVALID: u32 = 0xffffffff;
 
 #[repr(C)]
 struct SYSTEMTIME {

--- a/src/tz/system/windows/mod.rs
+++ b/src/tz/system/windows/mod.rs
@@ -2,11 +2,6 @@ use core::mem::MaybeUninit;
 
 use alloc::string::String;
 
-use windows_sys::Win32::System::Time::{
-    GetDynamicTimeZoneInformation, DYNAMIC_TIME_ZONE_INFORMATION,
-    TIME_ZONE_ID_INVALID,
-};
-
 use crate::{
     error::{tz::system::Error as E, Error, ErrorContext},
     tz::{TimeZone, TimeZoneDatabase},
@@ -17,6 +12,13 @@ use self::windows_zones::WINDOWS_TO_IANA;
 
 #[allow(dead_code)] // we don't currently read the version
 mod windows_zones;
+
+mod ffi;
+
+use ffi::{
+    GetDynamicTimeZoneInformation, DYNAMIC_TIME_ZONE_INFORMATION,
+    TIME_ZONE_ID_INVALID,
+};
 
 /// Attempts to find the default "system" time zone.
 ///
@@ -102,7 +104,7 @@ fn get_tz_key_name() -> Result<String, Error> {
     // to unless it fails, and we check for failure above. So we're only here
     // when `info` is properly initialized.
     let info = unsafe { info.assume_init() };
-    let tz_key_name = nul_terminated_utf16_to_string(&info.TimeZoneKeyName)
+    let tz_key_name = nul_terminated_utf16_to_string(&info.timezone_key_name)
         .context(E::WindowsTimeZoneKeyName)?;
     Ok(tz_key_name)
 }


### PR DESCRIPTION
I noticed when updating crates in one of my projects that `jiff` was pulling in the latest version of windows-sys which was giving me even more duplicates of windows-sys than were already there. I was fairly sure that jiff's usage of windows-sys would be extremely light, which was true, it calls exactly one function and reads one field from one struct. So this PR just replaces windows-sys with the minimal bindings needed by jiff.

Confirmed that it works, at least under wine (I don't have a Windows machine to test on, but presumably there is CI for windows).

```
uptime | wine examples/uptime/target/x86_64-pc-windows-msvc/debug/uptime.exe
[temp-clones/jiff/src/tz/system/windows/mod.rs:110:8] tz_key_name = "Central Europe Standard Time"
2026-03-30T14:39:00+02:00[Europe/Budapest]
```

Looking at #106 there was some interest in doing this. While the suggestion was to use windows-bindgen, I don't think that makes much sense for such a simple use case.

Note that I used `kind = "raw-dylib"` as that doesn't require the use of an import lib, but that required a bump of the MSRV to 1.71 which seems to be ok as the README indicates it will never be a release within the past year, and 1.71 is almost 3 years old at this point.