### PR TITLE
fmt: fix rendering of datetime value in error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Bug fixes:
 * [#525](https://github.com/BurntSushi/jiff/issues/525):
 Fix a bug that prevented time zone lookups when using an on-disk time zone
 database on Windows.
+* [#539](https://github.com/BurntSushi/jiff/issues/539):
+Fix a bug where rendering a datetime in an error message would omit a `T`
+separator.
 
 
 0.2.28 (2026-05-28)

--- a/src/fmt/temporal/mod.rs
+++ b/src/fmt/temporal/mod.rs
@@ -2489,6 +2489,17 @@ mod tests {
         );
     }
 
+    // Regression test for: https://github.com/BurntSushi/jiff/issues/539
+    #[test]
+    fn err_temporal_datetime_unparsed_input() {
+        insta::assert_snapshot!(
+            DateTimeParser::new()
+                .parse_datetime(b"2026-04-17 19:43 AM")
+                .unwrap_err(),
+            @r###"parsed value '2026-04-17T19:43:00', but unparsed input " AM" remains (expected no unparsed input)"###,
+        );
+    }
+
     #[test]
     fn year_zero() {
         insta::assert_snapshot!(

--- a/src/fmt/temporal/parser.rs
+++ b/src/fmt/temporal/parser.rs
@@ -172,6 +172,7 @@ impl<'i> core::fmt::Display for ParsedDateTime<'i> {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         core::fmt::Display::fmt(&self.date, f)?;
         if let Some(ref time) = self.time {
+            f.write_str("T")?;
             core::fmt::Display::fmt(&time, f)?;
         }
         if let Some(ref offset) = self.offset {


### PR DESCRIPTION
Fixes #539
