### PR TITLE
release: add some shell scripts to automate parts of the release

### DIFF
--- a/scripts/release/commit
+++ b/scripts/release/commit
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${JIFF_ALLOW_DIRTY:=}"
+if [ -z "$JIFF_ALLOW_DIRTY" ]; then
+  if [ -n "$(git status --porcelain)" ]; then
+    echo "repository must be in a clean state"
+    exit 1
+  fi
+fi
+if ! [ -f ./crates/jiff-cli/Cargo.toml ]; then
+  echo "must run in the root of a jiff repository checkout" >&2
+  exit 1
+fi
+
+crate="$1"
+shift
+
+release_dir="$(dirname "$0")"
+case $crate in
+  jiff)
+    next_version="$("$release_dir"/get-next-version ./Cargo.toml)"
+    "$release_dir"/update-version ./Cargo.toml "$next_version"
+    "$release_dir"/update-version ./crates/jiff-static/Cargo.toml "$next_version"
+    sed -i 's/^\(jiff-static = { version = \)"=[0-9.]\+"/\1"='$next_version'"/g' ./Cargo.toml
+    git commit --quiet --all --file - <<EOF
+$next_version
+EOF
+    ;;
+  jiff-tzdb)
+    next_version="$("$release_dir"/get-next-version ./crates/jiff-tzdb/Cargo.toml)"
+    "$release_dir"/update-version ./crates/jiff-tzdb/Cargo.toml "$next_version"
+    sed -i 's/^\(jiff-tzdb = { version = \)"[0-9.]\+"/\1"'$next_version'"/g' ./Cargo.toml
+    git commit --quiet --all --file - <<EOF
+jiff-tzdb-$next_version
+EOF
+esac

--- a/scripts/release/get-next-version
+++ b/scripts/release/get-next-version
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Ripped out of:
+# https://github.com/BurntSushi/dotfiles/blob/fb213eebcbeb9423bde476446478d32a81637212/bin/cargo-up
+
+set -euo pipefail
+
+function next_version {
+  cur="$1"
+  nopatch=${cur%.*}
+  patch=${cur##*.}
+  patchplus=$((patch + 1))
+  printf "%s.%s\n" $nopatch $patchplus
+}
+
+if ! [ -f ./crates/jiff-cli/Cargo.toml ]; then
+  echo "must run in the root of a jiff repository checkout" >&2
+  exit 1
+fi
+
+release_dir="$(dirname "$0")"
+cargo_toml="$1"
+if [ -z "$cargo_toml" ]; then
+  echo "Usage: $(basename "$0") <path-to-cargo-toml>" >&2
+  exit 1
+fi
+next_version $("$release_dir"/get-version "$cargo_toml")

--- a/scripts/release/get-version
+++ b/scripts/release/get-version
@@ -3,21 +3,21 @@
 # Ripped out of:
 # https://github.com/BurntSushi/dotfiles/blob/fb213eebcbeb9423bde476446478d32a81637212/bin/cargo-up
 
+set -euo pipefail
+
 function current_version {
   manifest="$1"
-  rg '^version' "$manifest" | sed 's/.*"\([0-9]\+\.[0-9]\+\.[0-9]\+\)"/\1/g'
-}
-
-function next_version {
-  cur="$1"
-  nopatch=${cur%.*}
-  patch=${cur##*.}
-  patchplus=$((patch + 1))
-  printf "%s.%s\n" $nopatch $patchplus
+  rg '^version.+#:version$' "$manifest" | sed 's/.*"\([0-9]\+\.[0-9]\+\.[0-9]\+\)".*/\1/g'
 }
 
 if ! [ -f ./crates/jiff-cli/Cargo.toml ]; then
   echo "must run in the root of a jiff repository checkout" >&2
   exit 1
 fi
-next_version $(current_version "./Cargo.toml")
+
+cargo_toml="$1"
+if [ -z "$cargo_toml" ]; then
+  echo "Usage: $(basename "$0") <path-to-cargo-toml>" >&2
+  exit 1
+fi
+current_version "$cargo_toml"

--- a/scripts/release/pr-tzdb-update
+++ b/scripts/release/pr-tzdb-update
@@ -12,14 +12,19 @@
 # 6. Update the CHANGELOG and submit a PR.
 #
 # This should be run without arguments. If you need to test, set
-# `JIFF_TZDB_UPDATE_ALLOW_DIRTY=1`. When set, this will stop just before
+# `JIFF_ALLOW_DIRTY=1`. When set, this will stop just before
 # submitting a PR.
 
 set -euo pipefail
 
+if ! [ -f ./crates/jiff-cli/Cargo.toml ]; then
+  echo "must run in the root of a jiff repository checkout" >&2
+  exit 1
+fi
+
 # Do some sanity checking first to make sure we are in a clean state.
-: "${JIFF_TZDB_UPDATE_ALLOW_DIRTY:=}"
-if [ -z "$JIFF_TZDB_UPDATE_ALLOW_DIRTY" ]; then
+: "${JIFF_ALLOW_DIRTY:=}"
+if [ -z "$JIFF_ALLOW_DIRTY" ]; then
   if [ -n "$(git status --porcelain)" ]; then
     echo "repository must be in a clean state"
     exit 1
@@ -39,7 +44,8 @@ fi
 mkdir -p "$TMPDIR"
 
 # Get the next version of Jiff that will contain the tzdb update.
-jiff_next_version="$(./scripts/get-next-version)"
+release_dir="$(dirname "$0")"
+jiff_next_version="$("$release_dir"/get-next-version ./Cargo.toml)"
 
 # Some URLs used below.
 download="https://www.iana.org/time-zones"

--- a/scripts/release/publish
+++ b/scripts/release/publish
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! [ -f ./crates/jiff-cli/Cargo.toml ]; then
+  echo "must run in the root of a jiff repository checkout" >&2
+  exit 1
+fi
+
+crate="$1"
+shift
+
+release_dir="$(dirname "$0")"
+case $crate in
+  jiff)
+    current="$("$release_dir"/get-version ./Cargo.toml)"
+    tag="$current"
+    git tag -s -a "$tag" -m "$tag"
+    cargo publish --manifest-path ./crates/jiff-static/Cargo.toml
+    cargo publish --manifest-path ./Cargo.toml
+    ;;
+  jiff-tzdb)
+    current="$("$release_dir"/get-version ./crates/jiff-tzdb/Cargo.toml)"
+    tag="jiff-tzdb-$current"
+    git tag -s -a "$tag" -m "$tag"
+    cargo publish --manifest-path ./crates/jiff-tzdb/Cargo.toml
+    ;;
+  *)
+    echo "unrecognize publish name" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/release/update-version
+++ b/scripts/release/update-version
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+manifest="$1"
+version="$2"
+if [[ -z "$manifest" ]] || [[ -z "$version" ]]; then
+  echo "Usage: $(basename "$0") <path-to-cargo-toml> <version>" >&2
+fi
+sed -i 's/^version = ".*"\s\+#:version$/version = "'$version'"  #:version/g' "$manifest"


### PR DESCRIPTION
This is specifically meant to split the release part into "commit the
version bump" and "publish the release." And in particular, to get into
a better habit of putting up release PRs.

The ultimate goal is to publish in CI, but this is good enough for now.
