### PR TITLE
tz: fix tzdata locations on Android

### DIFF
--- a/src/tz/db/concatenated/enabled.rs
+++ b/src/tz/db/concatenated/enabled.rs
@@ -27,14 +27,19 @@ const DEFAULT_TTL: Duration = Duration::new(5 * 60, 0);
 /// The places to look for a concatenated `tzdata` file.
 static TZDATA_LOCATIONS: &[TzdataLocation] = &[
     TzdataLocation::Env {
-        name: "ANDROID_ROOT",
-        default: "/system",
-        suffix: "usr/share/zoneinfo/tzdata",
+        name: "ANDROID_TZDATA_ROOT",
+        default: "/apex/com.android.tzdata",
+        suffix: "etc/tz/tzdata",
     },
     TzdataLocation::Env {
         name: "ANDROID_DATA",
-        default: "/data/misc",
-        suffix: "zoneinfo/current/tzdata",
+        default: "/data",
+        suffix: "misc/zoneinfo/current/tzdata",
+    },
+    TzdataLocation::Env {
+        name: "ANDROID_ROOT",
+        default: "/system",
+        suffix: "usr/share/zoneinfo/tzdata",
     },
 ];
 


### PR DESCRIPTION
Hi, this PR is about a fix to find right tzdata paths for Android. Thank you for your time to review this.
- added `/apex/com.android.tzdata/etc/tz/tzdata`
- corrected the right path for `/data/misc/zoneinfo/current`
- corrected lookup priority: `apex` -> `current` -> `system`

Feel free to see more detailed issue description and verification after fix here https://github.com/BurntSushi/jiff/issues/582.