### PR TITLE
Fast weekday

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+0.2.30 (TBD)
+============
+TODO
+
+Enhancements:
+
+* [#591](https://github.com/BurntSushi/jiff/pull/591):
+Improve the performance of weekday calculations from Gregorian dates by 30-50%.
+
+
 0.2.29 (2026-06-20)
 ===================
 This release adds support for [`defmt`], which is a highly efficient logging

--- a/bench/src/date.rs
+++ b/bench/src/date.rs
@@ -12,6 +12,9 @@ pub(super) fn define(c: &mut Criterion) {
     day_of_year_get(c);
     days_in_month(c);
     difference_days(c);
+    weekday(c);
+    nth_weekday_of_month(c);
+    nth_weekday(c);
     tomorrow(c);
     yesterday(c);
 }
@@ -251,6 +254,175 @@ fn difference_days(c: &mut Criterion) {
         benchmark(c, format!("{NAME}/duration/time"), |b| {
             b.iter(|| {
                 let got = (bb(date2) - bb(date1)).whole_days();
+                assert_eq!(got, expected);
+            })
+        });
+    }
+}
+
+/// Measures the timing for finding weekday of a date.
+fn weekday(c: &mut Criterion) {
+    const NAME: &str = "date/weekday";
+
+    let date = civil::date(2026, 6, 15);
+    let expected = civil::Weekday::Monday;
+    {
+        benchmark(c, format!("{NAME}/jiff"), |b| {
+            b.iter(|| {
+                let got = bb(date).weekday();
+                assert_eq!(got, expected);
+            })
+        });
+    }
+    {
+        let date = chrono::NaiveDate::convert_from(date);
+        let expected = chrono::Weekday::Mon;
+        benchmark(c, format!("{NAME}/chrono"), |b| {
+            b.iter(|| {
+                use chrono::Datelike;
+                let got = bb(date).weekday();
+                assert_eq!(got, expected);
+            })
+        });
+    }
+    {
+        let date = time::Date::convert_from(date);
+        let expected = time::Weekday::Monday;
+        benchmark(c, format!("{NAME}/time"), |b| {
+            b.iter(|| {
+                let got = bb(date).weekday();
+                assert_eq!(got, expected);
+            })
+        });
+    }
+}
+
+/// Measures the timing for finding the nth weekday of a month.
+///
+/// Compares jiff's `Date::nth_weekday_of_month` against chrono's
+/// `NaiveDate::from_weekday_of_month_opt` for the positive-nth case.
+/// Chrono has no API for negative nth (last weekday), so that variant is
+/// jiff-only.
+fn nth_weekday_of_month(c: &mut Criterion) {
+    const NAME: &str = "date/nth_weekday_of_month";
+
+    // 2nd Friday of June 2026 -> 2026-06-12
+    // (June 1 2026 is a Monday, so the 2nd Friday is June 12.)
+    let date = civil::date(2026, 6, 15);
+    let expected = civil::date(2026, 6, 12);
+    {
+        benchmark(c, format!("{NAME}/second/jiff"), |b| {
+            b.iter(|| {
+                let got = bb(date)
+                    .nth_weekday_of_month(2, civil::Weekday::Friday)
+                    .unwrap();
+                assert_eq!(got, expected);
+            })
+        });
+    }
+    {
+        let expected = chrono::NaiveDate::convert_from(expected);
+        benchmark(c, format!("{NAME}/second/chrono"), |b| {
+            b.iter(|| {
+                let got = chrono::NaiveDate::from_weekday_of_month_opt(
+                    bb(2026i32),
+                    bb(6u32),
+                    bb(chrono::Weekday::Fri),
+                    bb(2u8),
+                )
+                .unwrap();
+                assert_eq!(got, expected);
+            })
+        });
+    }
+
+    {
+        // Last Thursday of June 2026 -> 2026-06-25
+        // (Thursdays in June 2026: 4, 11, 18, 25.)
+        let expected = civil::date(2026, 6, 25);
+        benchmark(c, format!("{NAME}/last/jiff"), |b| {
+            b.iter(|| {
+                let got = bb(date)
+                    .nth_weekday_of_month(-1, civil::Weekday::Thursday)
+                    .unwrap();
+                assert_eq!(got, expected);
+            })
+        });
+    }
+}
+
+/// Measures the timing for finding the nth weekday relative to a date.
+///
+/// Jiff is the only library benchmarked here since neither chrono nor `time`
+/// expose a direct equivalent to `Date::nth_weekday`.
+fn nth_weekday(c: &mut Criterion) {
+    const NAME: &str = "date/nth_weekday";
+
+    // Next Friday after 2026-06-15 (Monday) -> 2026-06-19.
+    let date = civil::date(2026, 6, 15);
+    let expected = civil::date(2026, 6, 19);
+    {
+        benchmark(c, format!("{NAME}/next/jiff"), |b| {
+            b.iter(|| {
+                let got =
+                    bb(date).nth_weekday(1, civil::Weekday::Friday).unwrap();
+                assert_eq!(got, expected);
+            })
+        });
+    }
+    {
+        let date = time::Date::convert_from(date);
+        let expected = time::Date::convert_from(expected);
+        benchmark(c, format!("{NAME}/next/time"), |b| {
+            b.iter(|| {
+                let got = bb(date).next_occurrence(time::Weekday::Friday);
+                assert_eq!(got, expected);
+            })
+        });
+    }
+
+    // Previous Saturday before 2026-06-15 (Monday) -> 2026-06-13.
+    let expected = civil::date(2026, 6, 13);
+    {
+        benchmark(c, format!("{NAME}/prev/jiff"), |b| {
+            b.iter(|| {
+                let got = bb(date)
+                    .nth_weekday(-1, civil::Weekday::Saturday)
+                    .unwrap();
+                assert_eq!(got, expected);
+            })
+        });
+    }
+    {
+        let date = time::Date::convert_from(date);
+        let expected = time::Date::convert_from(expected);
+        benchmark(c, format!("{NAME}/prev/time"), |b| {
+            b.iter(|| {
+                let got = bb(date).prev_occurrence(time::Weekday::Saturday);
+                assert_eq!(got, expected);
+            })
+        });
+    }
+
+    // 2nd next Thursday after 2026-06-15 (Monday) -> 2026-06-25.
+    // (Thursdays after June 15: 18, 25.)
+    let expected = civil::date(2026, 6, 25);
+    {
+        benchmark(c, format!("{NAME}/second-next/jiff"), |b| {
+            b.iter(|| {
+                let got =
+                    bb(date).nth_weekday(2, civil::Weekday::Thursday).unwrap();
+                assert_eq!(got, expected);
+            })
+        });
+    }
+    {
+        let date = time::Date::convert_from(date);
+        let expected = time::Date::convert_from(expected);
+        benchmark(c, format!("{NAME}/second-next/time"), |b| {
+            b.iter(|| {
+                let got =
+                    bb(date).nth_next_occurrence(time::Weekday::Thursday, 2);
                 assert_eq!(got, expected);
             })
         });

--- a/crates/jiff-static/src/shared/util/itime.rs
+++ b/crates/jiff-static/src/shared/util/itime.rs
@@ -216,14 +216,37 @@ impl IEpochDay {
     /// Returns the day of the week for this epoch day.
     #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) const fn weekday(&self) -> IWeekday {
-        // Based on Hinnant's approach here, although we use ISO weekday
-        // numbering by default. Basically, this works by using the knowledge
-        // that 1970-01-01 was a Thursday.
+        // Fast technique to obtain weekday 1..7 (Mon..Sun)
+        // directly via an add-mul-shift. Relies on the fact
+        // that the Unix epoch was a Thursday and that 7 is a
+        // Mersenne number.
         //
-        // Ref: http://howardhinnant.github.io/date_algorithms.html
-        IWeekday::from_monday_zero_offset(
-            (self.epoch_day + 3).rem_euclid(7) as i8
-        )
+        // Accurate over a limited range (-89478489 to 89478489)
+        // which is -243014-03-21 (Tue) to 246953-10-13 (Sat).
+        // This exceeds Jiff's range.
+        //
+        // Ref: https://www.benjoffe.com/fast-day-of-week
+        IWeekday::from_monday_one_offset({
+            const M: u32 = {
+                // MSRV(1.73): Just use `n.div_ceil` instead.
+                const fn div_ceil(lhs: u64, rhs: u64) -> u64 {
+                    let d = lhs / rhs;
+                    let r = lhs % rhs;
+                    if r > 0 {
+                        d + 1
+                    } else {
+                        d
+                    }
+                }
+
+                let n = div_ceil(1u64 << 32, 7) as u32;
+                assert!(n == 613_566_757);
+                n
+            };
+            const Z: u32 = 0x90000000; // Magic add: see link above.
+            let rd: u32 = self.epoch_day as u32;
+            (rd.wrapping_mul(M).wrapping_add(Z) >> 29) as i8
+        })
     }
 
     /// Add the given number of days to this epoch day.
@@ -598,7 +621,7 @@ impl ITimeNanosecond {
 /// Represents a weekday.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub(crate) struct IWeekday {
-    /// Range is `1..=6` with `1=Monday`.
+    /// Range is `1..=7` with `1=Monday`.
     offset: i8,
 }
 

--- a/src/shared/util/itime.rs
+++ b/src/shared/util/itime.rs
@@ -214,14 +214,37 @@ impl IEpochDay {
     /// Returns the day of the week for this epoch day.
     #[cfg_attr(feature = "perf-inline", inline(always))]
     pub(crate) const fn weekday(&self) -> IWeekday {
-        // Based on Hinnant's approach here, although we use ISO weekday
-        // numbering by default. Basically, this works by using the knowledge
-        // that 1970-01-01 was a Thursday.
+        // Fast technique to obtain weekday 1..7 (Mon..Sun)
+        // directly via an add-mul-shift. Relies on the fact
+        // that the Unix epoch was a Thursday and that 7 is a
+        // Mersenne number.
         //
-        // Ref: http://howardhinnant.github.io/date_algorithms.html
-        IWeekday::from_monday_zero_offset(
-            (self.epoch_day + 3).rem_euclid(7) as i8
-        )
+        // Accurate over a limited range (-89478489 to 89478489)
+        // which is -243014-03-21 (Tue) to 246953-10-13 (Sat).
+        // This exceeds Jiff's range.
+        //
+        // Ref: https://www.benjoffe.com/fast-day-of-week
+        IWeekday::from_monday_one_offset({
+            const M: u32 = {
+                // MSRV(1.73): Just use `n.div_ceil` instead.
+                const fn div_ceil(lhs: u64, rhs: u64) -> u64 {
+                    let d = lhs / rhs;
+                    let r = lhs % rhs;
+                    if r > 0 {
+                        d + 1
+                    } else {
+                        d
+                    }
+                }
+
+                let n = div_ceil(1u64 << 32, 7) as u32;
+                assert!(n == 613_566_757);
+                n
+            };
+            const Z: u32 = 0x90000000; // Magic add: see link above.
+            let rd: u32 = self.epoch_day as u32;
+            (rd.wrapping_mul(M).wrapping_add(Z) >> 29) as i8
+        })
     }
 
     /// Add the given number of days to this epoch day.

--- a/src/shared/util/itime.rs
+++ b/src/shared/util/itime.rs
@@ -596,7 +596,7 @@ impl ITimeNanosecond {
 /// Represents a weekday.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub(crate) struct IWeekday {
-    /// Range is `1..=6` with `1=Monday`.
+    /// Range is `1..=7` with `1=Monday`.
     offset: i8,
 }
 


### PR DESCRIPTION
Hi,

I have prepared an alternative technique for obtaining the day-of-the-week.

There did not seem to be any benchmarks for this, so I also created another branch which holds a parent-commit with some benchmarks for obtaining the nth-weekday of the month etc.:
https://github.com/benjoffe/jiff/tree/fast_weekday

By running the following:
```
git checkout fast_weekday
cargo bench -- 'date/nth_weekday.*/jiff' --save-baseline base
git checkout fast_weekday_pt2
cargo bench -- 'date/nth_weekday.*/jiff' --save-baseline fast
critcmp base fast
```

I get the following results on my M4 Pro Macbook Pro:
```
group                                                 base                                   fast
-----                                                 ----                                   ----
date/epoch_day_to_date                                1.00     17.0±0.20ns        ? ?/sec
date/nth_weekday/next/jiff                            1.32      8.4±0.17ns        ? ?/sec    1.00      6.4±0.08ns        ? ?/sec
date/nth_weekday/prev/jiff                            1.06      6.8±0.12ns        ? ?/sec    1.00      6.5±0.09ns        ? ?/sec
date/nth_weekday/second-next/jiff                     1.33      8.5±0.13ns        ? ?/sec    1.00      6.4±0.09ns        ? ?/sec
date/nth_weekday_of_month/last/jiff                   1.22      2.7±0.04ns        ? ?/sec    1.00      2.2±0.04ns        ? ?/sec
date/nth_weekday_of_month/second/jiff                 1.23      1.8±0.04ns        ? ?/sec    1.00      1.5±0.04ns        ? ?/sec`
```

I must apologise, the benchmarks are written with Claude, and I suspect that you'll have opinions about what makes a good benchmark. I am happy to either implement changes based on your input, or rebase off any changes you want to make etc.

The comment has replaced the previous reference algorithm with a link to documentation about this new one:
https://www.benjoffe.com/fast-day-of-week#fastest-iso

That blog page is still in draft, it will be updated to include more variant algorithms, however I will make sure the url and hash-tag don't change, so that the comment (if you choose to accept the PR and keep the comment), will still go straight to the section explaining the logic.

I have a C++ repository which serves as a test-case for validation of the range, as per stated in the comment:
// Valid range:  -89478489 to 89478489
// -243,014-03-21 (Tue) to 246,953-10-13 (Sat)
Test repo: https://github.com/benjoffe/fast-world-calendars
