### PR TITLE
Use `crate::…` instead of `jiff::…` in a couple of lib tests

### DIFF
--- a/src/fmt/buffer.rs
+++ b/src/fmt/buffer.rs
@@ -1398,7 +1398,7 @@ mod tests {
     #[cfg(feature = "alloc")]
     #[test]
     fn spare_capacity_empty_buffer() {
-        use jiff::{civil::date, fmt::temporal::DateTimePrinter};
+        use crate::{civil::date, fmt::temporal::DateTimePrinter};
 
         let mut s = alloc::string::String::new();
         let printer = DateTimePrinter::new();
@@ -1418,7 +1418,7 @@ mod tests {
     #[cfg(feature = "alloc")]
     #[test]
     fn spare_capacity_non_empty_buffer() {
-        use jiff::{civil::date, fmt::temporal::DateTimePrinter};
+        use crate::{civil::date, fmt::temporal::DateTimePrinter};
 
         let mut s = alloc::string::String::from("🎉🎉🎉");
         let printer = DateTimePrinter::new();


### PR DESCRIPTION
Without this change, these two tests, added in 0.2.30, fail to build downstream in Fedora’s `rust-jiff` package:

```
error[E0433]: cannot find module or crate `jiff` in this scope
    --> src/fmt/buffer.rs:1401:13
     |
1401 |         use jiff::{civil::date, fmt::temporal::DateTimePrinter};
     |             ^^^^ use of unresolved module or unlinked crate `jiff`
     |
     = help: if you wanted to use a crate named `jiff`, use `cargo add jiff` to add it to your `Cargo.toml`

error[E0433]: cannot find module or crate `jiff` in this scope
    --> src/fmt/buffer.rs:1421:13
     |
1421 |         use jiff::{civil::date, fmt::temporal::DateTimePrinter};
     |             ^^^^ use of unresolved module or unlinked crate `jiff`
     |
     = help: if you wanted to use a crate named `jiff`, use `cargo add jiff` to add it to your `Cargo.toml`

For more information about this error, try `rustc --explain E0433`.
```