### PR TITLE
jiff-chrono: add integration crate for chrono

### DIFF
--- a/crates/jiff-chrono/COPYING
+++ b/crates/jiff-chrono/COPYING
@@ -1,0 +1,3 @@
+This project is dual-licensed under the Unlicense and MIT licenses.
+
+You may use this code under the terms of either license.

--- a/crates/jiff-chrono/Cargo.toml
+++ b/crates/jiff-chrono/Cargo.toml
@@ -1,0 +1,72 @@
+[package]
+name = "jiff-chrono"
+version = "0.1.0"  #:version
+authors = ["Rito Takeuchi <licht-t@outlook.jp>"]
+license = "Unlicense OR MIT"
+homepage = "https://github.com/BurntSushi/jiff/tree/master/crates/jiff-chrono"
+repository = "https://github.com/BurntSushi/jiff"
+documentation = "https://docs.rs/jiff-chrono"
+description = "Conversion routines between Jiff and chrono."
+categories = ["date-and-time"]
+keywords = ["date", "time", "temporal", "zone", "chrono"]
+edition = "2021"
+rust-version = "1.70"
+include = ["/src/*.rs", "COPYING", "LICENSE-MIT", "UNLICENSE"]
+
+# Integration crates in Jiff are explicitly isolated from the workspace to
+# avoid dependencies accumulating. I was originally motivated to do this
+# because rustc kept getting stun-locked compiling diesel. And this was somehow
+# happening every time I saved a file inside of Jiff proper. So I just ragequit
+# including everything in the same workspace and put integration crates (and
+# examples) into their own little bloated fiefdoms.
+[workspace]
+
+[lib]
+name = "jiff_chrono"
+bench = false
+path = "src/lib.rs"
+
+[features]
+default = ["std"]
+std = ["alloc", "jiff/std", "chrono/std"]
+alloc = ["jiff/alloc", "chrono/alloc"]
+# Enables conversions between `jiff::Zoned` and `chrono::DateTime<chrono_tz::Tz>`.
+# Requires `std`, since `chrono-tz` requires `std`.
+chrono-tz = ["dep:chrono-tz", "std"]
+# Passthrough that enables `serde` on both `jiff` and `chrono`. This crate
+# defines no `serde` impls itself; users serialize native types on each side.
+serde = ["jiff/serde", "chrono/serde"]
+
+[dependencies]
+jiff = { version = "0.2.11", path = "../..", default-features = false }
+chrono = { version = "0.4.38", default-features = false }
+chrono-tz = { version = "0.10", optional = true }
+
+[dev-dependencies]
+jiff = { version = "0.2.11", path = "../..", default-features = true }
+chrono = { version = "0.4.38" }
+chrono-tz = "0.10"
+quickcheck = { version = "1.0.3", default-features = false }
+
+[package.metadata.docs.rs]
+# We want to document all features.
+all-features = true
+# Since this crate's feature setup is pretty complicated, it is worth opting
+# into a nightly unstable option to show the features that need to be enabled
+# for public API items. To do that, we set `docsrs_jiff`, and when that's
+# enabled, we enable the 'doc_cfg' feature.
+#
+# To test this locally, run:
+#
+#     RUSTDOCFLAGS="--cfg docsrs_jiff" cargo +nightly doc --all-features
+#
+# Note that we use `docsrs_jiff` instead of the more standard `docsrs` because
+# other crates use that same `cfg` knob. And since we are enabling a nightly
+# feature, they sometimes break. By using our "own" `cfg` knob, we are closer
+# to being masters of our own destiny.
+rustdoc-args = ["--cfg", "docsrs_jiff"]
+
+# This squashes the (AFAIK) erroneous warning that `docsrs_jiff` is not a
+# valid `cfg` knob.
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(docsrs_jiff)'] }

--- a/crates/jiff-chrono/LICENSE-MIT
+++ b/crates/jiff-chrono/LICENSE-MIT
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2026 Rito Takeuchi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/crates/jiff-chrono/README.md
+++ b/crates/jiff-chrono/README.md
@@ -1,0 +1,12 @@
+jiff-chrono
+===========
+A crate for converting between the datetime types found in [`chrono`] and
+[`jiff`]. This can be used to bridge code that mixes the two ecosystems, or
+to incrementally migrate between them.
+
+[`chrono`]: https://docs.rs/chrono/0.4
+[`jiff`]: https://docs.rs/jiff/0.2
+
+### Documentation
+
+https://docs.rs/jiff-chrono

--- a/crates/jiff-chrono/UNLICENSE
+++ b/crates/jiff-chrono/UNLICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>

--- a/crates/jiff-chrono/src/civil.rs
+++ b/crates/jiff-chrono/src/civil.rs
@@ -1,0 +1,346 @@
+use chrono::{
+    Datelike as _, NaiveDate as ChronoNaiveDate,
+    NaiveDateTime as ChronoNaiveDateTime, NaiveTime as ChronoNaiveTime,
+    Timelike as _, Weekday as ChronoWeekday,
+};
+use jiff::civil::{
+    Date as JiffDate, DateTime as JiffDateTime, Time as JiffTime,
+    Weekday as JiffWeekday,
+};
+
+use crate::{
+    error::{err, Error},
+    traits::{ConvertFrom, ConvertInto as _, ConvertTryFrom},
+};
+
+/// Converts from a [`jiff::civil::Date`] to a [`chrono::NaiveDate`].
+///
+/// This conversion is infallible because the range of valid Jiff dates
+/// (years `-9999..=9999`) is strictly smaller than the range of valid
+/// chrono dates.
+///
+/// # Example
+///
+/// ```
+/// use jiff_chrono::ConvertFrom as _;
+///
+/// let jiff_date = jiff::civil::date(2025, 1, 30);
+/// let chrono_date = chrono::NaiveDate::convert_from(jiff_date);
+/// assert_eq!(chrono_date.to_string(), "2025-01-30");
+///
+/// let chrono_date = chrono::NaiveDate::convert_from(jiff::civil::Date::MIN);
+/// assert_eq!(chrono_date.to_string(), "-9999-01-01");
+///
+/// let chrono_date = chrono::NaiveDate::convert_from(jiff::civil::Date::MAX);
+/// assert_eq!(chrono_date.to_string(), "9999-12-31");
+/// ```
+impl ConvertFrom<JiffDate> for ChronoNaiveDate {
+    fn convert_from(v: JiffDate) -> ChronoNaiveDate {
+        // All Jiff dates are valid chrono dates.
+        ChronoNaiveDate::from_ymd_opt(
+            i32::from(v.year()),
+            u32::from(v.month().unsigned_abs()),
+            u32::from(v.day().unsigned_abs()),
+        )
+        .unwrap()
+    }
+}
+
+/// Converts from a [`chrono::NaiveDate`] to a [`jiff::civil::Date`].
+///
+/// This conversion is fallible because chrono's date range is wider than
+/// Jiff's (Jiff years are limited to `-9999..=9999`).
+///
+/// # Example
+///
+/// ```
+/// use jiff_chrono::ConvertTryFrom as _;
+///
+/// let chrono_date =
+///     chrono::NaiveDate::from_ymd_opt(2025, 1, 30).unwrap();
+/// let jiff_date = jiff::civil::Date::convert_try_from(chrono_date)?;
+/// assert_eq!(jiff_date.to_string(), "2025-01-30");
+///
+/// // Years outside Jiff's range fail:
+/// let chrono_date =
+///     chrono::NaiveDate::from_ymd_opt(50_000, 1, 1).unwrap();
+/// assert!(jiff::civil::Date::convert_try_from(chrono_date).is_err());
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+impl ConvertTryFrom<ChronoNaiveDate> for JiffDate {
+    type Error = Error;
+
+    fn convert_try_from(v: ChronoNaiveDate) -> Result<JiffDate, Error> {
+        let year = v.year();
+        let year = i16::try_from(year).map_err(|_| {
+            err!("failed to convert chrono year of {year} to Jiff `i16` year")
+        })?;
+        // NaiveDate guarantees month in 1..=12 and day in 1..=31, so the
+        // casts below never lose information.
+        let month = v.month() as i8;
+        let day = v.day() as i8;
+        Ok(JiffDate::new(year, month, day)?)
+    }
+}
+
+/// Converts from a [`jiff::civil::Time`] to a [`chrono::NaiveTime`].
+///
+/// This conversion is infallible. Jiff times never represent leap seconds,
+/// so the resulting chrono time always has nanoseconds in `0..1_000_000_000`.
+///
+/// # Example
+///
+/// ```
+/// use jiff_chrono::ConvertFrom as _;
+///
+/// let jiff_time = jiff::civil::time(17, 58, 30, 0);
+/// let chrono_time = chrono::NaiveTime::convert_from(jiff_time);
+/// assert_eq!(chrono_time.to_string(), "17:58:30");
+///
+/// let chrono_time =
+///     chrono::NaiveTime::convert_from(jiff::civil::Time::MAX);
+/// assert_eq!(chrono_time.to_string(), "23:59:59.999999999");
+/// ```
+impl ConvertFrom<JiffTime> for ChronoNaiveTime {
+    fn convert_from(v: JiffTime) -> ChronoNaiveTime {
+        // All Jiff times are valid non-leap chrono times.
+        ChronoNaiveTime::from_hms_nano_opt(
+            u32::from(v.hour().unsigned_abs()),
+            u32::from(v.minute().unsigned_abs()),
+            u32::from(v.second().unsigned_abs()),
+            v.subsec_nanosecond().unsigned_abs(),
+        )
+        .unwrap()
+    }
+}
+
+/// Converts from a [`chrono::NaiveTime`] to a [`jiff::civil::Time`].
+///
+/// This conversion is fallible. A chrono time representing a leap second
+/// (nanoseconds `>= 1_000_000_000`) is rejected, since Jiff civil times
+/// do not model leap seconds. If you want to accept leap-second values
+/// by clamping them to `:59.999999999`, use
+/// [`crate::lossy::naive_time_saturating`].
+///
+/// # Example
+///
+/// ```
+/// use jiff_chrono::ConvertTryFrom as _;
+///
+/// let chrono_time =
+///     chrono::NaiveTime::from_hms_nano_opt(17, 58, 30, 0).unwrap();
+/// let jiff_time = jiff::civil::Time::convert_try_from(chrono_time)?;
+/// assert_eq!(jiff_time, jiff::civil::time(17, 58, 30, 0));
+///
+/// // Leap-second values are rejected.
+/// let leap =
+///     chrono::NaiveTime::from_hms_nano_opt(23, 59, 59, 1_500_000_000)
+///         .unwrap();
+/// assert!(jiff::civil::Time::convert_try_from(leap).is_err());
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+impl ConvertTryFrom<ChronoNaiveTime> for JiffTime {
+    type Error = Error;
+
+    fn convert_try_from(v: ChronoNaiveTime) -> Result<JiffTime, Error> {
+        let nano = v.nanosecond();
+        if nano >= 1_000_000_000 {
+            return Err(err!(
+                "chrono `NaiveTime` with nanosecond value {nano} represents \
+                 a leap second, which is not representable in \
+                 `jiff::civil::Time`",
+            ));
+        }
+        // NaiveTime guarantees hour in 0..24, minute in 0..60, second in 0..60,
+        // and (now) nano in 0..1_000_000_000.
+        let hour = v.hour() as i8;
+        let minute = v.minute() as i8;
+        let second = v.second() as i8;
+        let nano = nano as i32;
+        Ok(JiffTime::new(hour, minute, second, nano)?)
+    }
+}
+
+/// Converts from a [`jiff::civil::DateTime`] to a [`chrono::NaiveDateTime`].
+///
+/// This conversion is infallible.
+///
+/// # Example
+///
+/// ```
+/// use jiff_chrono::ConvertFrom as _;
+///
+/// let jiff_datetime = jiff::civil::date(2025, 1, 30).at(17, 58, 30, 0);
+/// let chrono_datetime =
+///     chrono::NaiveDateTime::convert_from(jiff_datetime);
+/// assert_eq!(chrono_datetime.to_string(), "2025-01-30 17:58:30");
+/// ```
+impl ConvertFrom<JiffDateTime> for ChronoNaiveDateTime {
+    fn convert_from(v: JiffDateTime) -> ChronoNaiveDateTime {
+        ChronoNaiveDateTime::new(v.date().convert_into(), v.time().convert_into())
+    }
+}
+
+/// Converts from a [`chrono::NaiveDateTime`] to a [`jiff::civil::DateTime`].
+///
+/// This conversion is fallible for the same reasons as the `NaiveDate` and
+/// `NaiveTime` conversions.
+///
+/// # Example
+///
+/// ```
+/// use jiff_chrono::ConvertTryFrom as _;
+///
+/// let chrono_datetime = chrono::NaiveDate::from_ymd_opt(2025, 1, 30)
+///     .unwrap()
+///     .and_hms_opt(17, 58, 30)
+///     .unwrap();
+/// let jiff_datetime =
+///     jiff::civil::DateTime::convert_try_from(chrono_datetime)?;
+/// assert_eq!(jiff_datetime.to_string(), "2025-01-30T17:58:30");
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+impl ConvertTryFrom<ChronoNaiveDateTime> for JiffDateTime {
+    type Error = Error;
+
+    fn convert_try_from(
+        v: ChronoNaiveDateTime,
+    ) -> Result<JiffDateTime, Error> {
+        let date = JiffDate::convert_try_from(v.date())?;
+        let time = JiffTime::convert_try_from(v.time())?;
+        Ok(JiffDateTime::from_parts(date, time))
+    }
+}
+
+/// Converts from a [`jiff::civil::Weekday`] to a [`chrono::Weekday`].
+///
+/// # Example
+///
+/// ```
+/// use jiff_chrono::ConvertFrom as _;
+///
+/// let jiff_weekday = jiff::civil::Weekday::Wednesday;
+/// let chrono_weekday = chrono::Weekday::convert_from(jiff_weekday);
+/// assert_eq!(chrono_weekday, chrono::Weekday::Wed);
+/// ```
+impl ConvertFrom<JiffWeekday> for ChronoWeekday {
+    fn convert_from(v: JiffWeekday) -> ChronoWeekday {
+        match v {
+            JiffWeekday::Monday => ChronoWeekday::Mon,
+            JiffWeekday::Tuesday => ChronoWeekday::Tue,
+            JiffWeekday::Wednesday => ChronoWeekday::Wed,
+            JiffWeekday::Thursday => ChronoWeekday::Thu,
+            JiffWeekday::Friday => ChronoWeekday::Fri,
+            JiffWeekday::Saturday => ChronoWeekday::Sat,
+            JiffWeekday::Sunday => ChronoWeekday::Sun,
+        }
+    }
+}
+
+/// Converts from a [`chrono::Weekday`] to a [`jiff::civil::Weekday`].
+///
+/// # Example
+///
+/// ```
+/// use jiff_chrono::ConvertFrom as _;
+///
+/// let chrono_weekday = chrono::Weekday::Wed;
+/// let jiff_weekday = jiff::civil::Weekday::convert_from(chrono_weekday);
+/// assert_eq!(jiff_weekday, jiff::civil::Weekday::Wednesday);
+/// ```
+impl ConvertFrom<ChronoWeekday> for JiffWeekday {
+    fn convert_from(v: ChronoWeekday) -> JiffWeekday {
+        match v {
+            ChronoWeekday::Mon => JiffWeekday::Monday,
+            ChronoWeekday::Tue => JiffWeekday::Tuesday,
+            ChronoWeekday::Wed => JiffWeekday::Wednesday,
+            ChronoWeekday::Thu => JiffWeekday::Thursday,
+            ChronoWeekday::Fri => JiffWeekday::Friday,
+            ChronoWeekday::Sat => JiffWeekday::Saturday,
+            ChronoWeekday::Sun => JiffWeekday::Sunday,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::traits::{ConvertInto as _, ConvertTryInto as _};
+
+    use super::*;
+
+    fn arb_date(seed: u32) -> Option<JiffDate> {
+        // Map the seed to every valid Jiff date:
+        //     years  -9999..=9999 (20_000 values)
+        //     months 1..=12
+        //     days   1..=31
+        let year = (seed % 20_000) as i16 - 9999;
+        let month = ((seed / 20_000) % 12) as i8 + 1;
+        let day = ((seed / (20_000 * 12)) % 31) as i8 + 1;
+        JiffDate::new(year, month, day).ok()
+    }
+
+    fn arb_time(seed: u64) -> JiffTime {
+        let nano = (seed % 1_000_000_000) as i32;
+        let second = ((seed / 1_000_000_000) % 60) as i8;
+        let minute = ((seed / (1_000_000_000 * 60)) % 60) as i8;
+        let hour = ((seed / (1_000_000_000 * 3_600)) % 24) as i8;
+        JiffTime::new(hour, minute, second, nano).unwrap()
+    }
+
+    quickcheck::quickcheck! {
+        fn prop_date_roundtrip(seed: u32) -> quickcheck::TestResult {
+            let Some(d) = arb_date(seed) else {
+                return quickcheck::TestResult::discard();
+            };
+            let chrono_date: ChronoNaiveDate = d.convert_into();
+            let back: JiffDate = chrono_date.convert_try_into().unwrap();
+            quickcheck::TestResult::from_bool(d == back)
+        }
+
+        fn prop_time_roundtrip(seed: u64) -> bool {
+            let t = arb_time(seed);
+            let chrono_time: ChronoNaiveTime = t.convert_into();
+            let back: JiffTime = chrono_time.convert_try_into().unwrap();
+            t == back
+        }
+
+        fn prop_datetime_roundtrip(dseed: u32, tseed: u64) -> quickcheck::TestResult {
+            let Some(d) = arb_date(dseed) else {
+                return quickcheck::TestResult::discard();
+            };
+            let dt = JiffDateTime::from_parts(d, arb_time(tseed));
+            let chrono_dt: ChronoNaiveDateTime = dt.convert_into();
+            let back: JiffDateTime = chrono_dt.convert_try_into().unwrap();
+            quickcheck::TestResult::from_bool(dt == back)
+        }
+
+        fn prop_weekday_roundtrip(seed: u32) -> quickcheck::TestResult {
+            let Some(d) = arb_date(seed) else {
+                return quickcheck::TestResult::discard();
+            };
+            let jw = d.weekday();
+            let cw: ChronoWeekday = jw.convert_into();
+            let back: JiffWeekday = cw.convert_into();
+            quickcheck::TestResult::from_bool(jw == back)
+        }
+    }
+
+    #[test]
+    fn naive_time_leap_second_is_rejected() {
+        let leap =
+            ChronoNaiveTime::from_hms_nano_opt(23, 59, 59, 1_500_000_000)
+                .unwrap();
+        assert!(JiffTime::convert_try_from(leap).is_err());
+    }
+
+    #[test]
+    fn naive_date_outside_jiff_range_is_rejected() {
+        let big = ChronoNaiveDate::from_ymd_opt(50_000, 1, 1).unwrap();
+        assert!(JiffDate::convert_try_from(big).is_err());
+        let small = ChronoNaiveDate::from_ymd_opt(-50_000, 1, 1).unwrap();
+        assert!(JiffDate::convert_try_from(small).is_err());
+    }
+}

--- a/crates/jiff-chrono/src/duration.rs
+++ b/crates/jiff-chrono/src/duration.rs
@@ -1,0 +1,259 @@
+use chrono::{Months as ChronoMonths, TimeDelta as ChronoTimeDelta};
+use jiff::{SignedDuration as JiffSignedDuration, Span as JiffSpan};
+
+use crate::{
+    error::{err, Error},
+    traits::{ConvertFrom, ConvertTryFrom},
+};
+
+/// Converts from a [`chrono::TimeDelta`] to a [`jiff::SignedDuration`].
+///
+/// This conversion is infallible: chrono's `TimeDelta` range (bounded to
+/// what fits in milliseconds as `i64`) is a subset of `SignedDuration`'s
+/// range (seconds as `i64`).
+///
+/// # Example
+///
+/// ```
+/// use jiff_chrono::ConvertFrom as _;
+///
+/// let td = chrono::TimeDelta::new(86_400, 123_456_789).unwrap();
+/// let sd = jiff::SignedDuration::convert_from(td);
+/// assert_eq!(sd.as_secs(), 86_400);
+/// assert_eq!(sd.subsec_nanos(), 123_456_789);
+///
+/// let td = -chrono::TimeDelta::milliseconds(1_500);
+/// let sd = jiff::SignedDuration::convert_from(td);
+/// assert_eq!(sd.as_secs(), -1);
+/// assert_eq!(sd.subsec_nanos(), -500_000_000);
+/// ```
+impl ConvertFrom<ChronoTimeDelta> for JiffSignedDuration {
+    fn convert_from(v: ChronoTimeDelta) -> JiffSignedDuration {
+        // `TimeDelta` stores a non-negative subsec-nanos field internally and
+        // uses floored seconds. `num_seconds()` rounds toward zero and
+        // `subsec_nanos()` returns a value whose sign matches the overall
+        // delta. `SignedDuration::new` accepts values with the same sign,
+        // so this is a direct construction.
+        //
+        // `TimeDelta` cannot represent a duration larger (in absolute value)
+        // than `i64::MAX / 1000` seconds, so the `new` call cannot panic.
+        JiffSignedDuration::new(v.num_seconds(), v.subsec_nanos())
+    }
+}
+
+/// Converts from a [`jiff::SignedDuration`] to a [`chrono::TimeDelta`].
+///
+/// This conversion is fallible. `SignedDuration` supports seconds across the
+/// full `i64` range, whereas `TimeDelta`'s range is limited to values whose
+/// total milliseconds fit in `i64` (roughly `±2.9 * 10^11` seconds).
+///
+/// # Example
+///
+/// ```
+/// use jiff_chrono::ConvertTryFrom as _;
+///
+/// let sd = jiff::SignedDuration::new(86_400, 123_456_789);
+/// let td = chrono::TimeDelta::convert_try_from(sd)?;
+/// assert_eq!(td.num_seconds(), 86_400);
+/// assert_eq!(td.subsec_nanos(), 123_456_789);
+///
+/// // Negative durations are preserved.
+/// let sd = jiff::SignedDuration::new(-1, -500_000_000);
+/// let td = chrono::TimeDelta::convert_try_from(sd)?;
+/// assert_eq!(td.num_milliseconds(), -1_500);
+///
+/// // Values outside `TimeDelta`'s range are rejected.
+/// assert!(chrono::TimeDelta::convert_try_from(
+///     jiff::SignedDuration::MAX
+/// ).is_err());
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+impl ConvertTryFrom<JiffSignedDuration> for ChronoTimeDelta {
+    type Error = Error;
+
+    fn convert_try_from(
+        v: JiffSignedDuration,
+    ) -> Result<ChronoTimeDelta, Error> {
+        let secs = v.as_secs();
+        let nanos = v.subsec_nanos();
+        // `TimeDelta::new` requires a non-negative `nanos` argument in
+        // `0..1_000_000_000` and combines it with floored seconds.
+        // `SignedDuration` stores `secs` and `nanos` with the same sign,
+        // so for negative values we shift one second's worth of nanos
+        // into the positive range.
+        let (secs, nanos) = if nanos < 0 {
+            let secs = secs.checked_sub(1).ok_or_else(|| {
+                err!(
+                    "Jiff `SignedDuration` of {v} overflows when converting \
+                     to `chrono::TimeDelta`",
+                )
+            })?;
+            (secs, (nanos + 1_000_000_000) as u32)
+        } else {
+            (secs, nanos as u32)
+        };
+        ChronoTimeDelta::new(secs, nanos).ok_or_else(|| {
+            err!(
+                "Jiff `SignedDuration` of {v} is out of range for \
+                 `chrono::TimeDelta`",
+            )
+        })
+    }
+}
+
+/// Converts from a [`chrono::TimeDelta`] to a [`jiff::Span`].
+///
+/// This conversion is infallible. The resulting `Span` has non-zero units
+/// only in seconds and below (never years/months/weeks/days), matching the
+/// behavior of Jiff's own `TryFrom<SignedDuration> for Span`.
+///
+/// # Example
+///
+/// ```
+/// use jiff_chrono::ConvertFrom as _;
+///
+/// let td = chrono::TimeDelta::new(90, 500_000_000).unwrap();
+/// let span = jiff::Span::convert_from(td);
+/// assert_eq!(span.get_seconds(), 90);
+/// assert_eq!(span.get_milliseconds(), 500);
+/// ```
+impl ConvertFrom<ChronoTimeDelta> for JiffSpan {
+    fn convert_from(v: ChronoTimeDelta) -> JiffSpan {
+        let sd = JiffSignedDuration::convert_from(v);
+        // `Span` has sufficient range to represent any `SignedDuration`
+        // derived from a `TimeDelta`, so this conversion cannot fail.
+        JiffSpan::try_from(sd).unwrap()
+    }
+}
+
+/// Converts from a [`jiff::Span`] to a [`chrono::TimeDelta`].
+///
+/// This conversion is fallible. It fails if the span has any non-zero
+/// calendar units (years, months, weeks, or days), since those units
+/// cannot be meaningfully converted to an absolute `TimeDelta` without a
+/// reference date. It also fails if the resulting duration is outside
+/// `TimeDelta`'s range.
+///
+/// If you need to convert a span with calendar units, you have two
+/// options:
+///
+/// * If the span only adds nonzero `days` and you are comfortable
+///   treating each day as exactly 24 hours (ignoring DST), use
+///   [`crate::lossy::span_to_timedelta_days_are_24h`].
+/// * Otherwise, resolve the span to a [`jiff::SignedDuration`] via
+///   [`jiff::Span::to_duration`] with an explicit reference point, then
+///   convert the resulting `SignedDuration`.
+///
+/// # Example
+///
+/// ```
+/// use jiff::ToSpan;
+/// use jiff_chrono::ConvertTryFrom as _;
+///
+/// let span = 2.hours().minutes(30);
+/// let td = chrono::TimeDelta::convert_try_from(span)?;
+/// assert_eq!(td.num_minutes(), 150);
+///
+/// // Calendar units are rejected.
+/// let span = 1.month();
+/// assert!(chrono::TimeDelta::convert_try_from(span).is_err());
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+impl ConvertTryFrom<JiffSpan> for ChronoTimeDelta {
+    type Error = Error;
+
+    fn convert_try_from(v: JiffSpan) -> Result<ChronoTimeDelta, Error> {
+        // Jiff's own `TryFrom<Span> for SignedDuration` rejects spans whose
+        // largest unit requires a reference date (years, months, weeks,
+        // days), which is exactly the policy we want here.
+        let sd = JiffSignedDuration::try_from(v)?;
+        ChronoTimeDelta::convert_try_from(sd)
+    }
+}
+
+/// Converts from a [`chrono::Months`] to a [`jiff::Span`].
+///
+/// This conversion is infallible. The resulting span has its `months` field
+/// set and all other fields zero.
+///
+/// Note: there is no corresponding conversion for [`chrono::Days`] because,
+/// as of `chrono` 0.4.44, the inner `u64` of `chrono::Days` is not exposed
+/// through any public accessor. If you have a [`chrono::Days`] value,
+/// reconstruct it on the Jiff side using
+/// [`jiff::ToSpan::days`](jiff::ToSpan::days) directly.
+///
+/// # Example
+///
+/// ```
+/// use jiff_chrono::ConvertFrom as _;
+///
+/// let months = chrono::Months::new(18);
+/// let span = jiff::Span::convert_from(months);
+/// assert_eq!(span.get_months(), 18);
+/// assert_eq!(span.get_years(), 0);
+/// ```
+impl ConvertFrom<ChronoMonths> for JiffSpan {
+    fn convert_from(v: ChronoMonths) -> JiffSpan {
+        use jiff::ToSpan as _;
+        // `Months::as_u32()` returns a `u32`, which fits losslessly in the
+        // `i64` accepted by `Span::months`. `Span` internally caps months
+        // at a value well above `u32::MAX`, so this cannot fail.
+        i64::from(v.as_u32()).months()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use jiff::ToSpan;
+
+    use crate::traits::{ConvertInto as _, ConvertTryInto as _};
+
+    use super::*;
+
+    quickcheck::quickcheck! {
+        /// Round-trip `TimeDelta` through `SignedDuration`. The chrono side
+        /// is the narrower domain, so this is the interesting direction.
+        fn prop_timedelta_to_signed_duration_roundtrip(secs: i64, nanos: u32) -> quickcheck::TestResult {
+            let nanos = nanos % 1_000_000_000;
+            let Some(td) = ChronoTimeDelta::new(secs, nanos) else {
+                return quickcheck::TestResult::discard();
+            };
+            let sd: JiffSignedDuration = td.convert_into();
+            let back: ChronoTimeDelta = sd.convert_try_into().unwrap();
+            quickcheck::TestResult::from_bool(td == back)
+        }
+    }
+
+    #[test]
+    fn span_with_calendar_units_is_rejected() {
+        assert!(ChronoTimeDelta::convert_try_from(1.year()).is_err());
+        assert!(ChronoTimeDelta::convert_try_from(1.month()).is_err());
+        assert!(ChronoTimeDelta::convert_try_from(1.week()).is_err());
+        assert!(ChronoTimeDelta::convert_try_from(1.day()).is_err());
+    }
+
+    #[test]
+    fn span_with_time_units_converts() {
+        let span = 2.hours().minutes(30).seconds(15);
+        let td = ChronoTimeDelta::convert_try_from(span).unwrap();
+        assert_eq!(td.num_seconds(), 2 * 3600 + 30 * 60 + 15);
+    }
+
+    #[test]
+    fn signed_duration_negative_fractional_roundtrips_via_timedelta() {
+        let sd = JiffSignedDuration::new(-1, -500_000_000);
+        let td: ChronoTimeDelta = sd.convert_try_into().unwrap();
+        assert_eq!(td.num_milliseconds(), -1_500);
+        let back: JiffSignedDuration = td.convert_into();
+        assert_eq!(back, sd);
+    }
+
+    #[test]
+    fn signed_duration_max_is_rejected_by_timedelta() {
+        assert!(
+            ChronoTimeDelta::convert_try_from(JiffSignedDuration::MAX).is_err()
+        );
+    }
+}

--- a/crates/jiff-chrono/src/error.rs
+++ b/crates/jiff-chrono/src/error.rs
@@ -1,0 +1,103 @@
+/// Creates a new ad hoc error via `format_args!`.
+macro_rules! err {
+    ($($tt:tt)*) => {{
+        crate::error::Error::adhoc_from_args(format_args!($($tt)*))
+    }}
+}
+
+pub(crate) use err;
+
+/// An error that can occur when converting between types in this crate.
+#[derive(Clone, Debug)]
+pub struct Error {
+    kind: ErrorKind,
+}
+
+impl Error {
+    /// Creates an error from an arbitrary `core::fmt::Arguments`.
+    ///
+    /// When `alloc` isn't enabled, then `Arguments::as_str()` is used to
+    /// find an error message. Otherwise, a generic error message is emitted.
+    pub(crate) fn adhoc_from_args<'a>(
+        message: core::fmt::Arguments<'a>,
+    ) -> Error {
+        let kind = ErrorKind::Adhoc(AdhocError::from_args(message));
+        Error { kind }
+    }
+}
+
+#[derive(Clone, Debug)]
+enum ErrorKind {
+    Adhoc(AdhocError),
+    Jiff(jiff::Error),
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self.kind {
+            ErrorKind::Adhoc(ref err) => {
+                core::fmt::Display::fmt(&err.message, f)
+            }
+            ErrorKind::Jiff(ref err) => err.fmt(f),
+        }
+    }
+}
+
+// Why do we use `core::error::Error` here despite the fact that
+// we have a `std` feature? Well, because Jiff's `Error` type only
+// implements `std::error::Error` and can't (non-annoyingly) implement
+// `core::error::Error` because of its MSRV.
+#[cfg(feature = "std")]
+impl core::error::Error for Error {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self.kind {
+            ErrorKind::Adhoc(_) => None,
+            ErrorKind::Jiff(ref err) => Some(err),
+        }
+    }
+}
+
+impl From<jiff::Error> for Error {
+    fn from(e: jiff::Error) -> Error {
+        Error { kind: ErrorKind::Jiff(e) }
+    }
+}
+
+/// A generic error message.
+#[derive(Clone, Debug)]
+struct AdhocError {
+    #[cfg(feature = "alloc")]
+    message: alloc::boxed::Box<str>,
+    #[cfg(not(feature = "alloc"))]
+    message: &'static str,
+}
+
+impl AdhocError {
+    fn from_args<'a>(message: core::fmt::Arguments<'a>) -> AdhocError {
+        #[cfg(feature = "alloc")]
+        {
+            AdhocError::from_display(message)
+        }
+        #[cfg(not(feature = "alloc"))]
+        {
+            let message = message.as_str().unwrap_or(
+                "unknown `jiff-chrono` error (better error messages require \
+                 enabling the `alloc` feature for the `jiff-chrono` crate)",
+            );
+            AdhocError::from_static_str(message)
+        }
+    }
+
+    #[cfg(feature = "alloc")]
+    fn from_display<'a>(message: impl core::fmt::Display + 'a) -> AdhocError {
+        use alloc::string::ToString;
+
+        let message = message.to_string().into_boxed_str();
+        AdhocError { message }
+    }
+
+    #[cfg(not(feature = "alloc"))]
+    fn from_static_str(message: &'static str) -> AdhocError {
+        AdhocError { message }
+    }
+}

--- a/crates/jiff-chrono/src/lib.rs
+++ b/crates/jiff-chrono/src/lib.rs
@@ -1,0 +1,201 @@
+/*!
+This crate provides conversion routines between [`jiff`] and
+[`chrono`](https://docs.rs/chrono).
+
+The conversion routines are implemented via the conversion traits defined
+in this crate. These traits mirror [`From`], [`Into`], [`TryFrom`] and
+[`TryInto`] from the standard library. They exist here (rather than being
+`From`/`TryFrom` impls) because Rust's orphan rule forbids `From` impls
+between types that both live in foreign crates.
+
+[`jiff`]: https://docs.rs/jiff/0.2
+
+# Available conversions
+
+Infallible (use [`ConvertFrom`] / [`ConvertInto`]):
+
+* [`jiff::civil::Date`] → [`chrono::NaiveDate`]
+* [`jiff::civil::Time`] → [`chrono::NaiveTime`]
+* [`jiff::civil::DateTime`] → [`chrono::NaiveDateTime`]
+* [`jiff::civil::Weekday`] ↔ [`chrono::Weekday`]
+* [`jiff::Timestamp`] → [`chrono::DateTime<Utc>`](chrono::DateTime)
+* [`chrono::FixedOffset`] → [`jiff::tz::Offset`]
+* [`chrono::TimeDelta`] → [`jiff::SignedDuration`]
+* [`chrono::TimeDelta`] → [`jiff::Span`]
+
+Infallible (use [`ConvertFrom`] / [`ConvertInto`]):
+
+* [`chrono::Months`] → [`jiff::Span`]
+
+Fallible (use [`ConvertTryFrom`] / [`ConvertTryInto`]):
+
+* [`chrono::NaiveDate`] → [`jiff::civil::Date`]
+  (fails when outside Jiff's year range of `-9999..=9999`)
+* [`chrono::NaiveTime`] → [`jiff::civil::Time`]
+  (fails on leap-second values)
+* [`chrono::NaiveDateTime`] → [`jiff::civil::DateTime`]
+* [`chrono::DateTime<Tz>`](chrono::DateTime) → [`jiff::Timestamp`]
+  (generic over any chrono time zone; fails on leap-second values)
+* [`chrono::DateTime<Utc>`](chrono::DateTime) → [`jiff::Zoned`]
+* [`chrono::DateTime<FixedOffset>`](chrono::DateTime) ↔ [`jiff::Zoned`]
+* [`jiff::tz::Offset`] → [`chrono::FixedOffset`]
+  (fails outside chrono's `±23:59:59` range)
+* [`jiff::SignedDuration`] → [`chrono::TimeDelta`]
+  (fails outside chrono's ~`±2.9 × 10^11` second range)
+* [`jiff::Span`] → [`chrono::TimeDelta`]
+  (fails if the span contains calendar units or overflows)
+
+With the `chrono-tz` feature enabled:
+
+* [`jiff::Zoned`] ↔ `chrono::DateTime<chrono_tz::Tz>`
+* [`jiff::tz::TimeZone`] ↔ `chrono_tz::Tz`
+
+# Semantics caveats
+
+A value can be convertible without being *equivalent*. This section
+summarizes what is silently dropped by each non-trivial conversion and
+where the two libraries disagree on meaning. Read it before migrating
+production code.
+
+## Time-zone identity is lost when converting to `FixedOffset`
+
+A [`jiff::Zoned`] carries an IANA time zone (e.g. `America/New_York`) and
+the DST rule set that goes with it. A [`chrono::DateTime<FixedOffset>`](chrono::DateTime)
+only carries a fixed numeric offset. Converting `Zoned → DateTime<FixedOffset>`
+preserves the instant and the current offset but **discards the zone's
+identity and its DST rule**. A round trip back to `Zoned` yields a
+fixed-offset zone — subsequent calendar arithmetic will no longer follow
+DST.
+
+To preserve zone identity across a round trip, enable the `chrono-tz`
+feature and convert to [`chrono::DateTime<chrono_tz::Tz>`](chrono::DateTime) instead.
+
+## Leap seconds are rejected by default
+
+`chrono` can represent a leap-second reading by storing a subsecond value
+in `1_000_000_000..2_000_000_000`. Jiff cannot. The strict conversions
+reject such values with an error. If you have data that genuinely
+contains leap-second readings, use the helpers in the [`lossy`] module to
+clamp them to `:59.999999999` instead.
+
+## `Span` is calendar-aware; `TimeDelta` is not
+
+[`jiff::Span`] can carry `years`, `months`, `weeks`, and `days`, whose
+length depends on a reference date. [`chrono::TimeDelta`] is an absolute
+number of nanoseconds. The strict `Span → TimeDelta` conversion rejects
+any span with nonzero calendar units. If you have decided that days are
+exactly 24 hours (a civil-day interpretation that ignores DST), use
+[`lossy::span_to_timedelta_days_are_24h`]. For spans that should respect
+DST, resolve them first with [`jiff::Span::to_duration`] and an explicit
+reference date.
+
+## `NaiveDateTime` has no intrinsic meaning
+
+A [`chrono::NaiveDateTime`] could be a UTC instant, a local wall-clock
+reading, or a timezone-less civil datetime — the type does not say.
+Because of this ambiguity, this crate deliberately **does not** provide
+`NaiveDateTime → Timestamp` or `NaiveDateTime → Zoned`. Only the civil
+conversion `NaiveDateTime → jiff::civil::DateTime` is offered.
+If your naive value is meant to be a UTC instant, call `.and_utc()` on
+the chrono side first:
+```
+use jiff_chrono::ConvertTryFrom as _;
+let naive = chrono::NaiveDate::from_ymd_opt(2025, 1, 30)
+    .unwrap()
+    .and_hms_opt(17, 58, 30)
+    .unwrap();
+let ts = jiff::Timestamp::convert_try_from(naive.and_utc())?;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+If it is local to a specific zone, use chrono's
+`.and_local_timezone(tz).single()` (or the appropriate `LocalResult`
+branch) first, so the disambiguation decision is made at the chrono call
+site rather than buried inside a conversion.
+
+## DST-gap / DST-fold disambiguation policy
+
+This crate never constructs a zoned datetime from a naive local datetime,
+so DST ambiguity is not introduced on the conversion boundary. When you
+later build `jiff::Zoned` values from civil datetimes using Jiff's own
+API, note that Jiff defaults to `Disambiguation::Compatible` (gap →
+shift forward, fold → first occurrence), which may differ from how your
+old chrono code resolved `LocalResult::Ambiguous`/`::None`. Audit those
+call sites during migration.
+
+## `Timestamp`/`Zoned` vs `DateTime<Utc>`/`DateTime<Tz>`
+
+chrono code often uses `DateTime<Utc>` as a catch-all "timestamp" type.
+Jiff splits the concept: [`jiff::Timestamp`] is an absolute instant with
+no zone, and [`jiff::Zoned`] is an instant plus a zone. The conversion
+traits in this crate preserve that split — `DateTime<Utc> → Timestamp`
+discards nothing, but `Zoned ↔ DateTime<Tz>` moves the whole
+instant-plus-zone pair. Use the split to audit which variables in your
+migrated code are actually instants and which are zone-aware.
+
+# Known gaps
+
+* No conversions involving [`chrono::Local`]. Call
+  `.with_timezone(&Utc)` on chrono's side first.
+* No conversions from [`jiff::tz::TimeZone`] to a chrono zone type on its
+  own; time-zone identity only travels as part of a [`jiff::Zoned`] /
+  `chrono::DateTime<Tz>` pair.
+* No conversions involving [`std::time::Duration`] — Jiff already provides
+  those via [`jiff::SignedDuration`].
+* No `NaiveDateTime → Timestamp` / `NaiveDateTime → Zoned`. See the
+  "`NaiveDateTime` has no intrinsic meaning" caveat above.
+* No [`chrono::Days`] → [`jiff::Span`]. As of `chrono` 0.4.44, the inner
+  `u64` of `chrono::Days` is not exposed through any public accessor,
+  so we cannot read it out. Reconstruct on the Jiff side via
+  [`jiff::ToSpan::days`](jiff::ToSpan::days) instead.
+
+# Crate features
+
+* `std` (default) — enables the standard library. Required by most impls.
+* `alloc` — enables heap-allocated error messages in `no_std` builds.
+* `chrono-tz` — enables conversions between [`jiff::Zoned`] and
+  `chrono::DateTime<chrono_tz::Tz>`. Implies `std`.
+* `serde` — enables the `serde` feature on both `jiff` and `chrono`. This
+  crate defines no `serde` impls itself.
+
+# Example: migrating a value between the two ecosystems
+
+```
+use jiff_chrono::{ConvertFrom as _, ConvertTryFrom as _};
+
+let jiff_ts: jiff::Timestamp = "2025-01-30T17:58:30Z".parse()?;
+
+// Jiff → chrono (infallible for this pair).
+let chrono_dt = chrono::DateTime::<chrono::Utc>::convert_from(jiff_ts);
+assert_eq!(chrono_dt.to_rfc3339(), "2025-01-30T17:58:30+00:00");
+
+// chrono → Jiff (fallible because chrono's range is wider).
+let round_trip = jiff::Timestamp::convert_try_from(chrono_dt)?;
+assert_eq!(round_trip, jiff_ts);
+
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+*/
+
+#![no_std]
+#![deny(missing_docs)]
+#![cfg_attr(docsrs_jiff, feature(doc_cfg))]
+
+#[cfg(any(test, feature = "std"))]
+extern crate std;
+
+#[cfg(any(test, feature = "alloc"))]
+extern crate alloc;
+
+mod civil;
+mod duration;
+mod error;
+pub mod lossy;
+mod offset;
+mod timestamp;
+mod traits;
+mod zoned;
+
+pub use self::{
+    error::Error,
+    traits::{ConvertFrom, ConvertInto, ConvertTryFrom, ConvertTryInto},
+};

--- a/crates/jiff-chrono/src/lossy.rs
+++ b/crates/jiff-chrono/src/lossy.rs
@@ -1,0 +1,162 @@
+/*!
+Opt-in conversions that change the **meaning** of a value, not just its
+representation.
+
+Every function in this module makes a semantic choice that the default,
+strict conversion traits refuse to make for you. Calling one of these
+functions is an explicit acknowledgment of that choice.
+
+None of these helpers are traits — they are plainly named functions so
+that each call site makes the trade-off visible.
+
+# When to use these
+
+* [`naive_time_saturating`] / [`naive_datetime_saturating`] /
+  [`utc_datetime_saturating`] — when you have chrono data that genuinely
+  contains leap-second readings (nanoseconds `>= 1_000_000_000`) and you
+  prefer clamping them to `:59.999999999` over rejecting them.
+* [`span_to_timedelta_days_are_24h`] — when you want to convert a
+  [`jiff::Span`] that has nonzero `days` to a [`chrono::TimeDelta`] and you
+  have decided that days should be treated as exactly 24 hours (civil
+  days, ignoring DST transitions). If your span may cross a DST boundary,
+  use [`jiff::Span::to_duration`] with an explicit reference date
+  instead.
+*/
+
+use chrono::{
+    DateTime as ChronoDateTime, NaiveDateTime as ChronoNaiveDateTime,
+    NaiveTime as ChronoNaiveTime, TimeDelta as ChronoTimeDelta, Timelike as _,
+    Utc,
+};
+use jiff::{
+    civil::{DateTime as JiffDateTime, Time as JiffTime},
+    Span as JiffSpan, SpanRelativeTo, Timestamp as JiffTimestamp,
+};
+
+use crate::{
+    error::Error,
+    traits::{ConvertTryFrom, ConvertTryInto as _},
+};
+
+/// Convert a [`chrono::NaiveTime`] to [`jiff::civil::Time`], saturating any
+/// leap-second value down to `23:59:59.999999999`.
+///
+/// Chrono represents a leap-second reading by storing a nanosecond value
+/// in `1_000_000_000..2_000_000_000`. Jiff has no representation for leap
+/// seconds, so the strict
+/// [`ConvertTryFrom`](crate::ConvertTryFrom) impl rejects such values.
+/// This helper instead clamps them to the last representable instant
+/// within the minute.
+///
+/// # Example
+///
+/// ```
+/// let leap =
+///     chrono::NaiveTime::from_hms_nano_opt(23, 59, 59, 1_500_000_000)
+///         .unwrap();
+/// let t = jiff_chrono::lossy::naive_time_saturating(leap);
+/// assert_eq!(t, jiff::civil::time(23, 59, 59, 999_999_999));
+/// ```
+pub fn naive_time_saturating(t: ChronoNaiveTime) -> JiffTime {
+    let nano = t.nanosecond();
+    let nano = if nano >= 1_000_000_000 { 999_999_999 } else { nano };
+    // NaiveTime guarantees hour in 0..24, minute in 0..60, second in 0..60.
+    JiffTime::new(
+        t.hour() as i8,
+        t.minute() as i8,
+        t.second() as i8,
+        nano as i32,
+    )
+    .unwrap()
+}
+
+/// Convert a [`chrono::NaiveDateTime`] to [`jiff::civil::DateTime`],
+/// saturating any leap-second value in the time component.
+///
+/// Fails if the date component is outside Jiff's year range of
+/// `-9999..=9999`.
+///
+/// See [`naive_time_saturating`] for the leap-second policy.
+pub fn naive_datetime_saturating(
+    dt: ChronoNaiveDateTime,
+) -> Result<JiffDateTime, Error> {
+    let date = dt.date().convert_try_into()?;
+    let time = naive_time_saturating(dt.time());
+    Ok(JiffDateTime::from_parts(date, time))
+}
+
+/// Convert a [`chrono::DateTime<Utc>`](chrono::DateTime) to [`jiff::Timestamp`],
+/// saturating any leap-second value down to `:59.999999999`.
+///
+/// Fails only if the underlying instant is outside Jiff's timestamp range.
+///
+/// # Example
+///
+/// ```
+/// // Construct a `DateTime<Utc>` that carries a leap-second reading.
+/// // `and_hms_nano_opt` accepts nanos up to 2_000_000_000 when the
+/// // second is 59, which is how chrono encodes `:60.x`.
+/// let leap = chrono::NaiveDate::from_ymd_opt(2016, 12, 31)
+///     .unwrap()
+///     .and_hms_nano_opt(23, 59, 59, 1_500_000_000)
+///     .unwrap()
+///     .and_utc();
+/// let ts = jiff_chrono::lossy::utc_datetime_saturating(leap)?;
+/// assert_eq!(ts.to_string(), "2016-12-31T23:59:59.999999999Z");
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub fn utc_datetime_saturating(
+    dt: ChronoDateTime<Utc>,
+) -> Result<JiffTimestamp, Error> {
+    // When chrono stores a leap-second instant, `timestamp()` returns the
+    // seconds of the preceding non-leap instant (i.e. ':59'), and
+    // `timestamp_subsec_nanos()` returns a value in
+    // `1_000_000_000..2_000_000_000`. Clamping the nanos to 999_999_999
+    // picks "the last nanosecond of the minute," matching the policy used
+    // by [`naive_time_saturating`].
+    let secs = dt.timestamp();
+    let nanos = dt.timestamp_subsec_nanos();
+    let nanos = if nanos >= 1_000_000_000 { 999_999_999 } else { nanos };
+    Ok(JiffTimestamp::new(secs, nanos as i32)?)
+}
+
+/// Convert a [`jiff::Span`] to [`chrono::TimeDelta`] under the assumption
+/// that days are always exactly 24 hours.
+///
+/// The strict [`ConvertTryFrom`](crate::ConvertTryFrom) impl for
+/// `TimeDelta` refuses spans with any nonzero calendar units (years,
+/// months, weeks, days), because in general those units only have a
+/// well-defined length relative to a reference date. This helper
+/// accepts spans whose largest unit is `day` by treating each day as
+/// 24 × 60 × 60 seconds — the civil-day interpretation. Spans with
+/// nonzero weeks, months, or years still fail, because those units
+/// cannot be resolved without a reference date even under this policy.
+///
+/// If your span might cross a DST boundary, prefer
+/// [`jiff::Span::to_duration`] with an explicit civil or zoned
+/// reference instead of this helper.
+///
+/// # Example
+///
+/// ```
+/// use jiff::ToSpan;
+///
+/// let td = jiff_chrono::lossy::span_to_timedelta_days_are_24h(
+///     1.day().hours(2),
+/// )?;
+/// assert_eq!(td.num_hours(), 26);
+///
+/// // Weeks/months/years are still rejected.
+/// assert!(jiff_chrono::lossy::span_to_timedelta_days_are_24h(
+///     1.month(),
+/// ).is_err());
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub fn span_to_timedelta_days_are_24h(
+    span: JiffSpan,
+) -> Result<ChronoTimeDelta, Error> {
+    let sd = span.to_duration(SpanRelativeTo::days_are_24_hours())?;
+    ChronoTimeDelta::convert_try_from(sd)
+}

--- a/crates/jiff-chrono/src/offset.rs
+++ b/crates/jiff-chrono/src/offset.rs
@@ -1,0 +1,93 @@
+use chrono::FixedOffset as ChronoFixedOffset;
+use jiff::tz::Offset as JiffOffset;
+
+use crate::{
+    error::{err, Error},
+    traits::{ConvertFrom, ConvertTryFrom},
+};
+
+/// Converts from a [`chrono::FixedOffset`] to a [`jiff::tz::Offset`].
+///
+/// This conversion is infallible because chrono's offset range
+/// (`±23:59:59`) is strictly smaller than Jiff's (`±25:59:59`).
+///
+/// # Example
+///
+/// ```
+/// use jiff_chrono::ConvertFrom as _;
+///
+/// let chrono_offset = chrono::FixedOffset::east_opt(-5 * 3600).unwrap();
+/// let jiff_offset = jiff::tz::Offset::convert_from(chrono_offset);
+/// assert_eq!(jiff_offset, jiff::tz::offset(-5));
+/// ```
+impl ConvertFrom<ChronoFixedOffset> for JiffOffset {
+    fn convert_from(v: ChronoFixedOffset) -> JiffOffset {
+        // `FixedOffset::local_minus_utc()` returns seconds in
+        // `-86_399..=86_399`. That is a strict subset of Jiff's
+        // `-93_599..=93_599`, so this unwrap never fires.
+        JiffOffset::from_seconds(v.local_minus_utc()).unwrap()
+    }
+}
+
+/// Converts from a [`jiff::tz::Offset`] to a [`chrono::FixedOffset`].
+///
+/// This conversion is fallible because Jiff's offset range (`±25:59:59`) is
+/// wider than chrono's (`±23:59:59`). In practice all offsets used by real
+/// IANA time zones fit comfortably within chrono's range.
+///
+/// # Example
+///
+/// ```
+/// use jiff_chrono::ConvertTryFrom as _;
+///
+/// let jiff_offset = jiff::tz::offset(-5);
+/// let chrono_offset =
+///     chrono::FixedOffset::convert_try_from(jiff_offset)?;
+/// assert_eq!(chrono_offset.local_minus_utc(), -5 * 3600);
+///
+/// // Offsets beyond chrono's ±23:59:59 limit are rejected.
+/// let big = jiff::tz::Offset::from_seconds(25 * 3600).unwrap();
+/// assert!(chrono::FixedOffset::convert_try_from(big).is_err());
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+impl ConvertTryFrom<JiffOffset> for ChronoFixedOffset {
+    type Error = Error;
+
+    fn convert_try_from(v: JiffOffset) -> Result<ChronoFixedOffset, Error> {
+        ChronoFixedOffset::east_opt(v.seconds()).ok_or_else(|| {
+            err!(
+                "failed to convert Jiff offset of {v} seconds to \
+                 `chrono::FixedOffset`: chrono requires the offset to be \
+                 within ±23:59:59",
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::traits::{ConvertInto as _, ConvertTryInto as _};
+
+    use super::*;
+
+    quickcheck::quickcheck! {
+        fn prop_fixed_offset_to_jiff_roundtrip(seconds: i32) -> quickcheck::TestResult {
+            // Restrict to chrono's valid range.
+            if !(-86_399..=86_399).contains(&seconds) {
+                return quickcheck::TestResult::discard();
+            }
+            let chrono_offset = ChronoFixedOffset::east_opt(seconds).unwrap();
+            let jiff_offset: JiffOffset = chrono_offset.convert_into();
+            let back: ChronoFixedOffset =
+                jiff_offset.convert_try_into().unwrap();
+            quickcheck::TestResult::from_bool(chrono_offset == back)
+        }
+    }
+
+    #[test]
+    fn jiff_offset_beyond_chrono_is_rejected() {
+        let big = JiffOffset::from_seconds(25 * 3600).unwrap();
+        assert!(ChronoFixedOffset::convert_try_from(big).is_err());
+    }
+}

--- a/crates/jiff-chrono/src/timestamp.rs
+++ b/crates/jiff-chrono/src/timestamp.rs
@@ -1,0 +1,113 @@
+use chrono::{DateTime as ChronoDateTime, TimeZone as ChronoTimeZone, Utc};
+use jiff::Timestamp as JiffTimestamp;
+
+use crate::{
+    error::{err, Error},
+    traits::{ConvertFrom, ConvertTryFrom},
+};
+
+/// Converts from a [`jiff::Timestamp`] to a [`chrono::DateTime<Utc>`](chrono::DateTime).
+///
+/// This conversion is infallible because Jiff's `Timestamp` range is a
+/// subset of chrono's `DateTime<Utc>` range.
+///
+/// # Example
+///
+/// ```
+/// use jiff_chrono::ConvertFrom as _;
+///
+/// let jiff_ts: jiff::Timestamp = "2025-01-30T17:58:30Z".parse()?;
+/// let chrono_dt = chrono::DateTime::<chrono::Utc>::convert_from(jiff_ts);
+/// assert_eq!(chrono_dt.to_rfc3339(), "2025-01-30T17:58:30+00:00");
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+impl ConvertFrom<JiffTimestamp> for ChronoDateTime<Utc> {
+    fn convert_from(v: JiffTimestamp) -> ChronoDateTime<Utc> {
+        // `subsec_nanosecond` is in `-999_999_999..=999_999_999` and shares
+        // the sign of the seconds, so after calling `.unsigned_abs()` it
+        // fits in `0..1_000_000_000`, which is what `from_timestamp` wants.
+        ChronoDateTime::from_timestamp(
+            v.as_second(),
+            v.subsec_nanosecond().unsigned_abs(),
+        )
+        .unwrap()
+    }
+}
+
+/// Converts from a [`chrono::DateTime<Tz>`](chrono::DateTime) to a
+/// [`jiff::Timestamp`], for any chrono time zone type.
+///
+/// This is generic over `Tz: chrono::TimeZone`, so it covers
+/// [`chrono::Utc`], [`chrono::FixedOffset`], and (with the `chrono-tz`
+/// feature on the chrono side) any `chrono_tz::Tz`. The time-zone
+/// information is discarded — only the underlying UTC instant is kept.
+///
+/// This conversion is fallible. It can fail if:
+///
+/// * The chrono value falls outside Jiff's supported timestamp range.
+/// * The chrono value represents a leap second
+///   (`timestamp_subsec_nanos() >= 1_000_000_000`), which Jiff does not
+///   model. Use [`crate::lossy::utc_datetime_saturating`] if you want to
+///   clamp leap-second readings instead.
+///
+/// # Example
+///
+/// ```
+/// use jiff_chrono::ConvertTryFrom as _;
+///
+/// // `DateTime<Utc>`:
+/// let cdt: chrono::DateTime<chrono::Utc> =
+///     "2025-01-30T17:58:30Z".parse()?;
+/// let ts = jiff::Timestamp::convert_try_from(cdt)?;
+/// assert_eq!(ts.to_string(), "2025-01-30T17:58:30Z");
+///
+/// // `DateTime<FixedOffset>`, converted directly without going through UTC:
+/// let cdt = chrono::DateTime::parse_from_rfc3339(
+///     "2025-01-30T12:58:30-05:00",
+/// )?;
+/// let ts = jiff::Timestamp::convert_try_from(cdt)?;
+/// assert_eq!(ts.to_string(), "2025-01-30T17:58:30Z");
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+impl<Tz: ChronoTimeZone> ConvertTryFrom<ChronoDateTime<Tz>> for JiffTimestamp {
+    type Error = Error;
+
+    fn convert_try_from(
+        v: ChronoDateTime<Tz>,
+    ) -> Result<JiffTimestamp, Error> {
+        let secs = v.timestamp();
+        let nanos = v.timestamp_subsec_nanos();
+        if nanos >= 1_000_000_000 {
+            return Err(err!(
+                "chrono `DateTime` subsec nanos {nanos} represent a \
+                 leap second, which is not representable in \
+                 `jiff::Timestamp`",
+            ));
+        }
+        // `nanos` is in `0..1_000_000_000`, which fits in `i32` with a
+        // non-negative value. `Timestamp::new` rebalances negative seconds
+        // with positive nanos, so this construction is safe.
+        Ok(JiffTimestamp::new(secs, nanos as i32)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::traits::{ConvertInto as _, ConvertTryInto as _};
+
+    use super::*;
+
+    quickcheck::quickcheck! {
+        fn prop_timestamp_roundtrip(secs: i64, nanos: u32) -> quickcheck::TestResult {
+            let nanos = (nanos % 1_000_000_000) as i32;
+            let Ok(ts) = JiffTimestamp::new(secs, nanos) else {
+                return quickcheck::TestResult::discard();
+            };
+            let cdt: ChronoDateTime<Utc> = ts.convert_into();
+            let back: JiffTimestamp = cdt.convert_try_into().unwrap();
+            quickcheck::TestResult::from_bool(ts == back)
+        }
+    }
+}

--- a/crates/jiff-chrono/src/traits.rs
+++ b/crates/jiff-chrono/src/traits.rs
@@ -1,0 +1,59 @@
+use core::convert::Infallible;
+
+/// Adds infallible conversions between crates that mirrors [`From`].
+pub trait ConvertFrom<F>: Sized {
+    /// Infallibly converts a value of type `F` to a value of type `Self`.
+    fn convert_from(value: F) -> Self;
+}
+
+/// Adds infallible conversions between crates that mirrors [`Into`].
+pub trait ConvertInto<T>: Sized {
+    /// Infallibly converts a value of type `Self` to a value of type `T`.
+    fn convert_into(self) -> T;
+}
+
+/// Adds fallible conversions between crates that mirrors [`TryFrom`].
+pub trait ConvertTryFrom<F>: Sized {
+    /// The type of an error that can occur during a conversion.
+    ///
+    /// In this crate, all errors correspond to the [`Error`](crate::Error)
+    /// type.
+    type Error;
+
+    /// Fallibly converts a value of type `F` to a value of type `Self`.
+    fn convert_try_from(value: F) -> Result<Self, Self::Error>;
+}
+
+/// Adds fallible conversions between crates that mirrors [`TryInto`].
+pub trait ConvertTryInto<T>: Sized {
+    /// The type of an error that can occur during a conversion.
+    ///
+    /// In this crate, all errors correspond to the [`Error`](crate::Error)
+    /// type.
+    type Error;
+
+    /// Fallibly converts a value of type `Self` to a value of type `T`.
+    fn convert_try_into(self) -> Result<T, Self::Error>;
+}
+
+impl<F: ConvertInto<T>, T> ConvertTryFrom<F> for T {
+    type Error = Infallible;
+
+    fn convert_try_from(value: F) -> Result<T, Infallible> {
+        Ok(value.convert_into())
+    }
+}
+
+impl<F, T: ConvertFrom<F>> ConvertInto<T> for F {
+    fn convert_into(self) -> T {
+        T::convert_from(self)
+    }
+}
+
+impl<F, T: ConvertTryFrom<F>> ConvertTryInto<T> for F {
+    type Error = T::Error;
+
+    fn convert_try_into(self) -> Result<T, T::Error> {
+        T::convert_try_from(self)
+    }
+}

--- a/crates/jiff-chrono/src/zoned.rs
+++ b/crates/jiff-chrono/src/zoned.rs
@@ -1,0 +1,402 @@
+use chrono::{
+    DateTime as ChronoDateTime, FixedOffset as ChronoFixedOffset, Utc,
+};
+use jiff::{
+    tz::{Offset as JiffOffset, TimeZone as JiffTimeZone},
+    Timestamp as JiffTimestamp, Zoned as JiffZoned,
+};
+
+use crate::{
+    error::Error,
+    traits::{ConvertFrom, ConvertInto as _, ConvertTryFrom, ConvertTryInto as _},
+};
+
+#[cfg(feature = "chrono-tz")]
+use crate::error::err;
+
+/// Converts from a [`jiff::Zoned`] to a
+/// [`chrono::DateTime<FixedOffset>`](chrono::DateTime).
+///
+/// The offset on the resulting value is the active offset of the zoned
+/// instant (i.e. `zoned.offset()`), not the time zone's identity. The
+/// IANA zone name, if any, is discarded. Round-tripping through
+/// `DateTime<FixedOffset>` therefore loses DST-awareness.
+///
+/// **This is lossy.** If you need to preserve zone identity across a
+/// round trip, enable the `chrono-tz` feature and convert to
+/// [`chrono::DateTime<chrono_tz::Tz>`](chrono::DateTime) instead. See the
+/// "Semantics caveats" section of the crate docs.
+///
+/// This conversion is fallible because Jiff's [`jiff::tz::Offset`] range
+/// (`±25:59:59`) is wider than chrono's `FixedOffset` range (`±23:59:59`).
+/// In practice, every IANA time zone's actual offset fits within chrono's
+/// range.
+///
+/// # Example
+///
+/// ```
+/// use jiff_chrono::ConvertTryFrom as _;
+///
+/// let zdt: jiff::Zoned =
+///     "2025-01-30T17:58:30-05[America/New_York]".parse()?;
+/// let cdt = chrono::DateTime::<chrono::FixedOffset>::convert_try_from(&zdt)?;
+/// assert_eq!(cdt.to_rfc3339(), "2025-01-30T17:58:30-05:00");
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+impl<'a> ConvertTryFrom<&'a JiffZoned> for ChronoDateTime<ChronoFixedOffset> {
+    type Error = Error;
+
+    fn convert_try_from(
+        v: &'a JiffZoned,
+    ) -> Result<ChronoDateTime<ChronoFixedOffset>, Error> {
+        let offset: ChronoFixedOffset = v.offset().convert_try_into()?;
+        let utc: ChronoDateTime<Utc> = v.timestamp().convert_into();
+        Ok(utc.with_timezone(&offset))
+    }
+}
+
+/// Converts from a [`jiff::Zoned`] to a
+/// [`chrono::DateTime<FixedOffset>`](chrono::DateTime) by value.
+impl ConvertTryFrom<JiffZoned> for ChronoDateTime<ChronoFixedOffset> {
+    type Error = Error;
+
+    fn convert_try_from(
+        v: JiffZoned,
+    ) -> Result<ChronoDateTime<ChronoFixedOffset>, Error> {
+        ChronoDateTime::<ChronoFixedOffset>::convert_try_from(&v)
+    }
+}
+
+/// Converts from a [`chrono::DateTime<FixedOffset>`](chrono::DateTime) to a
+/// [`jiff::Zoned`].
+///
+/// The resulting `Zoned` uses a fixed-offset time zone
+/// ([`jiff::tz::TimeZone::fixed`]). It does not carry any IANA zone
+/// identity, since chrono's `FixedOffset` carries none.
+///
+/// This conversion is fallible: it can fail if the chrono value falls
+/// outside Jiff's supported timestamp range or represents a leap second.
+///
+/// # Example
+///
+/// ```
+/// use jiff_chrono::ConvertTryFrom as _;
+///
+/// let cdt = chrono::DateTime::parse_from_rfc3339(
+///     "2025-01-30T17:58:30-05:00",
+/// )?;
+/// let zdt = jiff::Zoned::convert_try_from(cdt)?;
+/// assert_eq!(zdt.to_string(), "2025-01-30T17:58:30-05:00[-05:00]");
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+impl ConvertTryFrom<ChronoDateTime<ChronoFixedOffset>> for JiffZoned {
+    type Error = Error;
+
+    fn convert_try_from(
+        v: ChronoDateTime<ChronoFixedOffset>,
+    ) -> Result<JiffZoned, Error> {
+        let offset = JiffOffset::convert_from(*v.offset());
+        let ts = JiffTimestamp::convert_try_from(v)?;
+        Ok(ts.to_zoned(JiffTimeZone::fixed(offset)))
+    }
+}
+
+/// Converts from a [`chrono::DateTime<Utc>`](chrono::DateTime) to a
+/// [`jiff::Zoned`] in UTC.
+///
+/// # Example
+///
+/// ```
+/// use jiff_chrono::ConvertTryFrom as _;
+///
+/// let cdt: chrono::DateTime<chrono::Utc> =
+///     "2025-01-30T17:58:30Z".parse()?;
+/// let zdt = jiff::Zoned::convert_try_from(cdt)?;
+/// assert_eq!(zdt.to_string(), "2025-01-30T17:58:30+00:00[UTC]");
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+impl ConvertTryFrom<ChronoDateTime<Utc>> for JiffZoned {
+    type Error = Error;
+
+    fn convert_try_from(
+        v: ChronoDateTime<Utc>,
+    ) -> Result<JiffZoned, Error> {
+        let ts = JiffTimestamp::convert_try_from(v)?;
+        Ok(ts.to_zoned(JiffTimeZone::UTC))
+    }
+}
+
+/// Converts from a [`jiff::Zoned`] to a
+/// [`chrono::DateTime<chrono_tz::Tz>`](chrono::DateTime).
+///
+/// This conversion uses the Jiff time zone's IANA identifier to look up the
+/// corresponding [`chrono_tz::Tz`]. It fails if:
+///
+/// * The Jiff time zone is not IANA-named (e.g. a fixed-offset zone, an
+///   unknown zone, or a POSIX-rule-only zone).
+/// * chrono-tz's bundled database does not recognize the identifier.
+///
+/// Note that `jiff` and `chrono-tz` ship with independent copies of the
+/// IANA time zone database. If the two databases disagree about offsets
+/// for a given instant (e.g. because one is newer than the other), the
+/// converted value's local clock reading may not match the original. This
+/// crate does not try to detect such skew.
+///
+/// # Example
+///
+/// ```
+/// use jiff_chrono::ConvertTryFrom as _;
+///
+/// let zdt: jiff::Zoned =
+///     "2025-01-30T17:58:30-05[America/New_York]".parse()?;
+/// let cdt =
+///     chrono::DateTime::<chrono_tz::Tz>::convert_try_from(&zdt)?;
+/// assert_eq!(cdt.timezone(), chrono_tz::America::New_York);
+/// assert_eq!(cdt.to_rfc3339(), "2025-01-30T17:58:30-05:00");
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[cfg(feature = "chrono-tz")]
+#[cfg_attr(docsrs_jiff, doc(cfg(feature = "chrono-tz")))]
+impl<'a> ConvertTryFrom<&'a JiffZoned> for ChronoDateTime<chrono_tz::Tz> {
+    type Error = Error;
+
+    fn convert_try_from(
+        v: &'a JiffZoned,
+    ) -> Result<ChronoDateTime<chrono_tz::Tz>, Error> {
+        use core::str::FromStr as _;
+
+        let Some(name) = v.time_zone().iana_name() else {
+            return Err(err!(
+                "cannot convert Jiff `Zoned` to `chrono::DateTime<Tz>`: \
+                 time zone has no IANA name",
+            ));
+        };
+        let tz = chrono_tz::Tz::from_str(name).map_err(|_| {
+            err!(
+                "cannot convert Jiff `Zoned` to `chrono::DateTime<Tz>`: \
+                 `chrono-tz` does not recognize IANA name {name:?}",
+            )
+        })?;
+        let utc: ChronoDateTime<Utc> = v.timestamp().convert_into();
+        Ok(utc.with_timezone(&tz))
+    }
+}
+
+/// Converts from a [`jiff::Zoned`] to a
+/// [`chrono::DateTime<chrono_tz::Tz>`](chrono::DateTime) by value.
+#[cfg(feature = "chrono-tz")]
+#[cfg_attr(docsrs_jiff, doc(cfg(feature = "chrono-tz")))]
+impl ConvertTryFrom<JiffZoned> for ChronoDateTime<chrono_tz::Tz> {
+    type Error = Error;
+
+    fn convert_try_from(
+        v: JiffZoned,
+    ) -> Result<ChronoDateTime<chrono_tz::Tz>, Error> {
+        ChronoDateTime::<chrono_tz::Tz>::convert_try_from(&v)
+    }
+}
+
+/// Converts from a [`chrono::DateTime<chrono_tz::Tz>`](chrono::DateTime) to a
+/// [`jiff::Zoned`].
+///
+/// The resulting `Zoned` is anchored to the same instant as the input and
+/// uses the same IANA time zone name, looked up via
+/// [`jiff::tz::TimeZone::get`].
+///
+/// This conversion fails if Jiff cannot find the zone identifier in its
+/// database, or if the instant falls outside Jiff's supported range.
+///
+/// # Example
+///
+/// ```
+/// use jiff_chrono::ConvertTryFrom as _;
+///
+/// let cdt = chrono::DateTime::parse_from_rfc3339(
+///     "2025-01-30T17:58:30-05:00",
+/// )?.with_timezone(&chrono_tz::America::New_York);
+/// let zdt = jiff::Zoned::convert_try_from(cdt)?;
+/// assert_eq!(
+///     zdt.to_string(),
+///     "2025-01-30T17:58:30-05:00[America/New_York]",
+/// );
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[cfg(feature = "chrono-tz")]
+#[cfg_attr(docsrs_jiff, doc(cfg(feature = "chrono-tz")))]
+impl ConvertTryFrom<ChronoDateTime<chrono_tz::Tz>> for JiffZoned {
+    type Error = Error;
+
+    fn convert_try_from(
+        v: ChronoDateTime<chrono_tz::Tz>,
+    ) -> Result<JiffZoned, Error> {
+        let name = v.timezone().name();
+        let tz = JiffTimeZone::get(name)?;
+        let ts = JiffTimestamp::convert_try_from(v)?;
+        Ok(ts.to_zoned(tz))
+    }
+}
+
+/// Converts from a [`jiff::tz::TimeZone`] to a [`chrono_tz::Tz`].
+///
+/// Uses the Jiff zone's IANA identifier, looked up against chrono-tz's
+/// bundled database. This conversion fails if:
+///
+/// * The Jiff time zone has no IANA name (e.g. a fixed-offset zone, the
+///   unknown zone, or a POSIX-rule-only zone).
+/// * chrono-tz's bundled database does not recognize the identifier.
+///
+/// # Example
+///
+/// ```
+/// use jiff_chrono::ConvertTryFrom as _;
+///
+/// let jiff_tz = jiff::tz::TimeZone::get("America/New_York")?;
+/// let chrono_tz = chrono_tz::Tz::convert_try_from(&jiff_tz)?;
+/// assert_eq!(chrono_tz, chrono_tz::America::New_York);
+///
+/// // Fixed-offset zones have no IANA name, so they are rejected.
+/// let fixed = jiff::tz::TimeZone::fixed(jiff::tz::offset(-5));
+/// assert!(chrono_tz::Tz::convert_try_from(&fixed).is_err());
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[cfg(feature = "chrono-tz")]
+#[cfg_attr(docsrs_jiff, doc(cfg(feature = "chrono-tz")))]
+impl<'a> ConvertTryFrom<&'a JiffTimeZone> for chrono_tz::Tz {
+    type Error = Error;
+
+    fn convert_try_from(v: &'a JiffTimeZone) -> Result<chrono_tz::Tz, Error> {
+        use core::str::FromStr as _;
+
+        let Some(name) = v.iana_name() else {
+            return Err(err!(
+                "cannot convert Jiff `TimeZone` to `chrono_tz::Tz`: \
+                 time zone has no IANA name",
+            ));
+        };
+        chrono_tz::Tz::from_str(name).map_err(|_| {
+            err!(
+                "cannot convert Jiff `TimeZone` to `chrono_tz::Tz`: \
+                 `chrono-tz` does not recognize IANA name {name:?}",
+            )
+        })
+    }
+}
+
+/// Converts from a [`jiff::tz::TimeZone`] to a [`chrono_tz::Tz`] by value.
+#[cfg(feature = "chrono-tz")]
+#[cfg_attr(docsrs_jiff, doc(cfg(feature = "chrono-tz")))]
+impl ConvertTryFrom<JiffTimeZone> for chrono_tz::Tz {
+    type Error = Error;
+
+    fn convert_try_from(v: JiffTimeZone) -> Result<chrono_tz::Tz, Error> {
+        chrono_tz::Tz::convert_try_from(&v)
+    }
+}
+
+/// Converts from a [`chrono_tz::Tz`] to a [`jiff::tz::TimeZone`].
+///
+/// Uses the chrono-tz identifier's IANA name to look up the zone in
+/// Jiff's time zone database. In practice this fails only if the running
+/// system's tzdb is missing an identifier that chrono-tz knows about,
+/// which is rare but possible on minimal containers.
+///
+/// # Example
+///
+/// ```
+/// use jiff_chrono::ConvertTryFrom as _;
+///
+/// let chrono_tz = chrono_tz::Asia::Tokyo;
+/// let jiff_tz = jiff::tz::TimeZone::convert_try_from(chrono_tz)?;
+/// assert_eq!(jiff_tz.iana_name(), Some("Asia/Tokyo"));
+///
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[cfg(feature = "chrono-tz")]
+#[cfg_attr(docsrs_jiff, doc(cfg(feature = "chrono-tz")))]
+impl ConvertTryFrom<chrono_tz::Tz> for JiffTimeZone {
+    type Error = Error;
+
+    fn convert_try_from(v: chrono_tz::Tz) -> Result<JiffTimeZone, Error> {
+        Ok(JiffTimeZone::get(v.name())?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixed_offset_roundtrip() {
+        let zdt: JiffZoned =
+            "2025-01-30T17:58:30-05[America/New_York]".parse().unwrap();
+        let cdt: ChronoDateTime<ChronoFixedOffset> =
+            ChronoDateTime::<ChronoFixedOffset>::convert_try_from(&zdt)
+                .unwrap();
+        let back = JiffZoned::convert_try_from(cdt).unwrap();
+        // The IANA zone identity is discarded by this round trip.
+        assert_eq!(back.timestamp(), zdt.timestamp());
+        assert!(back.time_zone().iana_name().is_none());
+    }
+
+    #[test]
+    fn utc_roundtrip() {
+        let cdt: ChronoDateTime<Utc> =
+            "2025-01-30T17:58:30Z".parse().unwrap();
+        let zdt = JiffZoned::convert_try_from(cdt).unwrap();
+        assert_eq!(zdt.time_zone().iana_name(), Some("UTC"));
+    }
+
+    #[cfg(feature = "chrono-tz")]
+    #[test]
+    fn chrono_tz_named_roundtrip() {
+        let zdt: JiffZoned =
+            "2025-01-30T17:58:30-05[America/New_York]".parse().unwrap();
+        let cdt: ChronoDateTime<chrono_tz::Tz> =
+            ChronoDateTime::<chrono_tz::Tz>::convert_try_from(&zdt).unwrap();
+        assert_eq!(cdt.timezone(), chrono_tz::America::New_York);
+        let back = JiffZoned::convert_try_from(cdt).unwrap();
+        assert_eq!(back.timestamp(), zdt.timestamp());
+        assert_eq!(
+            back.time_zone().iana_name(),
+            Some("America/New_York"),
+        );
+    }
+
+    #[cfg(feature = "chrono-tz")]
+    #[test]
+    fn chrono_tz_fixed_offset_jiff_zone_is_rejected() {
+        let zdt = jiff::Timestamp::from_second(0).unwrap().to_zoned(
+            JiffTimeZone::fixed(JiffOffset::from_seconds(-5 * 3600).unwrap()),
+        );
+        assert!(
+            ChronoDateTime::<chrono_tz::Tz>::convert_try_from(&zdt).is_err(),
+        );
+    }
+
+    #[cfg(feature = "chrono-tz")]
+    #[test]
+    fn timezone_standalone_roundtrip() {
+        use crate::traits::ConvertTryInto as _;
+
+        let jiff_tz = JiffTimeZone::get("Asia/Tokyo").unwrap();
+        let chrono_tz: chrono_tz::Tz = (&jiff_tz).convert_try_into().unwrap();
+        assert_eq!(chrono_tz, chrono_tz::Asia::Tokyo);
+        let back: JiffTimeZone = chrono_tz.convert_try_into().unwrap();
+        assert_eq!(back.iana_name(), Some("Asia/Tokyo"));
+    }
+
+    #[cfg(feature = "chrono-tz")]
+    #[test]
+    fn timezone_fixed_is_rejected_for_chrono_tz() {
+        let fixed = JiffTimeZone::fixed(
+            JiffOffset::from_seconds(-5 * 3600).unwrap(),
+        );
+        assert!(chrono_tz::Tz::convert_try_from(&fixed).is_err());
+    }
+}

--- a/scripts/test-integrations
+++ b/scripts/test-integrations
@@ -12,6 +12,8 @@ set -e
 cd "$(dirname "$0")/.."
 
 integrations=(
+  "jiff-chrono std"
+  "jiff-chrono std,chrono-tz"
   "jiff-diesel mysql"
   "jiff-diesel postgres"
   "jiff-icu std,zoned"
@@ -31,6 +33,7 @@ done
 # Same as above, but with `--lib` only. This is useful when we don't expect
 # doctests to pass for certain feature combinations.
 integrations=(
+  "jiff-chrono alloc"
   "jiff-icu alloc"
   "jiff-icu std"
   "jiff-icu time"


### PR DESCRIPTION
This PR adds a new `jiff-chrono` crate that provides conversions between Jiff types and their counterparts in `chrono` and, optionally, `chrono-tz`. It follows the same structural conventions as `jiff-icu`, `jiff-sqlx`, and `jiff-diesel`: standalone workspace, custom `ConvertFrom` / `ConvertTryFrom` traits (the orphan rule forbids `From` / `TryFrom` between two foreign types), strict-by-default policy, and a separately-named `lossy` module for opt-in semantics.

The covered conversion matrix:

* Civil types (`Date`, `Time`, `DateTime`, `Weekday`) ↔ chrono naive equivalents. Jiff → chrono is infallible; the reverse is fallible due to chrono's wider year range and its leap-second encoding.
* `Timestamp` ↔ `DateTime<Utc>`. The chrono → Jiff side is generic over `Tz: chrono::TimeZone`, so `DateTime<FixedOffset>` and (feature-gated) `DateTime<chrono_tz::Tz>` also convert directly.
* `Zoned` ↔ `DateTime<FixedOffset>`, with a rustdoc caveat that this drops IANA zone identity. Behind a `chrono-tz` feature, `Zoned` ↔ `DateTime<chrono_tz::Tz>` preserves identity.
* `tz::TimeZone` ↔ `chrono_tz::Tz` standalone, also under `chrono-tz`.
* `tz::Offset` ↔ `chrono::FixedOffset`. Jiff → chrono is fallible because Jiff's ±25:59:59 range is wider than chrono's ±23:59:59.
* `SignedDuration` ↔ `TimeDelta`.
* `Span` → `TimeDelta` (strict: rejects any nonzero calendar unit). `TimeDelta` → `Span` and `chrono::Months` → `Span` are infallible.

Some conversions were deliberately omitted:

* `NaiveDateTime → Timestamp` / `NaiveDateTime → Zoned`. A `NaiveDateTime` has no intrinsic meaning — it could be UTC, local, or a zoneless civil reading — and silently picking one is an off-by-N-hours bug waiting to ship. The caller must disambiguate on the chrono side (`.and_utc()` or `.and_local_timezone()`) before converting.
* Anything involving `chrono::Local`.
* `chrono::Days → Span`: as of `chrono` 0.4.44, `chrono::Days` does not expose an accessor for its inner `u64`, so a third-party crate cannot read it.

The `lossy` module provides opt-in helpers for cases where the default conversion refuses a trade-off:

* `naive_time_saturating`, `naive_datetime_saturating`, and `utc_datetime_saturating` clamp chrono leap-second readings (`nanosecond >= 10⁹`) down to `:59.999999999`.
* `span_to_timedelta_days_are_24h` converts a `Span` with nonzero `days` under the civil-day interpretation. Weeks, months, and years still require `Span::to_duration` with an explicit reference.

Features: `std` (default), `alloc`, `chrono-tz`, and `serde` (passthrough; no new serde impls are defined in this crate).

Tests cover boundary cases (range overflow, leap seconds, fixed-offset limits), quickcheck roundtrips, and a feature-combo matrix added to `scripts/test-integrations`.

Ref #34