### PR TITLE
tz: return bundled tzdb from db() when std is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+0.2.33 (TBD)
+============
+TODO
+
+Enhancements:
+
+* [#533](https://github.com/BurntSushi/jiff/issues/533):
+A bundled `TimeZoneDatabase` is now available when only `alloc` is enabled.
+
+
 0.2.32 (2026-07-08)
 ===================
 This release updates Jiff's bundled copy of the [IANA Time Zone Database]

--- a/src/tz/db/bundled/disabled.rs
+++ b/src/tz/db/bundled/disabled.rs
@@ -4,7 +4,7 @@ use crate::tz::{TimeZone, TimeZoneNameIter};
 pub(crate) struct Database;
 
 impl Database {
-    pub(crate) fn new() -> Database {
+    pub(crate) const fn new() -> Database {
         Database
     }
 

--- a/src/tz/db/bundled/enabled.rs
+++ b/src/tz/db/bundled/enabled.rs
@@ -1,9 +1,10 @@
 use crate::tz::{db::special_time_zone, TimeZone, TimeZoneNameIter};
 
+#[derive(Clone)]
 pub(crate) struct Database;
 
 impl Database {
-    pub(crate) fn new() -> Database {
+    pub(crate) const fn new() -> Database {
         Database
     }
 

--- a/src/tz/db/mod.rs
+++ b/src/tz/db/mod.rs
@@ -32,8 +32,33 @@ pub fn db() -> &'static TimeZoneDatabase {
     // #[cfg(any(not(feature = "std"), miri))]
     #[cfg(not(feature = "std"))]
     {
-        static NONE: TimeZoneDatabase = TimeZoneDatabase::none();
-        &NONE
+        // Without `std` there's no lazily initialized global state. But when
+        // the tzdb is bundled into the binary, we can still hand out a usable
+        // database: the bundled database needs no allocation, so it can be
+        // constructed in a `const`. (Without `std`, the zoneinfo and
+        // concatenated databases are both unavailable, so there's nothing to
+        // prefer over the bundle.)
+        //
+        // Ref: https://github.com/BurntSushi/jiff/issues/533
+        #[cfg(any(
+            feature = "tzdb-bundle-always",
+            all(
+                feature = "tzdb-bundle-platform",
+                any(windows, target_family = "wasm"),
+            ),
+        ))]
+        static DB: TimeZoneDatabase = TimeZoneDatabase {
+            inner: Repr::Bundled(bundled::Database::new()),
+        };
+        #[cfg(not(any(
+            feature = "tzdb-bundle-always",
+            all(
+                feature = "tzdb-bundle-platform",
+                any(windows, target_family = "wasm"),
+            ),
+        )))]
+        static DB: TimeZoneDatabase = TimeZoneDatabase::none();
+        &DB
     }
     // #[cfg(all(feature = "std", not(miri)))]
     #[cfg(feature = "std")]
@@ -727,6 +752,32 @@ fn special_time_zone(name: &str) -> Option<TimeZone> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Tests that the global database returns the bundled tzdb when the bundle
+    /// is enabled but neither the zoneinfo nor concatenated databases are.
+    ///
+    /// This configuration doesn't have `std` (since both `tzdb-zoneinfo` and
+    /// `tzdb-concatenated` imply it), and so without special handling `db()`
+    /// used to return an empty database despite the tzdb being compiled in.
+    ///
+    /// Regression test for: https://github.com/BurntSushi/jiff/issues/533
+    #[cfg(all(
+        feature = "tzdb-bundle-always",
+        not(feature = "tzdb-zoneinfo"),
+        not(feature = "tzdb-concatenated"),
+    ))]
+    #[test]
+    fn bundled_db_when_only_bundle_enabled() {
+        let db = db();
+        assert!(!db.is_definitively_empty());
+        assert!(db.get("America/New_York").is_ok());
+        // The convenience APIs route through the global `db()`, so this is
+        // the symptom originally reported in #533.
+        assert!(crate::civil::date(2024, 7, 4)
+            .at(12, 0, 0, 0)
+            .in_tz("America/New_York")
+            .is_ok());
+    }
 
     /// This tests that the size of a time zone database is kept small.
     ///

--- a/src/tz/db/mod.rs
+++ b/src/tz/db/mod.rs
@@ -188,7 +188,26 @@ pub fn db() -> &'static TimeZoneDatabase {
 /// ```
 #[derive(Clone)]
 pub struct TimeZoneDatabase {
-    inner: Option<Arc<Kind>>,
+    inner: Repr,
+}
+
+/// The internal representation of a `TimeZoneDatabase`.
+///
+/// The bundled database is kept out of the `Arc` because it carries no data
+/// of its own (the tzdb is compiled into the binary and any parsed zones are
+/// cached in a global). This lets it be constructed in a `const`, which is
+/// what makes it possible for `db()` to return the bundled database even when
+/// `std` is unavailable (and so there is no lazily initialized global state).
+///
+/// Ref: https://github.com/BurntSushi/jiff/issues/533
+#[derive(Clone)]
+enum Repr {
+    /// A database for which all lookups fail.
+    Empty,
+    /// The bundled database. Needs no allocation, so no `Arc`.
+    Bundled(bundled::Database),
+    /// A database backed by an `Arc` so that clones share its cache.
+    Arc(Arc<Kind>),
 }
 
 #[derive(Debug)]
@@ -197,7 +216,6 @@ pub struct TimeZoneDatabase {
 enum Kind {
     ZoneInfo(zoneinfo::Database),
     Concatenated(concatenated::Database),
-    Bundled(bundled::Database),
 }
 
 impl TimeZoneDatabase {
@@ -212,7 +230,7 @@ impl TimeZoneDatabase {
     /// assert_eq!(db.available().count(), 0);
     /// ```
     pub const fn none() -> TimeZoneDatabase {
-        TimeZoneDatabase { inner: None }
+        TimeZoneDatabase { inner: Repr::Empty }
     }
 
     /// Returns a time zone database initialized from the current environment.
@@ -283,7 +301,7 @@ impl TimeZoneDatabase {
 
         let db = bundled::Database::new();
         if !db.is_definitively_empty() {
-            return TimeZoneDatabase::new(Kind::Bundled(db));
+            return TimeZoneDatabase { inner: Repr::Bundled(db) };
         }
 
         warn!(
@@ -431,12 +449,12 @@ impl TimeZoneDatabase {
         if db.is_definitively_empty() {
             warn!("could not find embedded/bundled zoneinfo");
         }
-        TimeZoneDatabase::new(Kind::Bundled(db))
+        TimeZoneDatabase { inner: Repr::Bundled(db) }
     }
 
     /// Creates a new DB from the internal kind.
     fn new(kind: Kind) -> TimeZoneDatabase {
-        TimeZoneDatabase { inner: Some(Arc::new(kind)) }
+        TimeZoneDatabase { inner: Repr::Arc(Arc::new(kind)) }
     }
 
     /// Returns a [`TimeZone`] corresponding to the IANA time zone identifier
@@ -462,29 +480,21 @@ impl TimeZoneDatabase {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn get(&self, name: &str) -> Result<TimeZone, Error> {
-        let inner = self
-            .inner
-            .as_deref()
-            .ok_or_else(|| E::failed_time_zone_no_database_configured(name))?;
-        match *inner {
-            Kind::ZoneInfo(ref db) => {
-                if let Some(tz) = db.get(name) {
-                    trace!("found time zone `{name}` in {db:?}", db = self);
-                    return Ok(tz);
-                }
+        let found = match self.inner {
+            Repr::Empty => {
+                return Err(Error::from(
+                    E::failed_time_zone_no_database_configured(name),
+                ));
             }
-            Kind::Concatenated(ref db) => {
-                if let Some(tz) = db.get(name) {
-                    trace!("found time zone `{name}` in {db:?}", db = self);
-                    return Ok(tz);
-                }
-            }
-            Kind::Bundled(ref db) => {
-                if let Some(tz) = db.get(name) {
-                    trace!("found time zone `{name}` in {db:?}", db = self);
-                    return Ok(tz);
-                }
-            }
+            Repr::Bundled(ref db) => db.get(name),
+            Repr::Arc(ref kind) => match **kind {
+                Kind::ZoneInfo(ref db) => db.get(name),
+                Kind::Concatenated(ref db) => db.get(name),
+            },
+        };
+        if let Some(tz) = found {
+            trace!("found time zone `{name}` in {db:?}", db = self);
+            return Ok(tz);
         }
         Err(Error::from(E::failed_time_zone(name)))
     }
@@ -508,13 +518,13 @@ impl TimeZoneDatabase {
     /// }
     /// ```
     pub fn available<'d>(&'d self) -> TimeZoneNameIter<'d> {
-        let Some(inner) = self.inner.as_deref() else {
-            return TimeZoneNameIter::empty();
-        };
-        match *inner {
-            Kind::ZoneInfo(ref db) => db.available(),
-            Kind::Concatenated(ref db) => db.available(),
-            Kind::Bundled(ref db) => db.available(),
+        match self.inner {
+            Repr::Empty => TimeZoneNameIter::empty(),
+            Repr::Bundled(ref db) => db.available(),
+            Repr::Arc(ref kind) => match **kind {
+                Kind::ZoneInfo(ref db) => db.available(),
+                Kind::Concatenated(ref db) => db.available(),
+            },
         }
     }
 
@@ -528,11 +538,13 @@ impl TimeZoneDatabase {
     /// without spawning a new process or waiting for Jiff's internal cache
     /// invalidation heuristics to kick in.
     pub fn reset(&self) {
-        let Some(inner) = self.inner.as_deref() else { return };
-        match *inner {
-            Kind::ZoneInfo(ref db) => db.reset(),
-            Kind::Concatenated(ref db) => db.reset(),
-            Kind::Bundled(ref db) => db.reset(),
+        match self.inner {
+            Repr::Empty => {}
+            Repr::Bundled(ref db) => db.reset(),
+            Repr::Arc(ref kind) => match **kind {
+                Kind::ZoneInfo(ref db) => db.reset(),
+                Kind::Concatenated(ref db) => db.reset(),
+            },
         }
     }
 
@@ -554,11 +566,13 @@ impl TimeZoneDatabase {
     /// assert!(db.is_definitively_empty());
     /// ```
     pub fn is_definitively_empty(&self) -> bool {
-        let Some(inner) = self.inner.as_deref() else { return true };
-        match *inner {
-            Kind::ZoneInfo(ref db) => db.is_definitively_empty(),
-            Kind::Concatenated(ref db) => db.is_definitively_empty(),
-            Kind::Bundled(ref db) => db.is_definitively_empty(),
+        match self.inner {
+            Repr::Empty => true,
+            Repr::Bundled(ref db) => db.is_definitively_empty(),
+            Repr::Arc(ref kind) => match **kind {
+                Kind::ZoneInfo(ref db) => db.is_definitively_empty(),
+                Kind::Concatenated(ref db) => db.is_definitively_empty(),
+            },
         }
     }
 }
@@ -566,13 +580,13 @@ impl TimeZoneDatabase {
 impl core::fmt::Debug for TimeZoneDatabase {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.write_str("TimeZoneDatabase(")?;
-        let Some(inner) = self.inner.as_deref() else {
-            return f.write_str("unavailable)");
-        };
-        match *inner {
-            Kind::ZoneInfo(ref db) => core::fmt::Debug::fmt(db, f)?,
-            Kind::Concatenated(ref db) => core::fmt::Debug::fmt(db, f)?,
-            Kind::Bundled(ref db) => core::fmt::Debug::fmt(db, f)?,
+        match self.inner {
+            Repr::Empty => return f.write_str("unavailable)"),
+            Repr::Bundled(ref db) => core::fmt::Debug::fmt(db, f)?,
+            Repr::Arc(ref kind) => match **kind {
+                Kind::ZoneInfo(ref db) => core::fmt::Debug::fmt(db, f)?,
+                Kind::Concatenated(ref db) => core::fmt::Debug::fmt(db, f)?,
+            },
         }
         f.write_str(")")
     }
@@ -714,8 +728,12 @@ fn special_time_zone(name: &str) -> Option<TimeZone> {
 mod tests {
     use super::*;
 
-    /// This tests that the size of a time zone database is kept at a single
-    /// word.
+    /// This tests that the size of a time zone database is kept small.
+    ///
+    /// It's two words because the bundled database is stored outside the
+    /// `Arc` (so it can be constructed in a `const`, see `db()` and #533),
+    /// which means the representation needs a tag to distinguish it from the
+    /// empty and `Arc`-backed variants.
     ///
     /// I think it would probably be okay to make this bigger if we had a
     /// good reason to, but it seems sensible to put a road-block to avoid
@@ -725,7 +743,7 @@ mod tests {
         #[cfg(feature = "alloc")]
         {
             let word = core::mem::size_of::<usize>();
-            assert_eq!(word, core::mem::size_of::<TimeZoneDatabase>());
+            assert_eq!(2 * word, core::mem::size_of::<TimeZoneDatabase>());
         }
         // A `TimeZoneDatabase` in core-only is vapid.
         #[cfg(not(feature = "alloc"))]


### PR DESCRIPTION
Without `std`, `db()` returned an empty database even when the tzdb was
compiled in via `tzdb-bundle-always`/`tzdb-bundle-platform`, so `in_tz`
lookups failed in that configuration. `tzdb-zoneinfo` and
`tzdb-concatenated` both require `std`, so the bundled database is the
only source available there. `db()` now returns it directly.

To keep the bundled path allocation-free, the bundled database is stored
outside the `Arc`. It owns no data of its own (the tzdb is embedded and
parsed zones are cached in a global), so it needs no allocation and can
be built in a `const`. The tradeoff is that `TimeZoneDatabase` grows to
two words, since the internal repr now needs a tag to distinguish the
empty, bundled and `Arc`-backed variants. The size test's comment already
allows this "with good reason", but I'm happy to look at a one-word
variant if you'd prefer to keep it at one.

Fixes #533
