### PR TITLE
core: fix time zone offset subtraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+0.2.36 (TBD)
+============
+TODO
+
+* [#617](https://github.com/BurntSushi/jiff/pull/617):
+Fixes a bug in `jiff_core::tz::Offset` checked subtraction routine.
+
+
 0.2.35 (2026-07-25)
 ===================
 This release fixes a bug in duration parsing where, e.g., `-PT0.5S` would be

--- a/crates/jiff-core/src/tz/offset.rs
+++ b/crates/jiff-core/src/tz/offset.rs
@@ -138,8 +138,9 @@ impl Offset {
         self,
         seconds: i32,
     ) -> Result<Offset, RangeError> {
-        let seconds =
-            rtry!(b::OffsetTotalSeconds::checked_add(self.seconds(), seconds));
+        let seconds = rtry!(b::OffsetTotalSeconds::checkc(
+            self.seconds() as i64 - seconds as i64,
+        ));
         Ok(Offset { seconds })
     }
 
@@ -768,3 +769,36 @@ impl core::fmt::Display for AmbiguousError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for AmbiguousError {}
+
+#[cfg(test)]
+mod tests {
+    use super::Offset;
+
+    #[test]
+    fn checked_subtracts_positive_and_negative_seconds() {
+        assert_eq!(
+            Offset::UTC.checked_sub(1).unwrap(),
+            Offset::constant_seconds(-1),
+        );
+        assert_eq!(
+            Offset::UTC.checked_sub(-1).unwrap(),
+            Offset::constant_seconds(1),
+        );
+    }
+
+    #[test]
+    fn checked_sub_rejects_overflow() {
+        assert!(Offset::MIN.checked_sub(1).is_err());
+        assert!(Offset::MAX.checked_sub(-1).is_err());
+        assert!(Offset::UTC.checked_sub(i32::MIN).is_err());
+    }
+
+    #[test]
+    fn subtraction_operators_subtract_seconds() {
+        assert_eq!(Offset::UTC - 1, Offset::constant_seconds(-1));
+
+        let mut offset = Offset::UTC;
+        offset -= 1;
+        assert_eq!(offset, Offset::constant_seconds(-1));
+    }
+}


### PR DESCRIPTION
Fix `jiff_core::tz::Offset::checked_sub`, which incorrectly added seconds instead of subtracting them + add regression tests for signed inputs, overflow, and the `-` / `-=` operators`