### PR TITLE
error: tighten up some error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ TODO
 
 Enhancements:
 
+* [#519](https://github.com/BurntSushi/jiff/issues/519):
+Improve some parsing error messages by removing redundancy.
 * [#585](https://github.com/BurntSushi/jiff/issues/585):
 Change `Timestamp::strftime` (and similar methods) so that they will never
 panic.

--- a/src/error/fmt/temporal.rs
+++ b/src/error/fmt/temporal.rs
@@ -44,25 +44,13 @@ pub(crate) enum Error {
         byte: u8,
     },
     ExpectedWeekPrefixFoundEndOfInput,
-    FailedDayInDate,
-    FailedDayInMonthDay,
     FailedFractionalSecondInTime,
-    FailedHourInTime,
-    FailedMinuteInTime,
-    FailedMonthInDate,
-    FailedMonthInMonthDay,
-    FailedMonthInYearMonth,
     FailedOffsetNumeric,
-    FailedSecondInTime,
     FailedSeparatorAfterMonth,
     FailedSeparatorAfterWeekNumber,
     FailedSeparatorAfterYear,
     FailedTzdbLookup,
-    FailedWeekNumberInDate,
     FailedWeekNumberPrefixInDate,
-    FailedWeekdayInDate,
-    FailedYearInDate,
-    FailedYearInYearMonth,
     InvalidDate,
     InvalidMonthDay,
     InvalidTimeZoneUtf8,
@@ -220,31 +208,13 @@ impl core::fmt::Display for Error {
             ExpectedWeekPrefixFoundEndOfInput => {
                 f.write_str("expected `W` or `w`, but found end of input")
             }
-            FailedDayInDate => f.write_str("failed to parse day in date"),
-            FailedDayInMonthDay => {
-                f.write_str("failed to payse day in month-day")
-            }
             FailedFractionalSecondInTime => {
                 f.write_str("failed to parse fractional seconds in time")
-            }
-            FailedHourInTime => f.write_str("failed to parse hour in time"),
-            FailedMinuteInTime => {
-                f.write_str("failed to parse minute in time")
-            }
-            FailedMonthInDate => f.write_str("failed to parse month in date"),
-            FailedMonthInMonthDay => {
-                f.write_str("failed to parse month in month-day")
-            }
-            FailedMonthInYearMonth => {
-                f.write_str("failed to parse month in year-month")
             }
             FailedOffsetNumeric => f.write_str(
                 "offset successfully parsed, \
                  but failed to convert to numeric `jiff::tz::Offset`",
             ),
-            FailedSecondInTime => {
-                f.write_str("failed to parse second in time")
-            }
             FailedSeparatorAfterMonth => {
                 f.write_str("failed to parse separator after month")
             }
@@ -258,18 +228,8 @@ impl core::fmt::Display for Error {
                 "parsed apparent IANA time zone identifier, \
                  but the tzdb lookup failed",
             ),
-            FailedWeekNumberInDate => {
-                f.write_str("failed to parse week number in date")
-            }
             FailedWeekNumberPrefixInDate => {
                 f.write_str("failed to parse week number prefix in date")
-            }
-            FailedWeekdayInDate => {
-                f.write_str("failed to parse weekday in date")
-            }
-            FailedYearInDate => f.write_str("failed to parse year in date"),
-            FailedYearInYearMonth => {
-                f.write_str("failed to parse year in year-month")
             }
             InvalidDate => f.write_str("parsed date is not valid"),
             InvalidMonthDay => f.write_str("parsed month-day is not valid"),

--- a/src/fmt/temporal/mod.rs
+++ b/src/fmt/temporal/mod.rs
@@ -2512,7 +2512,7 @@ mod tests {
         );
         insta::assert_snapshot!(
             DateTimeParser::new().parse_date("-000000-01-01").unwrap_err(),
-            @"failed to parse year in date: year zero must be written without a sign or a positive sign, but not a negative sign",
+            @"year zero must be written without a sign or a positive sign, but not a negative sign",
         );
     }
 

--- a/src/fmt/temporal/parser.rs
+++ b/src/fmt/temporal/parser.rs
@@ -487,8 +487,7 @@ impl DateTimeParser {
         input: &'i [u8],
     ) -> Result<Parsed<'i, ISOWeekDate>, Error> {
         // Parse year component.
-        let Parsed { value: year, input } =
-            self.parse_year(input).context(E::FailedYearInDate)?;
+        let Parsed { value: year, input } = self.parse_year(input)?;
         let extended = input.starts_with(b"-");
 
         // Parse optional separator.
@@ -502,8 +501,7 @@ impl DateTimeParser {
             .context(E::FailedWeekNumberPrefixInDate)?;
 
         // Parse week num component.
-        let Parsed { value: week, input } =
-            self.parse_week_num(input).context(E::FailedWeekNumberInDate)?;
+        let Parsed { value: week, input } = self.parse_week_num(input)?;
 
         // Parse optional separator.
         let Parsed { input, .. } = self
@@ -511,8 +509,7 @@ impl DateTimeParser {
             .context(E::FailedSeparatorAfterWeekNumber)?;
 
         // Parse day component.
-        let Parsed { value: weekday, input } =
-            self.parse_weekday(input).context(E::FailedWeekdayInDate)?;
+        let Parsed { value: weekday, input } = self.parse_weekday(input)?;
 
         let iso_week_date = ISOWeekDate::new(year, week, weekday)
             .context(E::InvalidWeekDate)?;
@@ -529,8 +526,7 @@ impl DateTimeParser {
         input: &'i [u8],
     ) -> Result<Parsed<'i, ParsedDate>, Error> {
         // Parse year component.
-        let Parsed { value: year, input } =
-            self.parse_year(input).context(E::FailedYearInDate)?;
+        let Parsed { value: year, input } = self.parse_year(input)?;
         let extended = input.starts_with(b"-");
 
         // Parse optional separator.
@@ -539,8 +535,7 @@ impl DateTimeParser {
             .context(E::FailedSeparatorAfterYear)?;
 
         // Parse month component.
-        let Parsed { value: month, input } =
-            self.parse_month(input).context(E::FailedMonthInDate)?;
+        let Parsed { value: month, input } = self.parse_month(input)?;
 
         // Parse optional separator.
         let Parsed { input, .. } = self
@@ -548,8 +543,7 @@ impl DateTimeParser {
             .context(E::FailedSeparatorAfterMonth)?;
 
         // Parse day component.
-        let Parsed { value: day, input } =
-            self.parse_day(input).context(E::FailedDayInDate)?;
+        let Parsed { value: day, input } = self.parse_day(input)?;
 
         let date = Date::new(year, month, day).context(E::InvalidDate)?;
         let value = ParsedDate { date };
@@ -568,8 +562,7 @@ impl DateTimeParser {
         input: &'i [u8],
     ) -> Result<Parsed<'i, ParsedTime>, Error> {
         // Parse hour component.
-        let Parsed { value: hour, input } =
-            self.parse_hour(input).context(E::FailedHourInTime)?;
+        let Parsed { value: hour, input } = self.parse_hour(input)?;
         let extended = input.starts_with(b":");
 
         // Parse optional minute component.
@@ -582,8 +575,7 @@ impl DateTimeParser {
             let value = ParsedTime { time, extended };
             return Ok(Parsed { value, input });
         }
-        let Parsed { value: minute, input } =
-            self.parse_minute(input).context(E::FailedMinuteInTime)?;
+        let Parsed { value: minute, input } = self.parse_minute(input)?;
 
         // Parse optional second component.
         let Parsed { value: has_second, input } =
@@ -596,8 +588,7 @@ impl DateTimeParser {
             let value = ParsedTime { time, extended };
             return Ok(Parsed { value, input });
         }
-        let Parsed { value: second, input } =
-            self.parse_second(input).context(E::FailedSecondInTime)?;
+        let Parsed { value: second, input } = self.parse_second(input)?;
 
         // Parse an optional fractional component.
         let Parsed { value: nanosecond, input } =
@@ -637,8 +628,7 @@ impl DateTimeParser {
         input: &'i [u8],
     ) -> Result<Parsed<'i, ()>, Error> {
         // Parse month component.
-        let Parsed { value: month, mut input } =
-            self.parse_month(input).context(E::FailedMonthInMonthDay)?;
+        let Parsed { value: month, mut input } = self.parse_month(input)?;
 
         // Skip over optional separator.
         if let Some(tail) = input.strip_prefix(b"-") {
@@ -646,8 +636,7 @@ impl DateTimeParser {
         }
 
         // Parse day component.
-        let Parsed { value: day, input } =
-            self.parse_day(input).context(E::FailedDayInMonthDay)?;
+        let Parsed { value: day, input } = self.parse_day(input)?;
 
         // Check that the month-day is valid. Since Temporal's month-day
         // permits 02-29, we use a leap year. The error message here is
@@ -671,8 +660,7 @@ impl DateTimeParser {
         input: &'i [u8],
     ) -> Result<Parsed<'i, ()>, Error> {
         // Parse year component.
-        let Parsed { value: year, mut input } =
-            self.parse_year(input).context(E::FailedYearInYearMonth)?;
+        let Parsed { value: year, mut input } = self.parse_year(input)?;
 
         // Skip over optional separator.
         if let Some(tail) = input.strip_prefix(b"-") {
@@ -680,8 +668,7 @@ impl DateTimeParser {
         }
 
         // Parse month component.
-        let Parsed { value: month, input } =
-            self.parse_month(input).context(E::FailedMonthInYearMonth)?;
+        let Parsed { value: month, input } = self.parse_month(input)?;
 
         // Check that the year-month is valid. We just use a day of 1, since
         // every month in every year must have a day 1.
@@ -1999,7 +1986,7 @@ mod tests {
         // invalid time. (Because we're asking for a time here.)
         insta::assert_snapshot!(
             p(b"2099-13-01[America/New_York]"),
-            @"failed to parse minute in time: failed to parse two digit integer as minute: parameter 'minute' is not in the required range of 0..=59",
+            @"failed to parse two digit integer as minute: parameter 'minute' is not in the required range of 0..=59",
         );
     }
 
@@ -2077,7 +2064,7 @@ mod tests {
     fn err_date_empty() {
         insta::assert_snapshot!(
             DateTimeParser::new().parse_date_spec(b"").unwrap_err(),
-            @"failed to parse year in date: expected four digit year (or leading sign for six digit year), but found end of input",
+            @"expected four digit year (or leading sign for six digit year), but found end of input",
         );
     }
 
@@ -2085,40 +2072,40 @@ mod tests {
     fn err_date_year() {
         insta::assert_snapshot!(
             DateTimeParser::new().parse_date_spec(b"123").unwrap_err(),
-            @"failed to parse year in date: expected four digit year (or leading sign for six digit year), but found end of input",
+            @"expected four digit year (or leading sign for six digit year), but found end of input",
         );
         insta::assert_snapshot!(
             DateTimeParser::new().parse_date_spec(b"123a").unwrap_err(),
-            @"failed to parse year in date: failed to parse four digit integer as year: invalid digit, expected 0-9 but got a",
+            @"failed to parse four digit integer as year: invalid digit, expected 0-9 but got a",
         );
 
         insta::assert_snapshot!(
             DateTimeParser::new().parse_date_spec(b"-9999").unwrap_err(),
-            @"failed to parse year in date: expected six digit year (because of a leading sign), but found end of input",
+            @"expected six digit year (because of a leading sign), but found end of input",
         );
         insta::assert_snapshot!(
             DateTimeParser::new().parse_date_spec(b"+9999").unwrap_err(),
-            @"failed to parse year in date: expected six digit year (because of a leading sign), but found end of input",
+            @"expected six digit year (because of a leading sign), but found end of input",
         );
         insta::assert_snapshot!(
             DateTimeParser::new().parse_date_spec(b"-99999").unwrap_err(),
-            @"failed to parse year in date: expected six digit year (because of a leading sign), but found end of input",
+            @"expected six digit year (because of a leading sign), but found end of input",
         );
         insta::assert_snapshot!(
             DateTimeParser::new().parse_date_spec(b"+99999").unwrap_err(),
-            @"failed to parse year in date: expected six digit year (because of a leading sign), but found end of input",
+            @"expected six digit year (because of a leading sign), but found end of input",
         );
         insta::assert_snapshot!(
             DateTimeParser::new().parse_date_spec(b"-99999a").unwrap_err(),
-            @"failed to parse year in date: failed to parse six digit integer as year: invalid digit, expected 0-9 but got a",
+            @"failed to parse six digit integer as year: invalid digit, expected 0-9 but got a",
         );
         insta::assert_snapshot!(
             DateTimeParser::new().parse_date_spec(b"+999999").unwrap_err(),
-            @"failed to parse year in date: failed to parse six digit integer as year: parameter 'year' is not in the required range of -9999..=9999",
+            @"failed to parse six digit integer as year: parameter 'year' is not in the required range of -9999..=9999",
         );
         insta::assert_snapshot!(
             DateTimeParser::new().parse_date_spec(b"-010000").unwrap_err(),
-            @"failed to parse year in date: failed to parse six digit integer as year: parameter 'year' is not in the required range of -9999..=9999",
+            @"failed to parse six digit integer as year: parameter 'year' is not in the required range of -9999..=9999",
         );
     }
 
@@ -2126,19 +2113,19 @@ mod tests {
     fn err_date_month() {
         insta::assert_snapshot!(
             DateTimeParser::new().parse_date_spec(b"2024-").unwrap_err(),
-            @"failed to parse month in date: expected two digit month, but found end of input",
+            @"expected two digit month, but found end of input",
         );
         insta::assert_snapshot!(
             DateTimeParser::new().parse_date_spec(b"2024").unwrap_err(),
-            @"failed to parse month in date: expected two digit month, but found end of input",
+            @"expected two digit month, but found end of input",
         );
         insta::assert_snapshot!(
             DateTimeParser::new().parse_date_spec(b"2024-13-01").unwrap_err(),
-            @"failed to parse month in date: failed to parse two digit integer as month: parameter 'month' is not in the required range of 1..=12",
+            @"failed to parse two digit integer as month: parameter 'month' is not in the required range of 1..=12",
         );
         insta::assert_snapshot!(
             DateTimeParser::new().parse_date_spec(b"20241301").unwrap_err(),
-            @"failed to parse month in date: failed to parse two digit integer as month: parameter 'month' is not in the required range of 1..=12",
+            @"failed to parse two digit integer as month: parameter 'month' is not in the required range of 1..=12",
         );
     }
 
@@ -2146,15 +2133,15 @@ mod tests {
     fn err_date_day() {
         insta::assert_snapshot!(
             DateTimeParser::new().parse_date_spec(b"2024-12-").unwrap_err(),
-            @"failed to parse day in date: expected two digit day, but found end of input",
+            @"expected two digit day, but found end of input",
         );
         insta::assert_snapshot!(
             DateTimeParser::new().parse_date_spec(b"202412").unwrap_err(),
-            @"failed to parse day in date: expected two digit day, but found end of input",
+            @"expected two digit day, but found end of input",
         );
         insta::assert_snapshot!(
             DateTimeParser::new().parse_date_spec(b"2024-12-40").unwrap_err(),
-            @"failed to parse day in date: failed to parse two digit integer as day: parameter 'day' is not in the required range of 1..=31",
+            @"failed to parse two digit integer as day: parameter 'day' is not in the required range of 1..=31",
         );
         insta::assert_snapshot!(
             DateTimeParser::new().parse_date_spec(b"2024-11-31").unwrap_err(),
@@ -2298,7 +2285,7 @@ mod tests {
     fn err_time_empty() {
         insta::assert_snapshot!(
             DateTimeParser::new().parse_time_spec(b"").unwrap_err(),
-            @"failed to parse hour in time: expected two digit hour, but found end of input",
+            @"expected two digit hour, but found end of input",
         );
     }
 
@@ -2306,15 +2293,15 @@ mod tests {
     fn err_time_hour() {
         insta::assert_snapshot!(
             DateTimeParser::new().parse_time_spec(b"a").unwrap_err(),
-            @"failed to parse hour in time: expected two digit hour, but found end of input",
+            @"expected two digit hour, but found end of input",
         );
         insta::assert_snapshot!(
             DateTimeParser::new().parse_time_spec(b"1a").unwrap_err(),
-            @"failed to parse hour in time: failed to parse two digit integer as hour: invalid digit, expected 0-9 but got a",
+            @"failed to parse two digit integer as hour: invalid digit, expected 0-9 but got a",
         );
         insta::assert_snapshot!(
             DateTimeParser::new().parse_time_spec(b"24").unwrap_err(),
-            @"failed to parse hour in time: failed to parse two digit integer as hour: parameter 'hour' is not in the required range of 0..=23",
+            @"failed to parse two digit integer as hour: parameter 'hour' is not in the required range of 0..=23",
         );
     }
 
@@ -2322,19 +2309,19 @@ mod tests {
     fn err_time_minute() {
         insta::assert_snapshot!(
             DateTimeParser::new().parse_time_spec(b"01:").unwrap_err(),
-            @"failed to parse minute in time: expected two digit minute, but found end of input",
+            @"expected two digit minute, but found end of input",
         );
         insta::assert_snapshot!(
             DateTimeParser::new().parse_time_spec(b"01:a").unwrap_err(),
-            @"failed to parse minute in time: expected two digit minute, but found end of input",
+            @"expected two digit minute, but found end of input",
         );
         insta::assert_snapshot!(
             DateTimeParser::new().parse_time_spec(b"01:1a").unwrap_err(),
-            @"failed to parse minute in time: failed to parse two digit integer as minute: invalid digit, expected 0-9 but got a",
+            @"failed to parse two digit integer as minute: invalid digit, expected 0-9 but got a",
         );
         insta::assert_snapshot!(
             DateTimeParser::new().parse_time_spec(b"01:60").unwrap_err(),
-            @"failed to parse minute in time: failed to parse two digit integer as minute: parameter 'minute' is not in the required range of 0..=59",
+            @"failed to parse two digit integer as minute: parameter 'minute' is not in the required range of 0..=59",
         );
     }
 
@@ -2342,19 +2329,19 @@ mod tests {
     fn err_time_second() {
         insta::assert_snapshot!(
             DateTimeParser::new().parse_time_spec(b"01:02:").unwrap_err(),
-            @"failed to parse second in time: expected two digit second, but found end of input",
+            @"expected two digit second, but found end of input",
         );
         insta::assert_snapshot!(
             DateTimeParser::new().parse_time_spec(b"01:02:a").unwrap_err(),
-            @"failed to parse second in time: expected two digit second, but found end of input",
+            @"expected two digit second, but found end of input",
         );
         insta::assert_snapshot!(
             DateTimeParser::new().parse_time_spec(b"01:02:1a").unwrap_err(),
-            @"failed to parse second in time: failed to parse two digit integer as second: invalid digit, expected 0-9 but got a",
+            @"failed to parse two digit integer as second: invalid digit, expected 0-9 but got a",
         );
         insta::assert_snapshot!(
             DateTimeParser::new().parse_time_spec(b"01:02:61").unwrap_err(),
-            @"failed to parse second in time: failed to parse two digit integer as second: parameter 'second' is not in the required range of 0..=60",
+            @"failed to parse two digit integer as second: parameter 'second' is not in the required range of 0..=60",
         );
     }
 
@@ -2448,40 +2435,40 @@ mod tests {
 
         insta::assert_snapshot!(
             p("123"),
-            @"failed to parse year in date: expected four digit year (or leading sign for six digit year), but found end of input",
+            @"expected four digit year (or leading sign for six digit year), but found end of input",
         );
         insta::assert_snapshot!(
             p("123a"),
-            @"failed to parse year in date: failed to parse four digit integer as year: invalid digit, expected 0-9 but got a",
+            @"failed to parse four digit integer as year: invalid digit, expected 0-9 but got a",
         );
 
         insta::assert_snapshot!(
             p("-9999"),
-            @"failed to parse year in date: expected six digit year (because of a leading sign), but found end of input",
+            @"expected six digit year (because of a leading sign), but found end of input",
         );
         insta::assert_snapshot!(
             p("+9999"),
-            @"failed to parse year in date: expected six digit year (because of a leading sign), but found end of input",
+            @"expected six digit year (because of a leading sign), but found end of input",
         );
         insta::assert_snapshot!(
             p("-99999"),
-            @"failed to parse year in date: expected six digit year (because of a leading sign), but found end of input",
+            @"expected six digit year (because of a leading sign), but found end of input",
         );
         insta::assert_snapshot!(
             p("+99999"),
-            @"failed to parse year in date: expected six digit year (because of a leading sign), but found end of input",
+            @"expected six digit year (because of a leading sign), but found end of input",
         );
         insta::assert_snapshot!(
             p("-99999a"),
-            @"failed to parse year in date: failed to parse six digit integer as year: invalid digit, expected 0-9 but got a",
+            @"failed to parse six digit integer as year: invalid digit, expected 0-9 but got a",
         );
         insta::assert_snapshot!(
             p("+999999"),
-            @"failed to parse year in date: failed to parse six digit integer as year: parameter 'year' is not in the required range of -9999..=9999",
+            @"failed to parse six digit integer as year: parameter 'year' is not in the required range of -9999..=9999",
         );
         insta::assert_snapshot!(
             p("-010000"),
-            @"failed to parse year in date: failed to parse six digit integer as year: parameter 'year' is not in the required range of -9999..=9999",
+            @"failed to parse six digit integer as year: parameter 'year' is not in the required range of -9999..=9999",
         );
     }
 
@@ -2513,11 +2500,11 @@ mod tests {
 
         insta::assert_snapshot!(
             p("2024-W"),
-            @"failed to parse week number in date: expected two digit week number, but found end of input",
+            @"expected two digit week number, but found end of input",
         );
         insta::assert_snapshot!(
             p("2024-W1"),
-            @"failed to parse week number in date: expected two digit week number, but found end of input",
+            @"expected two digit week number, but found end of input",
         );
         insta::assert_snapshot!(
             p("2024-W53-1"),
@@ -2556,15 +2543,15 @@ mod tests {
         };
         insta::assert_snapshot!(
             p("2024-W12-"),
-            @"failed to parse weekday in date: expected one digit weekday, but found end of input",
+            @"expected one digit weekday, but found end of input",
         );
         insta::assert_snapshot!(
             p("2024W12"),
-            @"failed to parse weekday in date: expected one digit weekday, but found end of input",
+            @"expected one digit weekday, but found end of input",
         );
         insta::assert_snapshot!(
             p("2024-W11-8"),
-            @"failed to parse weekday in date: failed to parse one digit integer as weekday: parameter 'weekday (Monday 1-indexed)' is not in the required range of 1..=7",
+            @"failed to parse one digit integer as weekday: parameter 'weekday (Monday 1-indexed)' is not in the required range of 1..=7",
         );
     }
 


### PR DESCRIPTION
This removes a bit of redundancy in existing error messages. For
example, instead of:

```
failed to parse hour in time: failed to parse two digit integer as hour: parameter 'hour' is not in the required range of 0..=23
```

We now have:

```
failed to parse two digit integer as hour: parameter 'hour' is not in the required range of 0..=23
```

Which is a little better.

Fixes #519
