### PR TITLE
build(jiff-static): upgrade syn to v3

### DIFF
--- a/crates/jiff-static/Cargo.toml
+++ b/crates/jiff-static/Cargo.toml
@@ -40,4 +40,4 @@ jcore = { package = "jiff-core", version = "0.1", path = "../jiff-core" }
 jiff-tzdb = { version = "0.1.6", path = "../jiff-tzdb", optional = true }
 proc-macro2 = "1.0.93"
 quote = "1.0.38"
-syn = "3.0.3"
+syn = ">= 2.0.98, < 4"

--- a/crates/jiff-static/Cargo.toml
+++ b/crates/jiff-static/Cargo.toml
@@ -40,4 +40,4 @@ jcore = { package = "jiff-core", version = "0.1", path = "../jiff-core" }
 jiff-tzdb = { version = "0.1.6", path = "../jiff-tzdb", optional = true }
 proc-macro2 = "1.0.93"
 quote = "1.0.38"
-syn = "2.0.98"
+syn = "3.0.3"


### PR DESCRIPTION
cc @BurntSushi 

`syn` v3 requires MSRV >= 1.71 while `jiff` is now 1.70. Perhaps upgrade the MSRV.