### PR TITLE
fix soundness bug in low level printing APIs + some other safety clean-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Enhancements:
 * [#591](https://github.com/BurntSushi/jiff/pull/591):
 Improve the performance of weekday calculations from Gregorian dates by 30-50%.
 
+Bug fixes:
+
+* [#592](https://github.com/BurntSushi/jiff/issues/592):
+Fix safety soundness bug when using a non-empty `String` destination buffer
+with lower level printing APIs inside of `jiff::fmt`.
+
 
 0.2.29 (2026-06-20)
 ===================

--- a/src/fmt/buffer.rs
+++ b/src/fmt/buffer.rs
@@ -525,6 +525,9 @@ impl<'data> BorrowedBuffer<'data> {
         assert!(n <= 999_999_999);
         let mut buf = ArrayBuffer::<MAX_PRECISION>::default();
         for i in (0..MAX_PRECISION).rev() {
+            // SAFETY: Okay since `i` is guaranteed to be a valid index in
+            // `buf`. Namely, `buf` is created with `MAX_PRECISION` slots and
+            // `MAX_PRECISION - 1` is the largest value of `i` possible here.
             unsafe {
                 buf.data.get_unchecked_mut(i).write(b'0' + ((n % 10) as u8));
             }

--- a/src/fmt/buffer.rs
+++ b/src/fmt/buffer.rs
@@ -156,14 +156,21 @@ impl<'data> BorrowedBuffer<'data> {
         buf: &'data mut alloc::vec::Vec<u8>,
         mut with: impl FnMut(&mut BorrowedBuffer<'_>) -> T,
     ) -> T {
+        let old_len = buf.len();
         let mut bbuf = BorrowedBuffer::from_vec_spare_capacity(buf);
         let returned = with(&mut bbuf);
         let new_len = bbuf.len();
-        // SAFETY: `BorrowedBuffer::len()` always reflects the number of
-        // bytes that have been written to. Thus, the data up to the given new
-        // length is guaranteed to be initialized.
+        // SAFETY: `new_len` always reflects the number of bytes that have been
+        // written to. Moreover, the buffer provided may not be empty, in which
+        // case `old_len` reflects the number of bytes already there. Thus, the
+        // data up to the given new length is guaranteed to be initialized.
+        //
+        // Note that the addition here is guaranteed not to overflow (and
+        // thus potentially wrap in release mode) since it reflects the total
+        // capacity of `buf`. If it overflowed, then it would imply that the
+        // capacity for `buf` was invalid.
         unsafe {
-            buf.set_len(new_len);
+            buf.set_len(old_len + new_len);
         }
         returned
     }
@@ -1377,5 +1384,43 @@ mod tests {
         let mut buf = ArrayBuffer::<100>::default();
         let mut bbuf = buf.as_borrowed();
         bbuf.write_fraction(None, 1_000_000_000);
+    }
+
+    /// This tests that writing into an empty buffer is okay.
+    ///
+    /// This always worked, but we test it along with a non-empty buffer below
+    /// for completeness.
+    ///
+    /// Ref: https://github.com/BurntSushi/jiff/issues/592
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn spare_capacity_empty_buffer() {
+        use jiff::{civil::date, fmt::temporal::DateTimePrinter};
+
+        let mut s = alloc::string::String::new();
+        let printer = DateTimePrinter::new();
+        let d = date(2024, 6, 15);
+        printer.print_date(&d, &mut s).unwrap();
+        assert_eq!(s.chars().count(), 10);
+    }
+
+    /// This tests that writing into a non-empty buffer is okay.
+    ///
+    /// Previously, this would result in a truncation of the buffer that,
+    /// when provided via a `String`, could result in the `String` containing
+    /// invalid UTF-8. (And just generally incorrect results even if the string
+    /// contained valid UTF-8.)
+    ///
+    /// Ref: https://github.com/BurntSushi/jiff/issues/592
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn spare_capacity_non_empty_buffer() {
+        use jiff::{civil::date, fmt::temporal::DateTimePrinter};
+
+        let mut s = alloc::string::String::from("🎉🎉🎉");
+        let printer = DateTimePrinter::new();
+        let d = date(2024, 6, 15);
+        printer.print_date(&d, &mut s).unwrap();
+        assert_eq!(s.chars().map(|c| c.len_utf8()).sum::<usize>(), 22);
     }
 }

--- a/src/tz/system/android.rs
+++ b/src/tz/system/android.rs
@@ -82,7 +82,9 @@ pub(super) fn read(_db: &TimeZoneDatabase, path: &str) -> Option<TimeZone> {
 /// `android-system-properties` does though. We don't bother supporting >10
 /// year old versions of Android. (Although support for that could be added
 /// if there was a real need.) Also, when this fails, we give better error
-/// messages via `dlerror()` in the logs.
+/// messages via `dlerror()` in the logs. UPDATE: We don't give better error
+/// messages any more because `dlerror()` isn't sound to use for all possible
+/// libc implementations in a multi-threaded environment.
 struct PropertyGetter {
     /// A `dlopen` handle to `libc.so`.
     ///
@@ -120,11 +122,7 @@ impl PropertyGetter {
         // SAFETY: OK because we provide a valid NUL terminated string.
         let handle = unsafe { dlopen(cstr("libc.so\0").as_ptr(), 0) };
         let Some(libc) = NonNull::new(handle) else {
-            let _msg = dlerror_message();
-            warn!(
-                "could not open libc.so via `dlopen`: {err}",
-                err = crate::util::escape::Bytes(&_msg),
-            );
+            warn!("could not open libc.so via `dlopen`:");
             return None;
         };
 
@@ -226,12 +224,9 @@ unsafe fn load_symbol<F>(handle: NonNull<c_void>, symbol: &CStr) -> Option<F> {
     if sym.is_null() {
         // SAFETY: We know `handle` is non-null.
         let _ = unsafe { dlclose(handle.as_ptr()) };
-        let _msg = dlerror_message();
         warn!(
-            "could not load `{symbol}` \
-             symbol from `libc.so: {err}",
+            "could not load `{symbol}` symbol from `libc.so",
             symbol = crate::util::escape::Bytes(symbol.to_bytes()),
-            err = crate::util::escape::Bytes(&_msg),
         );
         return None;
     }
@@ -240,48 +235,6 @@ unsafe fn load_symbol<F>(handle: NonNull<c_void>, symbol: &CStr) -> Option<F> {
     // declared in `include/sys/system_properties.h` on Android.
     let function = unsafe { mem::transmute_copy::<*mut c_void, F>(&sym) };
     Some(function)
-}
-
-/// Returns the error message given by `dlerror`.
-///
-/// Callers should only use this when they expect an error to have occurred
-/// with one of the `dl*` APIs. If `dlerror` returns a null pointer, then a
-/// generic "unknown error" message is returned.
-fn dlerror_message() -> Vec<u8> {
-    // SAFETY: I believe `dlerror()` is always safe to call.
-    let msg = unsafe { dlerror() };
-    if msg.is_null() {
-        return b"unknown error".to_vec();
-    }
-    // SAFETY: We've verified that `msg` is not null and the contract of
-    // `dlerror` says that it returns a NUL terminated C string. Moreover,
-    // we do not hold on to this string and instead copy it to the heap
-    // immediately.
-    //
-    // One wonders if `dlerror()` is actually sound in this context. While
-    // Jiff can guarantee that itself will call `dlerror()` in only one
-    // thread, Jiff can't prevent other parts of the process from calling
-    // `dlerror()`. In particular, `dlerror(3)` says:
-    //
-    // > The message returned by dlerror() may reside in a statically allocated
-    // > buffer that is overwritten by subsequent dlerror() calls.
-    //
-    // But no mention is made about whether this statically allocated buffer
-    // is written to in a thread safe way. Or whether the string returned to
-    // the caller can be unceremoniously overwritten by a simultaneously
-    // executing thread.
-    //
-    // However, in practice, this could be sound if the libc in use is doing
-    // something sensible like using a thread local. Then I believe this is
-    // fine.
-    //
-    // My goodness C is awful. If this turns out to be unsound, then since
-    // `dlerror()` isn't essential, we'll probably just have to stop using it.
-    // So dumb.
-    //
-    // Note that in theory the error path should never be exercised.
-    let cstr = unsafe { CStr::from_ptr(msg) };
-    cstr.to_bytes().to_vec()
 }
 
 /// Creates a C string "literal" and returns it as a raw pointer.
@@ -298,7 +251,6 @@ fn cstr(string: &'static str) -> &'static CStr {
 extern "C" {
     fn dlopen(filename: *const c_char, flag: i32) -> *mut c_void;
     fn dlclose(handle: *mut c_void) -> i32;
-    fn dlerror() -> *mut c_char;
     fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *mut c_void;
 }
 

--- a/src/tz/system/wasm_emscripten.rs
+++ b/src/tz/system/wasm_emscripten.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 extern "C" {
-    /// https://emscripten.org/docs/api_reference/emscripten.h.html#c.emscripten_run_script_string
+    /// <https://emscripten.org/docs/api_reference/emscripten.h.html#c.emscripten_run_script_string>
     fn emscripten_run_script_string(script: *const c_char) -> *mut c_char;
 }
 
@@ -21,9 +21,19 @@ pub(super) fn get(db: &TimeZoneDatabase) -> Option<TimeZone> {
 
     // SAFETY: SCRIPT is a valid pointer to a null-terminated string. The
     // result will be a pointer to a null-terminated C string, or null if the
-    // script failed to run. The returned value is valid until the next call to
-    // `emscripten_run_script_string` in the same thread, so it is valid for
-    // the duration of this function.
+    // script failed to run. The returned value is valid until the next call
+    // to `emscripten_run_script_string` in the same thread, so it is valid
+    // for the duration of this function. This likely relies on emscripten
+    // managing its string lifetimes carefully, possibly through TLS or some
+    // other shenanigans. Either way, this usage seems clearly okay even in a
+    // multi-threaded environment according to emscripten docs:
+    //
+    // > This function can be called from a pthread, and it is executed
+    // > in the scope of the Web Worker that is hosting the pthread. To
+    // > evaluate a function in the scope of the main runtime thread,
+    // > see the function emscripten_sync_run_in_main_runtime_thread().
+    //
+    // From: <https://emscripten.org/docs/api_reference/emscripten.h.html#c.emscripten_run_script_string>
     let script_result =
         unsafe { emscripten_run_script_string(SCRIPT.as_ptr()) };
     let script_ptr = match NonNull::new(script_result) {


### PR DESCRIPTION
This PR principally fixes a soundness bug that occurs when providing a
non-empty `String` buffer to lower level printing APIs. Specifically,
it's possible for the `String` buffer to be left in a state where
undefined behavior occurs as a result of the `String` buffer containing
invalid UTF-8. The bug was simply that the existing length of the
buffer wasn't accounted for when setting the length of the buffer after
writing data into it.

Most use cases will likely pass an empty buffer, in which case, this
soundness bug does not apply.

An end user could only trigger undefined behavior here
if one is using the lower level printer APIs (like
`jiff::fmt::temporal::DateTimePrinter::print_date`) with a destination
`String` buffer whose contents are from user input. If one uses a
non-empty `Vec<u8>`, then no undefined behavior is possible from within
Jiff. However, the results are still incorrect which could cause
undefined behavior downstream if one depended on correct results.

This PR does some other mild safety clean-up noted in #592. We add
a missing safety comment, beef up an existing safety comment (for
emscripten) and remove use of `dlerror()` which is possibly unsound in
some environments with unreasonable `libc` implementations.

Fixes #592
