### PR TITLE
Fixes for testing from released crates since jiff-core split

### DIFF
--- a/crates/jiff/src/tz/tzif.rs
+++ b/crates/jiff/src/tz/tzif.rs
@@ -43,8 +43,8 @@ mod tests {
             }
         }
 
-        fn datetime(dt: tzif::DateTime) -> jiff::civil::DateTime {
-            jiff::civil::DateTime::constant(
+        fn datetime(dt: tzif::DateTime) -> crate::civil::DateTime {
+            crate::civil::DateTime::constant(
                 dt.year(),
                 dt.month(),
                 dt.day(),
@@ -67,7 +67,7 @@ mod tests {
                 out,
                 "  {i:03}:\toffset={off}\t\
                    designation={desig}\t{dst}\tindicator={ind}",
-                off = jiff::tz::Offset::from_seconds(typ.offset.seconds())
+                off = jcore::tz::Offset::from_seconds(typ.offset.seconds())
                     .unwrap(),
                 desig = tzif.designations[usize::from(typ.designation)],
                 dst = if typ.dst.is_dst() { "dst" } else { "" },
@@ -107,8 +107,9 @@ mod tests {
                        {desig}\t{dst}",
                     ts = timestamp.as_second(),
                     type_index = trans.infos[i].type_index,
-                    off = jiff::tz::Offset::from_seconds(typ.offset.seconds())
-                        .unwrap(),
+                    off =
+                        jcore::tz::Offset::from_seconds(typ.offset.seconds())
+                            .unwrap(),
                     desig = tzif.designations[usize::from(typ.designation)],
                     dst = if typ.dst.is_dst() { "dst" } else { "" },
                 )


### PR DESCRIPTION
Similarly to https://github.com/BurntSushi/jiff/pull/594, this lets me run the tests downstream in Fedora’s `rust-jiff` package, which is based on the release `.crate` archive from crates.io (and also uses integration tests and test data files from the GitHub archive).

I think I got the details right here. It needs to be `crate::civil::DateTime` rather than `jcore::civil::DateTime` because it needs to impl `Display`.