### PR TITLE
msrv: roll back to Rust 1.70

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Switch to Rust 2024
       run: sed -i.bak 's/^edition = "2021"$/edition = "2024"/' Cargo.toml
     - name: Bump rust-version to Rust 1.85
-      run: sed -i.bak 's/^rust-version = "1\.71"$/rust-version = "1.85"/' Cargo.toml
+      run: sed -i.bak 's/^rust-version = "1\.70"$/rust-version = "1.85"/' Cargo.toml
     - run: ./scripts/test-default
 
   # Test all features enabled.
@@ -96,7 +96,7 @@ jobs:
     - name: Switch to Rust 2024
       run: sed -i.bak 's/^edition = "2021"$/edition = "2024"/' Cargo.toml
     - name: Bump rust-version to Rust 1.85
-      run: sed -i.bak 's/^rust-version = "1\.71"$/rust-version = "1.85"/' Cargo.toml
+      run: sed -i.bak 's/^rust-version = "1\.70"$/rust-version = "1.85"/' Cargo.toml
     - run: ./scripts/test-all
 
   # Test Jiff when only the bundled tzdb is enabled.
@@ -127,7 +127,7 @@ jobs:
     - name: Switch to Rust 2024
       run: sed -i.bak 's/^edition = "2021"$/edition = "2024"/' Cargo.toml
     - name: Bump rust-version to Rust 1.85
-      run: sed -i.bak 's/^rust-version = "1\.71"$/rust-version = "1.85"/' Cargo.toml
+      run: sed -i.bak 's/^rust-version = "1\.70"$/rust-version = "1.85"/' Cargo.toml
     - run: ./scripts/test-only-bundle
 
   # Test Jiff in core-only (including no-alloc) configurations.
@@ -198,7 +198,7 @@ jobs:
     - name: Switch to Rust 2024
       run: sed -i.bak 's/^edition = "2021"$/edition = "2024"/' Cargo.toml
     - name: Bump rust-version to Rust 1.85
-      run: sed -i.bak 's/^rust-version = "1\.71"$/rust-version = "1.85"/' Cargo.toml
+      run: sed -i.bak 's/^rust-version = "1\.70"$/rust-version = "1.85"/' Cargo.toml
     - name: Run tests under release mode
       run: cargo test --verbose --all --profile testrelease
 
@@ -293,7 +293,7 @@ jobs:
       run: sed -i.bak 's/^edition = "2021"$/edition = "2024"/' Cargo.toml
     - name: Bump rust-version to Rust 1.85
       shell: bash
-      run: sed -i.bak 's/^rust-version = "1\.71"$/rust-version = "1.85"/' Cargo.toml
+      run: sed -i.bak 's/^rust-version = "1\.70"$/rust-version = "1.85"/' Cargo.toml
     - run: cargo build --verbose
     - run: cargo doc --features serde,static --verbose
     - run: cargo test --verbose --all
@@ -329,7 +329,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: 1.71.0
+        toolchain: 1.70.0
     # We would use `cargo build --all` here, but `jiff-cli` doesn't really
     # track an MSRV and I don't want it to.
     - name: Build jiff

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["date", "time", "calendar", "zone", "duration"]
 edition = "2021"
 autotests = false
 autoexamples = false
-rust-version = "1.71"
+rust-version = "1.70"
 # We include `/tests/lib.rs` to squash a `cargo package` warning that the
 # `integration` test target is being ignored. We don't include anything else
 # so tests obviously won't work, but it makes `cargo package` quiet.

--- a/src/tz/system/windows/ffi.rs
+++ b/src/tz/system/windows/ffi.rs
@@ -1,6 +1,18 @@
-//! FFI bindings to the Windows function and types used to acquire timezone information
+pub(super) const TIME_ZONE_ID_INVALID: u32 = 0xffffffff;
 
-pub const TIME_ZONE_ID_INVALID: u32 = 0xffffffff;
+#[repr(C)]
+pub(super) struct DYNAMIC_TIME_ZONE_INFORMATION {
+    bias: i32,
+    standard_name: [u16; 32],
+    standard_date: SYSTEMTIME,
+    standard_bias: i32,
+    daylight_name: [u16; 32],
+    daylight_date: SYSTEMTIME,
+    daylight_bias: i32,
+    /// This is the only field we actually need.
+    pub(super) timezone_key_name: [u16; 128],
+    dynamic_daylight_time_disabled: u8,
+}
 
 #[repr(C)]
 struct SYSTEMTIME {
@@ -14,23 +26,10 @@ struct SYSTEMTIME {
     milliseconds: u16,
 }
 
-#[repr(C)]
-pub(super) struct DYNAMIC_TIME_ZONE_INFORMATION {
-    bias: i32,
-    standard_name: [u16; 32],
-    standard_date: SYSTEMTIME,
-    standard_bias: i32,
-    daylight_name: [u16; 32],
-    daylight_date: SYSTEMTIME,
-    daylight_bias: i32,
-    /// This is the only field actually read by jiff
-    pub(super) timezone_key_name: [u16; 128],
-    dynamic_daylight_time_disabled: u8,
-}
-
-// Retrieves the current time zone and dynamic daylight saving time settings.
-//
-// These settings control the translations between Coordinated Universal Time (UTC) and local time.
-//
-// <https://learn.microsoft.com/en-us/windows/win32/api/timezoneapi/nf-timezoneapi-getdynamictimezoneinformation>
+/// Retrieves the current time zone and dynamic daylight saving time settings.
+///
+/// These settings control the translations between Coordinated Universal Time
+/// (UTC) and local time..
+///
+/// See: <https://learn.microsoft.com/en-us/windows/win32/api/timezoneapi/nf-timezoneapi-getdynamictimezoneinformation>
 windows_link::link!("kernel32.dll" "system" fn GetDynamicTimeZoneInformation(info: *mut DYNAMIC_TIME_ZONE_INFORMATION) -> u32);


### PR DESCRIPTION
For some reason I thought this would need an MSRV bump to Rust 1.71. But
that was already status quo. Jiff stayed on 1.70 while the rest of the
world moved on, including the low level Windows system libraries. (Which
is great.)

Jiff will move on too... But the MSRV policy in the README is rather
strictly worded for a pre-1.0 release. So I'll follow that until I
can't.

This PR also does a little clean-up on #538 that I meant to do in the
rollup PR (ref #562) but forgot about.

Ref https://github.com/BurntSushi/jiff/pull/538#issuecomment-4537306375
