### PR TITLE
error: fix error_size test on 32-bit targets

### DIFF
--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -798,7 +798,14 @@ mod tests {
             //
             // 2026-01-14: A change to the `Offset` type made this move back
             // down to `expected_size *= 4`.
-            expected_size *= 4;
+            //
+            // On 32-bit targets the `Offset`-related fields occupy one extra
+            // word compared to 64-bit, so the multiplier is 5 instead of 4.
+            if cfg!(target_pointer_width = "32") {
+                expected_size *= 5;
+            } else {
+                expected_size *= 4;
+            }
         }
         assert_eq!(expected_size, core::mem::size_of::<Error>());
     }


### PR DESCRIPTION
On 32-bit targets compiled without the `alloc` feature, the `Error` type is 20 bytes rather than 16. The existing multiplier of 4 was correct only for 64-bit (`8 * 4 = 32`). On 32-bit, the `Offset`-related fields occupy one additional word, so the multiplier should be 5 (`4 * 5 = 20`).\n\nThis was caught by the Debian packaging team when building jiff for i386/armhf targets.\n\nFixes #573