### PR TITLE
jiff: add optional `arbitrary::Arbitrary` implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 ============
 TODO
 
+Enhancements:
+
+* [#631](https://github.com/BurntSushi/jiff/issues/631):
+Add optional `Arbitrary` trait implementations from the `arbitrary` crate.
+
+Bug fixes:
+
 * [#617](https://github.com/BurntSushi/jiff/pull/617):
 Fixes a bug in `jiff_core::tz::Offset` checked subtraction routine.
 * [#627](https://github.com/BurntSushi/jiff/issues/627):

--- a/crates/jiff-core/Cargo.toml
+++ b/crates/jiff-core/Cargo.toml
@@ -22,11 +22,13 @@ bench = false
 default = ["std", "tz-fat"]
 alloc = ["defmt?/alloc"]
 std = ["alloc", "log?/std"]
+arbitrary = ["dep:arbitrary", "std"]
 defmt = ["dep:defmt"]
 logging = ["dep:log"]
 tz-fat = []
 
 [dependencies]
+arbitrary = { version = "1.4.2", optional = true, features = ["derive"] }
 defmt = { version = "1.0.0", optional = true }
 log = { version = "0.4.21", optional = true, default-features = false }
 

--- a/crates/jiff-core/src/civil/date.rs
+++ b/crates/jiff-core/src/civil/date.rs
@@ -645,6 +645,26 @@ impl core::ops::Sub for Date {
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for Date {
+    fn arbitrary(
+        u: &mut arbitrary::Unstructured<'a>,
+    ) -> arbitrary::Result<Date> {
+        let year = u.int_in_range(b::Year::MIN..=b::Year::MAX)?;
+        let month = u.int_in_range(b::Month::MIN..=b::Month::MAX)?;
+        let day = u.int_in_range(b::Day::MIN..=b::Day::MAX)?;
+        Ok(Date::new_constrain(year, month, day).unwrap())
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        arbitrary::size_hint::and_all(&[
+            <i16 as arbitrary::Arbitrary>::size_hint(depth),
+            <i8 as arbitrary::Arbitrary>::size_hint(depth),
+            <i8 as arbitrary::Arbitrary>::size_hint(depth),
+        ])
+    }
+}
+
 #[cfg(test)]
 impl quickcheck::Arbitrary for Date {
     fn arbitrary(g: &mut quickcheck::Gen) -> Date {
@@ -1331,6 +1351,26 @@ const fn iso_week_start_from_year(year: i16) -> UnixEpochDay {
         epoch_day_in_first_week.checked_sub(diff_from_monday as i32),
         "valid Unix epoch day"
     )
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for ISOWeekDate {
+    fn arbitrary(
+        u: &mut arbitrary::Unstructured<'a>,
+    ) -> arbitrary::Result<ISOWeekDate> {
+        let year = u.int_in_range(b::ISOYear::MIN..=b::ISOYear::MAX)?;
+        let week = u.int_in_range(b::ISOWeek::MIN..=b::ISOWeek::MAX)?;
+        let weekday = Weekday::arbitrary(u)?;
+        Ok(ISOWeekDate::new_constrain(year, week, weekday).unwrap())
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        arbitrary::size_hint::and_all(&[
+            <i16 as arbitrary::Arbitrary>::size_hint(depth),
+            <i8 as arbitrary::Arbitrary>::size_hint(depth),
+            <Weekday as arbitrary::Arbitrary>::size_hint(depth),
+        ])
+    }
 }
 
 #[cfg(test)]

--- a/crates/jiff-core/src/civil/time.rs
+++ b/crates/jiff-core/src/civil/time.rs
@@ -241,6 +241,30 @@ impl core::fmt::Debug for Time {
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for Time {
+    fn arbitrary(
+        u: &mut arbitrary::Unstructured<'a>,
+    ) -> arbitrary::Result<Time> {
+        let hour = u.int_in_range(b::Hour::MIN..=b::Hour::MAX)?;
+        let minute = u.int_in_range(b::Minute::MIN..=b::Minute::MAX)?;
+        let second = u.int_in_range(b::Second::MIN..=b::Second::MAX)?;
+        let subsec_nanosecond = u.int_in_range(
+            b::SubsecNanosecond::MIN..=b::SubsecNanosecond::MAX,
+        )?;
+        Ok(Time::new(hour, minute, second, subsec_nanosecond).unwrap())
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        arbitrary::size_hint::and_all(&[
+            <i8 as arbitrary::Arbitrary>::size_hint(depth),
+            <i8 as arbitrary::Arbitrary>::size_hint(depth),
+            <i8 as arbitrary::Arbitrary>::size_hint(depth),
+            <i32 as arbitrary::Arbitrary>::size_hint(depth),
+        ])
+    }
+}
+
 #[cfg(test)]
 impl quickcheck::Arbitrary for Time {
     fn arbitrary(g: &mut quickcheck::Gen) -> Time {

--- a/crates/jiff-core/src/civil/weekday.rs
+++ b/crates/jiff-core/src/civil/weekday.rs
@@ -6,6 +6,7 @@ use crate::{
 /// A representation for the day of the week.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[repr(u8)]
 #[allow(missing_docs)]
 pub enum Weekday {

--- a/crates/jiff-core/src/timestamp.rs
+++ b/crates/jiff-core/src/timestamp.rs
@@ -754,6 +754,33 @@ impl core::ops::SubAssign<(i64, i32)> for Timestamp {
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for Timestamp {
+    fn arbitrary(
+        u: &mut arbitrary::Unstructured<'a>,
+    ) -> arbitrary::Result<Timestamp> {
+        let secs = u.int_in_range(
+            b::UnixEpochSeconds::MIN..=b::UnixEpochSeconds::MAX,
+        )?;
+        let mut nanos = u.int_in_range(
+            b::SignedSubsecNanosecond::MIN..=b::SignedSubsecNanosecond::MAX,
+        )?;
+        // nanoseconds must be zero for the minimum second value,
+        // so just clamp it to 0.
+        if secs == b::UnixEpochSeconds::MIN && nanos < 0 {
+            nanos = 0;
+        }
+        Ok(Timestamp::new(secs, nanos).unwrap_or(Timestamp::UNIX_EPOCH))
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        arbitrary::size_hint::and(
+            <i64 as arbitrary::Arbitrary>::size_hint(depth),
+            <i32 as arbitrary::Arbitrary>::size_hint(depth),
+        )
+    }
+}
+
 #[cfg(test)]
 impl quickcheck::Arbitrary for Timestamp {
     fn arbitrary(g: &mut quickcheck::Gen) -> Timestamp {

--- a/crates/jiff-core/src/tz/offset.rs
+++ b/crates/jiff-core/src/tz/offset.rs
@@ -372,6 +372,22 @@ impl defmt::Format for Offset {
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for Offset {
+    fn arbitrary(
+        u: &mut arbitrary::Unstructured<'a>,
+    ) -> arbitrary::Result<Offset> {
+        let secs = u.int_in_range(
+            b::OffsetTotalSeconds::MIN..=b::OffsetTotalSeconds::MAX,
+        )?;
+        Ok(Offset::from_seconds(secs).unwrap_or(Offset::UTC))
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        <i32 as arbitrary::Arbitrary>::size_hint(depth)
+    }
+}
+
 #[cfg(test)]
 impl quickcheck::Arbitrary for Offset {
     fn arbitrary(g: &mut quickcheck::Gen) -> Offset {

--- a/crates/jiff/Cargo.toml
+++ b/crates/jiff/Cargo.toml
@@ -48,6 +48,10 @@ alloc = [
   "defmt?/alloc",
 ]
 
+# Enables integration with the `arbitray` crate. This provides implemetations
+# of the `arbitrary::Arbitrary` trait on many of Jiff's core primitives.
+arbitrary = ["dep:arbitrary", "jcore/arbitrary", "std"]
+
 # Enables integration with `serde`. This provides implementations of
 # `Serialize` and `Deserialize` for many of Jiff's core primitives.
 serde = ["dep:serde_core"]
@@ -187,6 +191,7 @@ js = ["dep:wasm-bindgen", "dep:js-sys"]
 perf-inline = []
 
 [dependencies]
+arbitrary = { version = "1.4.2", optional = true, features = ["derive"] }
 defmt = { version = "1.0.0", optional = true }
 # Jiff's only required dependency. The `jiff-core` crate just contains stuff
 # that used to be inside `jiff`, so while it shows up as an additional

--- a/crates/jiff/src/civil/date.rs
+++ b/crates/jiff/src/civil/date.rs
@@ -168,6 +168,7 @@ use crate::{
 ///
 /// [add-date-rounding]: https://github.com/BurntSushi/jiff/issues/1
 #[derive(Clone, Copy, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Date {
     inner: JDate,
 }

--- a/crates/jiff/src/civil/datetime.rs
+++ b/crates/jiff/src/civil/datetime.rs
@@ -214,6 +214,7 @@ use crate::{
 ///
 /// See [`DateTime::round`] for more details.
 #[derive(Clone, Copy, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct DateTime {
     date: Date,
     time: Time,

--- a/crates/jiff/src/civil/iso_week_date.rs
+++ b/crates/jiff/src/civil/iso_week_date.rs
@@ -154,6 +154,7 @@ use crate::{
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 #[derive(Clone, Copy, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ISOWeekDate {
     pub(crate) inner: JISOWeekDate,
 }

--- a/crates/jiff/src/civil/time.rs
+++ b/crates/jiff/src/civil/time.rs
@@ -219,6 +219,7 @@ use crate::{
 ///
 /// See [`Time::round`] for more details.
 #[derive(Clone, Copy, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Time {
     inner: JTime,
 }

--- a/crates/jiff/src/civil/weekday.rs
+++ b/crates/jiff/src/civil/weekday.rs
@@ -82,6 +82,7 @@ use crate::error::Error;
 /// ```
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[repr(u8)]
 #[allow(missing_docs)]
 pub enum Weekday {

--- a/crates/jiff/src/lib.rs
+++ b/crates/jiff/src/lib.rs
@@ -636,6 +636,9 @@ For more, see the [`fmt::serde`] sub-module. (This requires enabling Jiff's
   (2026-06-12), not all public types in this crate implement [`defmt::Format`].
   If there are types for which you need `defmt` support but don't have it in
   Jiff, then please [open a new issue][issue-new].
+* **arbitrary** -
+  When enabled, `Arbitrary` trait implementations (for the `arbitrary` crate)
+  are provided for many of Jiff's core datetime primitives.
 
 ### Time zone features
 

--- a/crates/jiff/src/signed_duration.rs
+++ b/crates/jiff/src/signed_duration.rs
@@ -2979,6 +2979,25 @@ fn parse_iso_or_friendly(bytes: &[u8]) -> Result<SignedDuration, Error> {
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for SignedDuration {
+    fn arbitrary(
+        u: &mut arbitrary::Unstructured<'a>,
+    ) -> arbitrary::Result<SignedDuration> {
+        let secs = i64::arbitrary(u)?;
+        let nanos =
+            u.int_in_range(-(NANOS_PER_SEC - 1)..=(NANOS_PER_SEC - 1))?;
+        Ok(SignedDuration::new(secs, nanos))
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        arbitrary::size_hint::and(
+            <i64 as arbitrary::Arbitrary>::size_hint(depth),
+            <i32 as arbitrary::Arbitrary>::size_hint(depth),
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::Cursor;

--- a/crates/jiff/src/timestamp.rs
+++ b/crates/jiff/src/timestamp.rs
@@ -310,6 +310,7 @@ use crate::{
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Timestamp {
     dur: JTimestamp,
 }

--- a/crates/jiff/src/tz/offset.rs
+++ b/crates/jiff/src/tz/offset.rs
@@ -129,6 +129,7 @@ impl From<bool> for Dst {
 /// since there is no time zone identifier, the offset instead is repeated as
 /// an additional assertion that a fixed offset datetime was intended.
 #[derive(Clone, Copy, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Offset {
     inner: JOffset,
 }

--- a/crates/jiff/src/tz/timezone.rs
+++ b/crates/jiff/src/tz/timezone.rs
@@ -1513,6 +1513,34 @@ impl defmt::Format for TimeZone {
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for TimeZone {
+    fn arbitrary(
+        u: &mut arbitrary::Unstructured<'a>,
+    ) -> arbitrary::Result<TimeZone> {
+        #[cfg(feature = "alloc")]
+        {
+            if bool::arbitrary(u)? {
+                let names: alloc::vec::Vec<_> =
+                    crate::tz::db().available().collect();
+                if let Ok(name) = u.choose(&names) {
+                    if let Ok(tz) = crate::tz::db().get(name.as_str()) {
+                        return Ok(tz);
+                    }
+                }
+            }
+        }
+        Ok(TimeZone::fixed(Offset::arbitrary(u)?))
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        arbitrary::size_hint::and(
+            <bool as arbitrary::Arbitrary>::size_hint(depth),
+            <Offset as arbitrary::Arbitrary>::size_hint(depth),
+        )
+    }
+}
+
 /// A representation a single time zone transition.
 ///
 /// A time zone transition is an instant in time the marks the beginning of


### PR DESCRIPTION
Closes #631, Closes #633
