### PR TITLE
Add optional arbitrary::Arbitrary implementations

### DIFF
--- a/crates/jiff-core/Cargo.toml
+++ b/crates/jiff-core/Cargo.toml
@@ -22,11 +22,13 @@ bench = false
 default = ["std", "tz-fat"]
 alloc = ["defmt?/alloc"]
 std = ["alloc", "log?/std"]
+arbitrary = ["dep:arbitrary"]
 defmt = ["dep:defmt"]
 logging = ["dep:log"]
 tz-fat = []
 
 [dependencies]
+arbitrary = { version = "1.4.2", optional = true, features = ["derive"] }
 defmt = { version = "1.0.0", optional = true }
 log = { version = "0.4.21", optional = true, default-features = false }
 

--- a/crates/jiff-core/src/civil/date.rs
+++ b/crates/jiff-core/src/civil/date.rs
@@ -1415,6 +1415,70 @@ mod tests {
         assert_eq!(Date::MAX, date(9999, 12, 31));
     }
 
+    #[cfg(feature = "arbitrary")]
+    #[test]
+    fn arbitrary_always_produces_valid_date() {
+        use arbitrary::{Arbitrary, Unstructured};
+
+        for byte in [0x00, 0x7f, 0x80, 0xff] {
+            let buf = [byte; 32];
+            let mut u = Unstructured::new(&buf);
+            let d = Date::arbitrary(&mut u).unwrap();
+            assert!(d >= Date::MIN && d <= Date::MAX);
+        }
+
+        let mut state: u64 = 0x1234_5678_9abc_def0;
+        for _ in 0..10_000 {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            let mut buf = [0u8; 8];
+            buf.copy_from_slice(&state.to_le_bytes());
+
+            let mut u = Unstructured::new(&buf);
+            if let Ok(d) = Date::arbitrary(&mut u) {
+                assert!(d >= Date::MIN && d <= Date::MAX);
+            }
+        }
+    }
+
+    #[cfg(feature = "arbitrary")]
+    #[test]
+    fn arbitrary_always_produces_valid_iso_week_date() {
+        use arbitrary::{Arbitrary, Unstructured};
+
+        fn check(wd: ISOWeekDate) {
+            // Re-validating the constituent parts must succeed, and the
+            // corresponding `Date` must be in range, since `ISOWeekDate`
+            // and `Date` support an infallible conversion between them.
+            let re =
+                ISOWeekDate::new(wd.year(), wd.week(), wd.weekday()).unwrap();
+            assert_eq!(wd, re);
+            let d = wd.to_date();
+            assert!(d >= Date::MIN && d <= Date::MAX);
+        }
+
+        for byte in [0x00, 0x7f, 0x80, 0xff] {
+            let buf = [byte; 32];
+            let mut u = Unstructured::new(&buf);
+            check(ISOWeekDate::arbitrary(&mut u).unwrap());
+        }
+
+        let mut state: u64 = 0x1234_5678_9abc_def0;
+        for _ in 0..10_000 {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            let mut buf = [0u8; 8];
+            buf.copy_from_slice(&state.to_le_bytes());
+
+            let mut u = Unstructured::new(&buf);
+            if let Ok(wd) = ISOWeekDate::arbitrary(&mut u) {
+                check(wd);
+            }
+        }
+    }
+
     #[test]
     fn unix_epoch_to_date_and_back_again_min_to_max() {
         for i in 0.. {

--- a/crates/jiff-core/src/civil/date.rs
+++ b/crates/jiff-core/src/civil/date.rs
@@ -645,6 +645,26 @@ impl core::ops::Sub for Date {
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for Date {
+    fn arbitrary(
+        u: &mut arbitrary::Unstructured<'a>,
+    ) -> arbitrary::Result<Date> {
+        let year = u.int_in_range(b::Year::MIN..=b::Year::MAX)?;
+        let month = u.int_in_range(b::Month::MIN..=b::Month::MAX)?;
+        let day = u.int_in_range(b::Day::MIN..=b::Day::MAX)?;
+        Ok(Date::new_constrain(year, month, day).unwrap())
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        arbitrary::size_hint::and_all(&[
+            <i16 as arbitrary::Arbitrary>::size_hint(depth),
+            <i8 as arbitrary::Arbitrary>::size_hint(depth),
+            <i8 as arbitrary::Arbitrary>::size_hint(depth),
+        ])
+    }
+}
+
 #[cfg(test)]
 impl quickcheck::Arbitrary for Date {
     fn arbitrary(g: &mut quickcheck::Gen) -> Date {
@@ -1331,6 +1351,26 @@ const fn iso_week_start_from_year(year: i16) -> UnixEpochDay {
         epoch_day_in_first_week.checked_sub(diff_from_monday as i32),
         "valid Unix epoch day"
     )
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for ISOWeekDate {
+    fn arbitrary(
+        u: &mut arbitrary::Unstructured<'a>,
+    ) -> arbitrary::Result<ISOWeekDate> {
+        let year = u.int_in_range(b::ISOYear::MIN..=b::ISOYear::MAX)?;
+        let week = u.int_in_range(b::ISOWeek::MIN..=b::ISOWeek::MAX)?;
+        let weekday = Weekday::arbitrary(u)?;
+        Ok(ISOWeekDate::new_constrain(year, week, weekday).unwrap())
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        arbitrary::size_hint::and_all(&[
+            <i16 as arbitrary::Arbitrary>::size_hint(depth),
+            <i8 as arbitrary::Arbitrary>::size_hint(depth),
+            <Weekday as arbitrary::Arbitrary>::size_hint(depth),
+        ])
+    }
 }
 
 #[cfg(test)]

--- a/crates/jiff-core/src/civil/time.rs
+++ b/crates/jiff-core/src/civil/time.rs
@@ -241,6 +241,30 @@ impl core::fmt::Debug for Time {
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for Time {
+    fn arbitrary(
+        u: &mut arbitrary::Unstructured<'a>,
+    ) -> arbitrary::Result<Time> {
+        let hour = u.int_in_range(b::Hour::MIN..=b::Hour::MAX)?;
+        let minute = u.int_in_range(b::Minute::MIN..=b::Minute::MAX)?;
+        let second = u.int_in_range(b::Second::MIN..=b::Second::MAX)?;
+        let subsec_nanosecond = u.int_in_range(
+            b::SubsecNanosecond::MIN..=b::SubsecNanosecond::MAX,
+        )?;
+        Ok(Time::new(hour, minute, second, subsec_nanosecond).unwrap())
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        arbitrary::size_hint::and_all(&[
+            <i8 as arbitrary::Arbitrary>::size_hint(depth),
+            <i8 as arbitrary::Arbitrary>::size_hint(depth),
+            <i8 as arbitrary::Arbitrary>::size_hint(depth),
+            <i32 as arbitrary::Arbitrary>::size_hint(depth),
+        ])
+    }
+}
+
 #[cfg(test)]
 impl quickcheck::Arbitrary for Time {
     fn arbitrary(g: &mut quickcheck::Gen) -> Time {

--- a/crates/jiff-core/src/civil/time.rs
+++ b/crates/jiff-core/src/civil/time.rs
@@ -474,6 +474,33 @@ mod tests {
         TimeNanosecond::new(nanosecond).unwrap()
     }
 
+    #[cfg(feature = "arbitrary")]
+    #[test]
+    fn arbitrary_always_produces_valid_time() {
+        use arbitrary::{Arbitrary, Unstructured};
+
+        for byte in [0x00, 0x7f, 0x80, 0xff] {
+            let buf = [byte; 16];
+            let mut u = Unstructured::new(&buf);
+            let t = Time::arbitrary(&mut u).unwrap();
+            assert!(t >= Time::MIN && t <= Time::MAX);
+        }
+
+        let mut state: u64 = 0x1234_5678_9abc_def0;
+        for _ in 0..10_000 {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            let mut buf = [0u8; 8];
+            buf.copy_from_slice(&state.to_le_bytes());
+
+            let mut u = Unstructured::new(&buf);
+            if let Ok(t) = Time::arbitrary(&mut u) {
+                assert!(t >= Time::MIN && t <= Time::MAX);
+            }
+        }
+    }
+
     #[test]
     fn time_to_second_various() {
         let t = time(0, 0, 0);

--- a/crates/jiff-core/src/civil/weekday.rs
+++ b/crates/jiff-core/src/civil/weekday.rs
@@ -6,6 +6,7 @@ use crate::{
 /// A representation for the day of the week.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[repr(u8)]
 #[allow(missing_docs)]
 pub enum Weekday {

--- a/crates/jiff-core/src/timestamp.rs
+++ b/crates/jiff-core/src/timestamp.rs
@@ -754,6 +754,33 @@ impl core::ops::SubAssign<(i64, i32)> for Timestamp {
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for Timestamp {
+    fn arbitrary(
+        u: &mut arbitrary::Unstructured<'a>,
+    ) -> arbitrary::Result<Timestamp> {
+        let secs = u.int_in_range(
+            b::UnixEpochSeconds::MIN..=b::UnixEpochSeconds::MAX,
+        )?;
+        let mut nanos = u.int_in_range(
+            b::SignedSubsecNanosecond::MIN..=b::SignedSubsecNanosecond::MAX,
+        )?;
+        // nanoseconds must be zero for the minimum second value,
+        // so just clamp it to 0.
+        if secs == b::UnixEpochSeconds::MIN && nanos < 0 {
+            nanos = 0;
+        }
+        Ok(Timestamp::new(secs, nanos).unwrap_or(Timestamp::UNIX_EPOCH))
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        arbitrary::size_hint::and(
+            <i64 as arbitrary::Arbitrary>::size_hint(depth),
+            <i32 as arbitrary::Arbitrary>::size_hint(depth),
+        )
+    }
+}
+
 #[cfg(test)]
 impl quickcheck::Arbitrary for Timestamp {
     fn arbitrary(g: &mut quickcheck::Gen) -> Timestamp {

--- a/crates/jiff-core/src/timestamp.rs
+++ b/crates/jiff-core/src/timestamp.rs
@@ -957,4 +957,33 @@ mod tests {
             got == ts
         }
     }
+
+    #[cfg(feature = "arbitrary")]
+    #[test]
+    fn arbitrary_always_produces_valid_timestamp() {
+        use arbitrary::{Arbitrary, Unstructured};
+
+        for byte in [0x00, 0x7f, 0x80, 0xff] {
+            let buf = [byte; 32];
+            let mut u = Unstructured::new(&buf);
+            let ts = Timestamp::arbitrary(&mut u).unwrap();
+            assert!(ts >= Timestamp::MIN && ts <= Timestamp::MAX);
+        }
+
+        let mut state: u64 = 0x1234_5678_9abc_def0;
+        for _ in 0..10_000 {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            let mut buf = [0u8; 16];
+            buf[..8].copy_from_slice(&state.to_le_bytes());
+            state ^= state << 5;
+            buf[8..].copy_from_slice(&state.to_le_bytes());
+
+            let mut u = Unstructured::new(&buf);
+            if let Ok(ts) = Timestamp::arbitrary(&mut u) {
+                assert!(ts >= Timestamp::MIN && ts <= Timestamp::MAX);
+            }
+        }
+    }
 }

--- a/crates/jiff-core/src/tz/offset.rs
+++ b/crates/jiff-core/src/tz/offset.rs
@@ -790,6 +790,33 @@ impl std::error::Error for AmbiguousError {}
 mod tests {
     use super::Offset;
 
+    #[cfg(feature = "arbitrary")]
+    #[test]
+    fn arbitrary_always_produces_valid_offset() {
+        use arbitrary::{Arbitrary, Unstructured};
+
+        for byte in [0x00, 0x7f, 0x80, 0xff] {
+            let buf = [byte; 8];
+            let mut u = Unstructured::new(&buf);
+            let o = Offset::arbitrary(&mut u).unwrap();
+            assert!(o >= Offset::MIN && o <= Offset::MAX);
+        }
+
+        let mut state: u64 = 0x1234_5678_9abc_def0;
+        for _ in 0..10_000 {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            let mut buf = [0u8; 8];
+            buf.copy_from_slice(&state.to_le_bytes());
+
+            let mut u = Unstructured::new(&buf);
+            if let Ok(o) = Offset::arbitrary(&mut u) {
+                assert!(o >= Offset::MIN && o <= Offset::MAX);
+            }
+        }
+    }
+
     #[test]
     fn checked_subtracts_positive_and_negative_seconds() {
         assert_eq!(

--- a/crates/jiff-core/src/tz/offset.rs
+++ b/crates/jiff-core/src/tz/offset.rs
@@ -372,6 +372,22 @@ impl defmt::Format for Offset {
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for Offset {
+    fn arbitrary(
+        u: &mut arbitrary::Unstructured<'a>,
+    ) -> arbitrary::Result<Offset> {
+        let secs = u.int_in_range(
+            b::OffsetTotalSeconds::MIN..=b::OffsetTotalSeconds::MAX,
+        )?;
+        Ok(Offset::from_seconds(secs).unwrap_or(Offset::UTC))
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        <i32 as arbitrary::Arbitrary>::size_hint(depth)
+    }
+}
+
 #[cfg(test)]
 impl quickcheck::Arbitrary for Offset {
     fn arbitrary(g: &mut quickcheck::Gen) -> Offset {

--- a/crates/jiff/Cargo.toml
+++ b/crates/jiff/Cargo.toml
@@ -48,6 +48,10 @@ alloc = [
   "defmt?/alloc",
 ]
 
+# Enables integration with the `arbitray` crate. This provides implemetations
+# of the `arbitrary::Arbitrary` trait on many of Jiff's core primitives.
+arbitrary = ["dep:arbitrary", "jcore/arbitrary"]
+
 # Enables integration with `serde`. This provides implementations of
 # `Serialize` and `Deserialize` for many of Jiff's core primitives.
 serde = ["dep:serde_core"]
@@ -187,6 +191,7 @@ js = ["dep:wasm-bindgen", "dep:js-sys"]
 perf-inline = []
 
 [dependencies]
+arbitrary = { version = "1.4.2", optional = true, features = ["derive"] }
 defmt = { version = "1.0.0", optional = true }
 # Jiff's only required dependency. The `jiff-core` crate just contains stuff
 # that used to be inside `jiff`, so while it shows up as an additional

--- a/crates/jiff/src/civil/date.rs
+++ b/crates/jiff/src/civil/date.rs
@@ -168,6 +168,7 @@ use crate::{
 ///
 /// [add-date-rounding]: https://github.com/BurntSushi/jiff/issues/1
 #[derive(Clone, Copy, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Date {
     inner: JDate,
 }

--- a/crates/jiff/src/civil/datetime.rs
+++ b/crates/jiff/src/civil/datetime.rs
@@ -214,6 +214,7 @@ use crate::{
 ///
 /// See [`DateTime::round`] for more details.
 #[derive(Clone, Copy, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct DateTime {
     date: Date,
     time: Time,

--- a/crates/jiff/src/civil/iso_week_date.rs
+++ b/crates/jiff/src/civil/iso_week_date.rs
@@ -154,6 +154,7 @@ use crate::{
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 #[derive(Clone, Copy, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ISOWeekDate {
     pub(crate) inner: JISOWeekDate,
 }

--- a/crates/jiff/src/civil/time.rs
+++ b/crates/jiff/src/civil/time.rs
@@ -219,6 +219,7 @@ use crate::{
 ///
 /// See [`Time::round`] for more details.
 #[derive(Clone, Copy, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Time {
     inner: JTime,
 }

--- a/crates/jiff/src/signed_duration.rs
+++ b/crates/jiff/src/signed_duration.rs
@@ -3006,6 +3006,40 @@ mod tests {
 
     use super::*;
 
+    #[cfg(feature = "arbitrary")]
+    #[test]
+    fn arbitrary_always_produces_valid_signed_duration() {
+        use arbitrary::{Arbitrary, Unstructured};
+
+        fn check(d: SignedDuration) {
+            assert!(d >= SignedDuration::MIN && d <= SignedDuration::MAX);
+            assert!(d.subsec_nanos() > -NANOS_PER_SEC);
+            assert!(d.subsec_nanos() < NANOS_PER_SEC);
+        }
+
+        for byte in [0x00, 0x7f, 0x80, 0xff] {
+            let buf = [byte; 16];
+            let mut u = Unstructured::new(&buf);
+            check(SignedDuration::arbitrary(&mut u).unwrap());
+        }
+
+        let mut state: u64 = 0x1234_5678_9abc_def0;
+        for _ in 0..10_000 {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            let mut buf = [0u8; 16];
+            buf[..8].copy_from_slice(&state.to_le_bytes());
+            state ^= state << 5;
+            buf[8..].copy_from_slice(&state.to_le_bytes());
+
+            let mut u = Unstructured::new(&buf);
+            if let Ok(d) = SignedDuration::arbitrary(&mut u) {
+                check(d);
+            }
+        }
+    }
+
     #[test]
     fn new() {
         let d = SignedDuration::new(12, i32::MAX);

--- a/crates/jiff/src/signed_duration.rs
+++ b/crates/jiff/src/signed_duration.rs
@@ -2979,6 +2979,25 @@ fn parse_iso_or_friendly(bytes: &[u8]) -> Result<SignedDuration, Error> {
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for SignedDuration {
+    fn arbitrary(
+        u: &mut arbitrary::Unstructured<'a>,
+    ) -> arbitrary::Result<SignedDuration> {
+        let secs = i64::arbitrary(u)?;
+        let nanos =
+            u.int_in_range(-(NANOS_PER_SEC - 1)..=(NANOS_PER_SEC - 1))?;
+        Ok(SignedDuration::new(secs, nanos))
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        arbitrary::size_hint::and(
+            <i64 as arbitrary::Arbitrary>::size_hint(depth),
+            <i32 as arbitrary::Arbitrary>::size_hint(depth),
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::Cursor;

--- a/crates/jiff/src/timestamp.rs
+++ b/crates/jiff/src/timestamp.rs
@@ -310,6 +310,7 @@ use crate::{
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Timestamp {
     dur: JTimestamp,
 }

--- a/crates/jiff/src/tz/offset.rs
+++ b/crates/jiff/src/tz/offset.rs
@@ -129,6 +129,7 @@ impl From<bool> for Dst {
 /// since there is no time zone identifier, the offset instead is repeated as
 /// an additional assertion that a fixed offset datetime was intended.
 #[derive(Clone, Copy, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Offset {
     inner: JOffset,
 }

--- a/crates/jiff/src/tz/timezone.rs
+++ b/crates/jiff/src/tz/timezone.rs
@@ -1513,6 +1513,34 @@ impl defmt::Format for TimeZone {
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for TimeZone {
+    fn arbitrary(
+        u: &mut arbitrary::Unstructured<'a>,
+    ) -> arbitrary::Result<TimeZone> {
+        #[cfg(feature = "alloc")]
+        {
+            if bool::arbitrary(u)? {
+                let names: alloc::vec::Vec<_> =
+                    crate::tz::db().available().collect();
+                if let Ok(name) = u.choose(&names) {
+                    if let Ok(tz) = crate::tz::db().get(name.as_str()) {
+                        return Ok(tz);
+                    }
+                }
+            }
+        }
+        Ok(TimeZone::fixed(Offset::arbitrary(u)?))
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        arbitrary::size_hint::and(
+            <bool as arbitrary::Arbitrary>::size_hint(depth),
+            <Offset as arbitrary::Arbitrary>::size_hint(depth),
+        )
+    }
+}
+
 /// A representation a single time zone transition.
 ///
 /// A time zone transition is an instant in time the marks the beginning of

--- a/crates/jiff/src/tz/timezone.rs
+++ b/crates/jiff/src/tz/timezone.rs
@@ -2618,6 +2618,56 @@ mod tests {
 
     use super::*;
 
+    #[cfg(feature = "arbitrary")]
+    #[test]
+    fn arbitrary_always_produces_valid_time_zone() {
+        use arbitrary::{Arbitrary, Unstructured};
+
+        for byte in [0x00, 0x7f, 0x80, 0xff] {
+            let buf = [byte; 64];
+            let mut u = Unstructured::new(&buf);
+            // Must never panic.
+            let _ = TimeZone::arbitrary(&mut u).unwrap();
+        }
+
+        let mut state: u64 = 0x1234_5678_9abc_def0;
+        let mut saw_iana = false;
+        let mut saw_fixed = false;
+        for _ in 0..10_000 {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            let mut buf = [0u8; 32];
+            buf[..8].copy_from_slice(&state.to_le_bytes());
+            state ^= state << 5;
+            buf[8..16].copy_from_slice(&state.to_le_bytes());
+            state ^= state << 13;
+            buf[16..24].copy_from_slice(&state.to_le_bytes());
+            state ^= state >> 7;
+            buf[24..32].copy_from_slice(&state.to_le_bytes());
+
+            let mut u = Unstructured::new(&buf);
+            if let Ok(tz) = TimeZone::arbitrary(&mut u) {
+                if tz.iana_name().is_some() {
+                    saw_iana = true;
+                } else {
+                    saw_fixed = true;
+                }
+                // Every generated time zone must actually be usable for
+                // converting a timestamp to civil time and back.
+                let ts = Timestamp::UNIX_EPOCH;
+                let dt = tz.to_datetime(ts);
+                tz.to_zoned(dt).unwrap();
+            }
+        }
+        // Sanity check that this system's tzdb is non-empty and that we
+        // actually exercised both branches of the impl.
+        if !crate::tz::db().is_definitively_empty() {
+            assert!(saw_iana, "never generated a named IANA time zone");
+        }
+        assert!(saw_fixed, "never generated a fixed-offset time zone");
+    }
+
     fn unambiguous(offset_hours: i8) -> AmbiguousOffset {
         let offset = offset(offset_hours);
         o_unambiguous(offset)


### PR DESCRIPTION
Closes https://github.com/BurntSushi/jiff/issues/631

In contrast to what I said in the issue this obviously doesn't work with simply deriving the trait since not all values of the underlying primitives are valid `jiff` types. Manually implementing the trait was easy enough though.

I had an LLM generate some unit tests of the implementations just to see what they would look like. IMO it's a bit overkill so I moved this to a separate commit that I'm happy to revert if you want/