### PR TITLE
fmt: use lenient formatting mode for `strftime` APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+0.2.34 (TBD)
+============
+TODO
+
+Enhancements:
+
+* [#585](https://github.com/BurntSushi/jiff/issues/585):
+Change `Timestamp::strftime` (and similar methods) so that they will never
+panic.
+
+
 0.2.33 (2026-07-18)
 ===================
 This release permits the use of a global time zone database in `alloc`-only

--- a/src/civil/date.rs
+++ b/src/civil/date.rs
@@ -1932,11 +1932,14 @@ impl Date {
     ///
     /// # Errors and panics
     ///
-    /// While this routine itself does not error or panic, using the value
-    /// returned may result in a panic if formatting fails. See the
-    /// documentation on [`fmt::strtime::Display`] for more information.
+    /// This will never error or panic. In particular,
+    /// [lenient mode](crate::fmt::strtime::Config::lenient) is enabled, which
+    /// means that all possible strings have some non-error interpretation.
+    /// Note that because of this, and since Jiff may add new conversion
+    /// specifiers in the future, the behavior of a format string may change
+    /// when it would otherwise be invalid.
     ///
-    /// To format in a way that surfaces errors without panicking, use either
+    /// To format in a way that surfaces errors, use either
     /// [`fmt::strtime::format`] or [`fmt::strtime::BrokenDownTime::format`].
     ///
     /// # Example
@@ -1949,6 +1952,33 @@ impl Date {
     /// let date = date(2024, 7, 15);
     /// let string = date.strftime("%Y-%m-%d is a %A").to_string();
     /// assert_eq!(string, "2024-07-15 is a Monday");
+    /// ```
+    ///
+    /// # Example: errors are silently ignored
+    ///
+    /// If the formatting string is malformed in some way, then it is silently
+    /// ignored. For example, when using an invalid formatting directive:
+    ///
+    /// ```
+    /// use jiff::civil::date;
+    ///
+    /// let date = date(2024, 7, 15);
+    /// let string = date.strftime("%Y %").to_string();
+    /// assert_eq!(string, "2024 %");
+    /// ```
+    ///
+    /// If one wants to surface errors from a formatting string, use a lower
+    /// level API:
+    ///
+    /// ```
+    /// use jiff::civil::date;
+    ///
+    /// let date = date(2024, 7, 15);
+    /// assert_eq!(
+    ///     jiff::fmt::strtime::format("%Y %", date).unwrap_err().to_string(),
+    ///     "strftime formatting failed: invalid format string, \
+    ///      expected byte after `%`, but found end of format string",
+    /// );
     /// ```
     #[inline]
     pub fn strftime<'f, F: 'f + ?Sized + AsRef<[u8]>>(

--- a/src/civil/datetime.rs
+++ b/src/civil/datetime.rs
@@ -2433,11 +2433,14 @@ impl DateTime {
     ///
     /// # Errors and panics
     ///
-    /// While this routine itself does not error or panic, using the value
-    /// returned may result in a panic if formatting fails. See the
-    /// documentation on [`fmt::strtime::Display`] for more information.
+    /// This will never error or panic. In particular,
+    /// [lenient mode](crate::fmt::strtime::Config::lenient) is enabled, which
+    /// means that all possible strings have some non-error interpretation.
+    /// Note that because of this, and since Jiff may add new conversion
+    /// specifiers in the future, the behavior of a format string may change
+    /// when it would otherwise be invalid.
     ///
-    /// To format in a way that surfaces errors without panicking, use either
+    /// To format in a way that surfaces errors, use either
     /// [`fmt::strtime::format`] or [`fmt::strtime::BrokenDownTime::format`].
     ///
     /// # Example
@@ -2450,6 +2453,33 @@ impl DateTime {
     /// let dt = date(2024, 7, 15).at(16, 24, 59, 0);
     /// let string = dt.strftime("%A, %B %e, %Y at %H:%M:%S").to_string();
     /// assert_eq!(string, "Monday, July 15, 2024 at 16:24:59");
+    /// ```
+    ///
+    /// # Example: errors are silently ignored
+    ///
+    /// If the formatting string is malformed in some way, then it is silently
+    /// ignored. For example, when using an invalid formatting directive:
+    ///
+    /// ```
+    /// use jiff::civil::date;
+    ///
+    /// let dt = date(2024, 7, 15).at(16, 24, 59, 0);
+    /// let string = dt.strftime("%Y %").to_string();
+    /// assert_eq!(string, "2024 %");
+    /// ```
+    ///
+    /// If one wants to surface errors from a formatting string, use a lower
+    /// level API:
+    ///
+    /// ```
+    /// use jiff::civil::date;
+    ///
+    /// let dt = date(2024, 7, 15).at(16, 24, 59, 0);
+    /// assert_eq!(
+    ///     jiff::fmt::strtime::format("%Y %", dt).unwrap_err().to_string(),
+    ///     "strftime formatting failed: invalid format string, \
+    ///      expected byte after `%`, but found end of format string",
+    /// );
     /// ```
     #[inline]
     pub fn strftime<'f, F: 'f + ?Sized + AsRef<[u8]>>(

--- a/src/civil/time.rs
+++ b/src/civil/time.rs
@@ -1607,11 +1607,14 @@ impl Time {
     ///
     /// # Errors and panics
     ///
-    /// While this routine itself does not error or panic, using the value
-    /// returned may result in a panic if formatting fails. See the
-    /// documentation on [`fmt::strtime::Display`] for more information.
+    /// This will never error or panic. In particular,
+    /// [lenient mode](crate::fmt::strtime::Config::lenient) is enabled, which
+    /// means that all possible strings have some non-error interpretation.
+    /// Note that because of this, and since Jiff may add new conversion
+    /// specifiers in the future, the behavior of a format string may change
+    /// when it would otherwise be invalid.
     ///
-    /// To format in a way that surfaces errors without panicking, use either
+    /// To format in a way that surfaces errors, use either
     /// [`fmt::strtime::format`] or [`fmt::strtime::BrokenDownTime::format`].
     ///
     /// # Example
@@ -1638,6 +1641,33 @@ impl Time {
     /// assert_eq!(string, "4:31pm");
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// # Example: errors are silently ignored
+    ///
+    /// If the formatting string is malformed in some way, then it is silently
+    /// ignored. For example, when using an invalid formatting directive:
+    ///
+    /// ```
+    /// use jiff::civil::time;
+    ///
+    /// let t = time(16, 30, 59, 0);
+    /// let string = t.strftime("%H %").to_string();
+    /// assert_eq!(string, "16 %");
+    /// ```
+    ///
+    /// If one wants to surface errors from a formatting string, use a lower
+    /// level API:
+    ///
+    /// ```
+    /// use jiff::civil::time;
+    ///
+    /// let t = time(16, 30, 59, 0);
+    /// assert_eq!(
+    ///     jiff::fmt::strtime::format("%H %", t).unwrap_err().to_string(),
+    ///     "strftime formatting failed: invalid format string, \
+    ///      expected byte after `%`, but found end of format string",
+    /// );
     /// ```
     #[inline]
     pub fn strftime<'f, F: 'f + ?Sized + AsRef<[u8]>>(

--- a/src/fmt/strtime/mod.rs
+++ b/src/fmt/strtime/mod.rs
@@ -3278,26 +3278,12 @@ impl From<Time> for BrokenDownTime {
 ///
 /// # Errors and panics
 ///
-/// This trait implementation returns an error when the underlying formatting
-/// can fail. Formatting can fail either because of an invalid format string,
-/// or if formatting requires a field in `BrokenDownTime` to be set that isn't.
-/// For example, trying to format a [`DateTime`] with the `%z` specifier will
-/// fail because a `DateTime` has no time zone or offset information associated
-/// with it.
-///
-/// Note though that the `std::fmt::Display` API doesn't support surfacing
-/// arbitrary errors. All errors collapse into the unit `std::fmt::Error`
-/// struct. To see the actual error, use [`BrokenDownTime::format`],
-/// [`BrokenDownTime::to_string`] or [`strtime::format`](format()).
-/// Unfortunately, the `std::fmt::Display` trait is used in many places where
-/// there is no way to report errors other than panicking.
-///
-/// Therefore, only use this type if you know your formatting string is valid
-/// and that the datetime type being formatted has all of the information
-/// required by the format string. Moreover, the `strftime` implementation in
-/// this crate is specifically designed to never error based on the specific
-/// values. For example, even though `%y` can only _parse_ years in the
-/// `1969-2068` range, it can format any valid year supported by Jiff.
+/// This trait implementation configures formatting to use
+/// [lenient mode](Config::lenient). This avoids panics occuring when using
+/// APIs like [`Timestamp::strftime`] with unsupported or invalid formatting
+/// directives. Without lenient mode, whenever formatting would fail, this
+/// would surface as a panic when converting this display implementation to
+/// a string.
 ///
 /// # Example
 ///
@@ -3326,6 +3312,33 @@ impl From<Time> for BrokenDownTime {
 ///
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
+///
+/// # Example: errors are silently ignored
+///
+/// If the formatting string is malformed in some way, then it is silently
+/// ignored. For example, when using an invalid formatting directive:
+///
+/// ```
+/// use jiff::Zoned;
+///
+/// let zdt = Zoned::UNIX_EPOCH;
+/// let string = zdt.strftime("%Y %").to_string();
+/// assert_eq!(string, "1970 %");
+/// ```
+///
+/// If one wants to surface errors from a formatting string, use a lower
+/// level API:
+///
+/// ```
+/// use jiff::Zoned;
+///
+/// let zdt = Zoned::UNIX_EPOCH;
+/// assert_eq!(
+///     jiff::fmt::strtime::format("%Y %", &zdt).unwrap_err().to_string(),
+///     "strftime formatting failed: invalid format string, \
+///      expected byte after `%`, but found end of format string",
+/// );
+/// ```
 pub struct Display<'f> {
     pub(crate) fmt: &'f [u8],
     pub(crate) tm: BrokenDownTime,
@@ -3335,7 +3348,13 @@ impl<'f> core::fmt::Display for Display<'f> {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         use crate::fmt::StdFmtWrite;
 
-        self.tm.format(self.fmt, StdFmtWrite(f)).map_err(|_| core::fmt::Error)
+        self.tm
+            .format_with_config(
+                &Config::new().lenient(true),
+                self.fmt,
+                &mut StdFmtWrite(f),
+            )
+            .map_err(|_| core::fmt::Error)
     }
 }
 

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -2123,11 +2123,14 @@ impl Timestamp {
     ///
     /// # Errors and panics
     ///
-    /// While this routine itself does not error or panic, using the value
-    /// returned may result in a panic if formatting fails. See the
-    /// documentation on [`fmt::strtime::Display`] for more information.
+    /// This will never error or panic. In particular,
+    /// [lenient mode](crate::fmt::strtime::Config::lenient) is enabled, which
+    /// means that all possible strings have some non-error interpretation.
+    /// Note that because of this, and since Jiff may add new conversion
+    /// specifiers in the future, the behavior of a format string may change
+    /// when it would otherwise be invalid.
     ///
-    /// To format in a way that surfaces errors without panicking, use either
+    /// To format in a way that surfaces errors, use either
     /// [`fmt::strtime::format`] or [`fmt::strtime::BrokenDownTime::format`].
     ///
     /// # Example
@@ -2143,6 +2146,33 @@ impl Timestamp {
     /// assert_eq!(string, "Fri Jan  2 12:00:00 AM UTC 1970");
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// # Example: errors are silently ignored
+    ///
+    /// If the formatting string is malformed in some way, then it is silently
+    /// ignored. For example, when using an invalid formatting directive:
+    ///
+    /// ```
+    /// use jiff::Timestamp;
+    ///
+    /// let ts = Timestamp::UNIX_EPOCH;
+    /// let string = ts.strftime("%Y %").to_string();
+    /// assert_eq!(string, "1970 %");
+    /// ```
+    ///
+    /// If one wants to surface errors from a formatting string, use a lower
+    /// level API:
+    ///
+    /// ```
+    /// use jiff::Timestamp;
+    ///
+    /// let ts = Timestamp::UNIX_EPOCH;
+    /// assert_eq!(
+    ///     jiff::fmt::strtime::format("%Y %", ts).unwrap_err().to_string(),
+    ///     "strftime formatting failed: invalid format string, \
+    ///      expected byte after `%`, but found end of format string",
+    /// );
     /// ```
     #[inline]
     pub fn strftime<'f, F: 'f + ?Sized + AsRef<[u8]>>(

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -3324,11 +3324,14 @@ impl Zoned {
     ///
     /// # Errors and panics
     ///
-    /// While this routine itself does not error or panic, using the value
-    /// returned may result in a panic if formatting fails. See the
-    /// documentation on [`fmt::strtime::Display`] for more information.
+    /// This will never error or panic. In particular,
+    /// [lenient mode](crate::fmt::strtime::Config::lenient) is enabled, which
+    /// means that all possible strings have some non-error interpretation.
+    /// Note that because of this, and since Jiff may add new conversion
+    /// specifiers in the future, the behavior of a format string may change
+    /// when it would otherwise be invalid.
     ///
-    /// To format in a way that surfaces errors without panicking, use either
+    /// To format in a way that surfaces errors, use either
     /// [`fmt::strtime::format`] or [`fmt::strtime::BrokenDownTime::format`].
     ///
     /// # Example
@@ -3344,6 +3347,33 @@ impl Zoned {
     /// assert_eq!(string, "Mon Jul 15 04:24:59 PM EDT 2024");
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    ///
+    /// # Example: errors are silently ignored
+    ///
+    /// If the formatting string is malformed in some way, then it is silently
+    /// ignored. For example, when using an invalid formatting directive:
+    ///
+    /// ```
+    /// use jiff::Zoned;
+    ///
+    /// let zdt = Zoned::UNIX_EPOCH;
+    /// let string = zdt.strftime("%Y %").to_string();
+    /// assert_eq!(string, "1970 %");
+    /// ```
+    ///
+    /// If one wants to surface errors from a formatting string, use a lower
+    /// level API:
+    ///
+    /// ```
+    /// use jiff::Zoned;
+    ///
+    /// let zdt = Zoned::UNIX_EPOCH;
+    /// assert_eq!(
+    ///     jiff::fmt::strtime::format("%Y %", &zdt).unwrap_err().to_string(),
+    ///     "strftime formatting failed: invalid format string, \
+    ///      expected byte after `%`, but found end of format string",
+    /// );
     /// ```
     #[inline]
     pub fn strftime<'f, F: 'f + ?Sized + AsRef<[u8]>>(


### PR DESCRIPTION
This makes it so all possible strings are valid format strings. This in
turn implies there will never be an error when using
`<datetime-type>::strftime` and thus will never be a panic when trying
to convert it to a string.

This resolves a footgun where it is very easy to use the `strftime` APIs
and have that result in a panic. That's bad juju enough that we should
fix that.

Fixes #585
