### PR TITLE
fix `UnitSet` debug impl, add regression test

### DIFF
--- a/src/span.rs
+++ b/src/span.rs
@@ -6529,7 +6529,7 @@ fn requires_relative_date_err(unit: Unit) -> Result<(), Error> {
 
 #[cfg(test)]
 mod tests {
-    use std::{format, io::Cursor};
+    use std::io::Cursor;
 
     use alloc::string::ToString;
 

--- a/src/span.rs
+++ b/src/span.rs
@@ -5630,7 +5630,7 @@ impl core::fmt::Debug for UnitSet {
             }
             i += 1;
             write!(f, "{}", unit.compact())?;
-            units = units.set(unit, false);
+            units = units.set(unit, true);
         }
         if i == 0 {
             write!(f, "∅")?;
@@ -6529,7 +6529,7 @@ fn requires_relative_date_err(unit: Unit) -> Result<(), Error> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Cursor;
+    use std::{format, io::Cursor};
 
     use alloc::string::ToString;
 
@@ -7182,6 +7182,14 @@ mod tests {
                 2_459_430_479 * 60 * 60 + 34 * 60 + 33,
                 709_551_614,
             ),
+        );
+    }
+
+    #[test]
+    fn unit_set_debug() {
+        assert_eq!(
+            format!("{:?}", UnitSet::from_slice(&[Unit::Second])),
+            "{s}",
         );
     }
 }

--- a/src/span.rs
+++ b/src/span.rs
@@ -7187,9 +7187,7 @@ mod tests {
 
     #[test]
     fn unit_set_debug() {
-        assert_eq!(
-            format!("{:?}", UnitSet::from_slice(&[Unit::Second])),
-            "{s}",
-        );
+        let set = UnitSet::from_slice(&[Unit::Second]);
+        assert_eq!(std::format!("{set:?}"), "{s}");
     }
 }


### PR DESCRIPTION
TLDR: the implementation of `Debug` for `UnitSet` overflowed the stack. 
I added a regression test for this; however, I'm not sure we actually need it. Let me know if you want it removed. 

Closes https://github.com/BurntSushi/jiff/issues/569
