### PR TITLE
Branch-free time handling

### DIFF
--- a/crates/jiff-core/src/civil/time.rs
+++ b/crates/jiff-core/src/civil/time.rs
@@ -359,19 +359,29 @@ impl TimeSecond {
     /// components of a civil time.
     ///
     /// The subsecond component on the `Time` returned is always `0`.
+    ///
+    /// Uses a non-obvious sequence to allow component extraction
+    /// to have overlapping execution.
+    ///
+    /// Calculation of `minute` and `second` use an optimised
+    /// "power-complement-padding" technique instead of standard mod.
+    /// Relies on the identity: 60 + 2^2 = 2^6.
+    ///
+    /// Ref: https://www.benjoffe.com/fast-time-of-day
     #[inline]
     pub const fn to_time(&self) -> Time {
-        let mut second = self.second as u32;
-        let mut time = Time::MIN;
-        if second != 0 {
-            time.hour = (second / 3600) as i8;
-            second %= 3600;
-            if second != 0 {
-                time.minute = (second / 60) as i8;
-                time.second = (second % 60) as i8;
-            }
+
+        // cast to unsigned for faster division:
+        let secs: u32 = self.second as u32;
+        let hour: u32 = (secs / 3600) as u32;
+        let tmin: u32 = (secs / 60) as u32;
+
+        Time {
+            hour: hour as i8,
+            minute: ((tmin + 4 * hour) % 64) as i8,
+            second: ((secs + 4 * tmin) % 64) as i8,
+            subsec_nanosecond: 0,
         }
-        time
     }
 }
 
@@ -435,21 +445,14 @@ impl TimeNanosecond {
     /// The subsecond component on the `Time` returned is always `0`.
     #[inline]
     pub const fn to_time(&self) -> Time {
-        let mut nanosecond = self.nanosecond as u64;
-        let mut time = Time::MIN;
-        if nanosecond != 0 {
-            time.hour = (nanosecond / 3_600_000_000_000) as i8;
-            nanosecond %= 3_600_000_000_000;
-            if nanosecond != 0 {
-                time.minute = (nanosecond / 60_000_000_000) as i8;
-                nanosecond %= 60_000_000_000;
-                if nanosecond != 0 {
-                    time.second = (nanosecond / 1_000_000_000) as i8;
-                    time.subsec_nanosecond =
-                        (nanosecond % 1_000_000_000) as i32;
-                }
-            }
-        }
+        // Nanosecond is enforced as non-negative elsewhere
+        // as such, we can cast to unsigned for faster division:
+        let nanos: u64 = self.nanosecond as u64;
+
+        let mut time: Time = TimeSecond {
+            second: (nanos / 1_000_000_000) as i32
+        }.to_time();
+        time.subsec_nanosecond = (nanos % 1_000_000_000) as i32;
         time
     }
 }

--- a/crates/jiff-core/src/tz/offset.rs
+++ b/crates/jiff-core/src/tz/offset.rs
@@ -174,20 +174,14 @@ impl Offset {
         const DAY_SHIFT: i32 = 30 * 146097;
         const SEC_SHIFT: i64 = (DAY_SHIFT as i64) * 86_400;
 
-        let pos_sec = (second + (offset.seconds() as i64) + SEC_SHIFT) as u64;
-        let mut epoch_day = (pos_sec / 86_400) as i32;
-        let mut second = (pos_sec % 86_400) as i32;
+        let mut pos_sec = (second + (offset.seconds() as i64) + SEC_SHIFT) as u64;
 
-        if nanosecond < 0 {
-            if second > 0 {
-                second -= 1;
-                nanosecond += 1_000_000_000;
-            } else {
-                epoch_day -= 1;
-                second += 86_399;
-                nanosecond += 1_000_000_000;
-            }
-        }
+        let is_neg_nano: bool = nanosecond < 0;
+        pos_sec -= is_neg_nano as u64;
+        nanosecond += if is_neg_nano { 1_000_000_000 } else { 0 };
+        
+        let mut epoch_day = (pos_sec / 86_400) as i32;
+        let second = (pos_sec % 86_400) as i32;
 
         epoch_day -= DAY_SHIFT;
 


### PR DESCRIPTION
Hello,

This change to the time-handling logic results in:
1. a small improvement to `to_civil_datetime_offset_conversion` - around 3% by my measurements
2. more notably, the performance of datetime conversion should now be fully branch-free

In regards to point 2, this is laid out in more detail in Issue #638.

Since this resolves the issue noted there, the benchmark which measures the varying performance is unlikely required in Jiff's codebase. To use the benchmark though, you can see the branch here:
https://github.com/benjoffe/jiff/commit/71a22103c4452ff65956d16826861ea48b613532

If you take the branch here, rebase it off that one, then run the benchmark `to_civil_datetime_offset_conversion` before-and-after, you should see that the timings are now all very consistent, instead of changing based on data-set range.

If this gets merged, I think #638 could be closed as no longer needed.

Please let me know if anything about this has been poorly explained, or if you have any questions.

Also, as always, the URL in the comment is totally optional. It points to this draft blog post which will have more detailed information: https://www.benjoffe.com/fast-time-of-day

Off-topic, but related to my last PR: The full blog post detailing the day-of-week algorithm is now published in the last hour or so: https://www.benjoffe.com/fast-day-of-week

Cheers,

Ben