### PR TITLE
readme: add a commitment to Jiff 0.2 after Jiff 1.0 is released

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ It's important to get Jiff 1.0 as "right" as possible. Namely, once it's
 released, I plan to commit to its API indefinitely. At which point, users of
 Jiff should feel comfortable using it as a stable base in public APIs.
 
+Once Jiff 1.0 is released, Jiff 0.2 will continue to get critical bug fix
+updates. There won't be any active feature development, but since so many folks
+are already using Jiff 0.2, it makes sense to offer a transition grace period.
+My plan here is to do it for 1 year after Jiff 1.0 is released.
+
 ### Performance
 
 The most important design goal of Jiff is to be a high level datetime library


### PR DESCRIPTION
I feel strongly that [stability is a deliverable]. Since so many people
are already using Jiff 0.2 (including in public APIs), it's likely that
the invevitable Jiff 1.0 transition may have some pain. I had hoped to
get Jiff 1.0 out _before_ it became widespread in public APIs, but that
ship has sailed.

In any case, the least I can do here is promise to continue supporting
Jiff 0.2 with critical bug fixes after Jiff 1.0 is released.

[stability is a deliverable]: https://blog.rust-lang.org/2014/10/30/Stability/
