### PR TITLE
Remove redundant cast

### DIFF
--- a/crates/jiff/src/fmt/util.rs
+++ b/crates/jiff/src/fmt/util.rs
@@ -761,7 +761,6 @@ pub(crate) fn parse_temporal_fraction<'i>(
         // OK because parsing is forcefully limited to 9 digits,
         // which can never be greater than `999_999_99`,
         // which is less than `u32::MAX`.
-        let nanoseconds = nanoseconds as u32;
         Ok(Parsed { value: Some(nanoseconds), input })
     }
 


### PR DESCRIPTION
I believe this cast can be safely removed, as the source type is already the target type.

For reference, this change was found by an optimizer developed as a research project.

CC @nunoplopes