### PR TITLE
fmt: fix parsing of sign for fractional values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+0.2.35 (TBD)
+============
+TODO
+
+Bug fixes:
+
+* [#613](https://github.com/BurntSushi/jiff/issues/613):
+Fixes a bug where the sign in a duration could be ignored while parsing.
+
+
 0.2.34 (2026-07-19)
 ===================
 This release contains a few small enhancements. Namely, some error messages

--- a/crates/jiff/src/fmt/friendly/parser.rs
+++ b/crates/jiff/src/fmt/friendly/parser.rs
@@ -677,6 +677,8 @@ mod tests {
         insta::assert_snapshot!(p("1.5secs"), @"PT1.5S");
         insta::assert_snapshot!(p("1.5msecs"), @"PT0.0015S");
         insta::assert_snapshot!(p("1.5µsecs"), @"PT0.0000015S");
+        insta::assert_snapshot!(p("-0.5secs"), @"-PT0.5S");
+        insta::assert_snapshot!(p("0.5secs ago"), @"-PT0.5S");
 
         insta::assert_snapshot!(p("1d 1.5hrs"), @"P1DT1H30M");
         insta::assert_snapshot!(p("1h 1.5mins"), @"PT1H1M30S");
@@ -941,6 +943,8 @@ mod tests {
         insta::assert_snapshot!(p("1.5secs"), @"PT1.5S");
         insta::assert_snapshot!(p("1.5msecs"), @"PT0.0015S");
         insta::assert_snapshot!(p("1.5µsecs"), @"PT0.0000015S");
+        insta::assert_snapshot!(p("-0.5secs"), @"-PT0.5S");
+        insta::assert_snapshot!(p("0.5secs ago"), @"-PT0.5S");
 
         insta::assert_snapshot!(p("1h 1.5mins"), @"PT1H1M30S");
         insta::assert_snapshot!(p("1m 1.5secs"), @"PT1M1.5S");

--- a/crates/jiff/src/fmt/temporal/parser.rs
+++ b/crates/jiff/src/fmt/temporal/parser.rs
@@ -1280,6 +1280,8 @@ mod tests {
 
         insta::assert_debug_snapshot!(p(b"PT0s"), @"0s");
         insta::assert_debug_snapshot!(p(b"PT0.000000001s"), @"1ns");
+        insta::assert_debug_snapshot!(p(b"-PT0.000000001s"), @"-1ns");
+        insta::assert_debug_snapshot!(p(b"-PT0.5s"), @"-500000000ns");
         insta::assert_debug_snapshot!(p(b"PT1s"), @"1s");
         insta::assert_debug_snapshot!(p(b"PT59s"), @"59s");
         insta::assert_debug_snapshot!(p(b"PT60s"), @"60s");
@@ -1503,6 +1505,11 @@ mod tests {
         insta::assert_debug_snapshot!(p(b"PT1.123456789m"), @"1m 7s 407ms 407µs 340ns");
 
         insta::assert_debug_snapshot!(p(b"PT0.5s"), @"500ms");
+        insta::assert_debug_snapshot!(p(b"-PT0.5s"), @"500ms ago");
+        insta::assert_debug_snapshot!(
+            p(b"-PT0.000000001s"),
+            @"1ns ago",
+        );
         insta::assert_debug_snapshot!(p(b"PT0.123456789s"), @"123ms 456µs 789ns");
         insta::assert_debug_snapshot!(p(b"PT1.123456789s"), @"1s 123ms 456µs 789ns");
 

--- a/crates/jiff/src/fmt/util.rs
+++ b/crates/jiff/src/fmt/util.rs
@@ -155,6 +155,7 @@ impl DurationUnits {
             }
         }
         self.fraction = Some(fraction);
+        self.any_non_zero_units = self.any_non_zero_units || fraction != 0;
         Ok(())
     }
 


### PR DESCRIPTION
This only happens when there is a negative sign and when the only
non-zero units are fractional. This was likely an oversight in the
parser refactor done a bit ago.

Fixes #613
