### PR TITLE
test: fix error size test in no-alloc environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,6 +468,10 @@ jobs:
     # https://github.com/BurntSushi/tauri-jiff
     - if: "!contains(matrix.target, 'android')"
       run: cross test --verbose --target ${{ matrix.target }} --all --all-targets
+    # Useful to catch some classes of test failures.
+    # Ref: https://github.com/BurntSushi/jiff/issues/573
+    - if: "!contains(matrix.target, 'android')"
+      run: cross test --verbose --target ${{ matrix.target }} --lib --no-default-features -- size
     - if: "!contains(matrix.target, 'android')"
       run: cross test --verbose --target ${{ matrix.target }} -p jiff-cli
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+0.2.28 (2026-05-28)
+===================
+This is a small release with a fix for test failures on 32-bit targets in
+`no-alloc` environments.
+
+Bug fixes:
+
+* [#573](https://github.com/BurntSushi/jiff/issues/573):
+Fix test failure on 32-bit targets in `no-alloc` environments.
+
+
 0.2.27 (2026-05-26)
 ===================
 This is a small release with a bug fix for build errors on Windows for very old

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -769,37 +769,49 @@ mod tests {
     // general, we should not increase the size without a very good reason.
     #[test]
     fn error_size() {
-        let mut expected_size = core::mem::size_of::<usize>();
-        if !cfg!(feature = "alloc") {
-            // oooowwwwwwwwwwwch.
-            //
-            // Like, this is horrible, right? core-only environments are
-            // precisely the place where one want to keep things slim. But
-            // in core-only, I don't know of a way to introduce any sort of
-            // indirection in the library level without using a completely
-            // different API.
-            //
-            // This is what makes me doubt that core-only Jiff is actually
-            // useful. In what context are people using a huge library like
-            // Jiff but can't define a small little heap allocator?
-            //
-            // OK, this used to be `expected_size *= 10`, but I slimmed it down
-            // to x3. Still kinda sucks right? If we tried harder, I think we
-            // could probably slim this down more. And if we were willing to
-            // sacrifice error message quality even more (like, all the way),
-            // then we could make `Error` a zero sized type. Which might
-            // actually be the right trade-off for core-only, but I'll hold off
-            // until we have some real world use cases.
-            //
-            // OK... after switching to structured errors, this jumped
-            // back up to `expected_size *= 6`. And that was with me being
-            // conscientious about what data we store inside of error types.
-            // Blech.
-            //
-            // 2026-01-14: A change to the `Offset` type made this move back
-            // down to `expected_size *= 4`.
-            expected_size *= 4;
+        if cfg!(feature = "alloc") {
+            let expected_size = core::mem::size_of::<usize>();
+            assert_eq!(expected_size, core::mem::size_of::<Error>());
+            return;
         }
-        assert_eq!(expected_size, core::mem::size_of::<Error>());
+        // oooowwwwwwwwwwwch.
+        //
+        // Like, this is horrible, right? core-only environments are
+        // precisely the place where one want to keep things slim. But
+        // in core-only, I don't know of a way to introduce any sort of
+        // indirection in the library level without using a completely
+        // different API.
+        //
+        // This is what makes me doubt that core-only Jiff is actually
+        // useful. In what context are people using a huge library like
+        // Jiff but can't define a small little heap allocator?
+        //
+        // OK, this used to be `expected_size *= 10`, but I slimmed it down
+        // to x3. Still kinda sucks right? If we tried harder, I think we
+        // could probably slim this down more. And if we were willing to
+        // sacrifice error message quality even more (like, all the way),
+        // then we could make `Error` a zero sized type. Which might
+        // actually be the right trade-off for core-only, but I'll hold off
+        // until we have some real world use cases.
+        //
+        // OK... after switching to structured errors, this jumped
+        // back up to `expected_size *= 6`. And that was with me being
+        // conscientious about what data we store inside of error types.
+        // Blech.
+        //
+        // 2026-01-14: A change to the `Offset` type made this move back
+        // down to `expected_size *= 4`.
+        //
+        // 2026-05-28: No changes here, but `4 * pointer-size` is not the
+        // right calculation here. This is unfortunately coupled with an
+        // internal representation for the biggest possible error variant.
+        // And also compiler optimizations. But at time of writing, it's
+        // from the `jiff::error::tz::offset::Error` enum. We get 4 32-bit
+        // integers (always 32-bit) plus one pointer sized discriminant.
+        //
+        // 2026-05-28 redux: this now seems coupled with compiler
+        // optimizations. So just give up and check that it's reasonable.
+        let got = core::mem::size_of::<Error>();
+        assert!(got <= 40, "wanted error size to be <= 40, but got {got}");
     }
 }


### PR DESCRIPTION
One wonders why even bother having such a test. It's annoying. The
reason is to keep a tight check on the size of `Error` when there is no
allocator. It's already pretty bad, so we try not to make it worse.

We also make sure this test is covered in CI.

Fixes #573
