### PR TITLE
test: make most tests use `-p jiff`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,6 +560,7 @@ jobs:
     env:
       CARGO_BUILD_TARGET: wasm32-unknown-emscripten
       CARGO_TARGET_WASM32_UNKNOWN_EMSCRIPTEN_RUNNER: node
+      CARGO_TARGET_WASM32_UNKNOWN_EMSCRIPTEN_LINKER: em++
       INSTA_FORCE_PASS: 1
       INSTA_UPDATE: no
       RUSTFLAGS: >
@@ -583,7 +584,7 @@ jobs:
       - name: Build jiff-tzdb-platform
         run: cargo build --verbose -p jiff-tzdb-platform
       - name: Run library tests
-        run: cargo test --lib -- --nocapture
+        run: cargo test -p jiff --lib -- --nocapture
       - name: Run integration tests
         run: cargo test --test integration -- --nocapture
 

--- a/scripts/test-only-bundle
+++ b/scripts/test-only-bundle
@@ -14,4 +14,4 @@ cd "$(dirname "$0")/.."
 # likely to see it with the bundled database while missing it completely with
 # the system database.
 echo "===== WITH ONLY THE BUNDLED TIME ZONE DATABASE ====="
-cargo test --no-default-features --features std,tz-system,tzdb-bundle-always
+cargo test -p jiff --no-default-features --features std,tz-system,tzdb-bundle-always

--- a/scripts/test-only-core
+++ b/scripts/test-only-core
@@ -16,9 +16,9 @@ cd "$(dirname "$0")/.."
 # We accept this risk because this still runs a lot of tests, and the tests
 # that aren't covered are run in other configurations. Still, it's not ideal.
 echo "===== CORE ONLY ====="
-cargo build --no-default-features
-INSTA_FORCE_PASS=1 INSTA_UPDATE=no cargo test --lib --no-default-features
-INSTA_FORCE_PASS=1 INSTA_UPDATE=no cargo test --test integration --no-default-features
+cargo build -p jiff --no-default-features
+INSTA_FORCE_PASS=1 INSTA_UPDATE=no cargo test -p jiff --lib --no-default-features
+INSTA_FORCE_PASS=1 INSTA_UPDATE=no cargo test -p jiff --test integration --no-default-features
 
 # More core-only tests, when combined with compatible features.
 features=(
@@ -31,6 +31,6 @@ features=(
 for f in "${features[@]}"; do
     echo "===== COREONLY PLUS '$f' ====="
     cargo build --no-default-features --features "$f"
-    INSTA_FORCE_PASS=1 INSTA_UPDATE=no cargo test --lib --no-default-features --features "$f"
-    INSTA_FORCE_PASS=1 INSTA_UPDATE=no cargo test --test integration --no-default-features --features "$f"
+    INSTA_FORCE_PASS=1 INSTA_UPDATE=no cargo test -p jiff --lib --no-default-features --features "$f"
+    INSTA_FORCE_PASS=1 INSTA_UPDATE=no cargo test -p jiff --test integration --no-default-features --features "$f"
 done

--- a/scripts/test-various-feature-combos
+++ b/scripts/test-various-feature-combos
@@ -25,7 +25,7 @@ features=(
 )
 for f in "${features[@]}"; do
     echo "===== FEATURES: '$f' ====="
-    cargo build --no-default-features --features "$f"
-    cargo test --lib --no-default-features --features "$f"
-    cargo test --test integration --no-default-features --features "$f"
+    cargo build -p jiff --no-default-features --features "$f"
+    cargo test -p jiff --lib --no-default-features --features "$f"
+    cargo test -p jiff --test integration --no-default-features --features "$f"
 done


### PR DESCRIPTION
This was an oversight from when I switched to a virtual manifest in
cebda72f8f7702ac618e5a54ac844d0853c89de7. Specifically, because of
feature unification, these tests ended up not testing what we want:
specific feature combinations.
